### PR TITLE
feat: chat-build — declarative Python build CLI replacing build-app.sh + run-*.sh

### DIFF
--- a/chat-deploy/pom.xml
+++ b/chat-deploy/pom.xml
@@ -132,6 +132,16 @@
             </dependencies>
         </profile>
         <profile>
+            <id>e2ee</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.demo</groupId>
+                    <artifactId>chat-deploy-e2ee</artifactId>
+                    <version>0.0.1</version>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>expose-webflux</id>
             <dependencies>
                 <dependency>

--- a/shell-scripts/README-chat-build.md
+++ b/shell-scripts/README-chat-build.md
@@ -1,0 +1,263 @@
+# chat-build
+
+A single Python CLI that composes the Maven command for any demo-chat service from
+declarative feature flags. It replaces the flag assembly spread across
+`build-app.sh` and the five `run-*.sh` scripts.
+
+Python 3.10+, stdlib only. No virtualenv, no `pip install`.
+
+```bash
+./shell-scripts/chat-build core --memory --run --notls
+# or via the wrapper
+./shell-scripts/run core --memory --run --notls
+```
+
+The old shell scripts still work and are not deleted. `test-parity.sh` asserts the
+two paths produce the same JVM flags.
+
+---
+
+## Quick start
+
+```bash
+# Core RSocket service, in-memory backend, seeding users and root keys
+chat-build core --memory --run --notls --init users,rootkeys
+
+# Same, but Cassandra-backed with UUID keys
+chat-build core --cassandra --run --notls --uuid --init users,rootkeys
+
+# Kafka messaging in front of the memory backend
+chat-build core --memory --kafka --run --notls
+
+# REST facade (talks to core over RSocket)
+chat-build rest --run --notls
+
+# Interactive shell client
+chat-build shell --run --notls
+
+# Build a container image instead of running
+chat-build core --cassandra --build --notls
+
+# See what would happen, run nothing
+chat-build core --memory --run --notls --dry-run
+```
+
+`--dry-run` prints the resolved feature set, the Maven command, every
+`JAVA_TOOL_OPTIONS` flag one per line, and the env file path. It is the fastest
+way to answer "why is this property set".
+
+---
+
+## Services
+
+Each service mirrors one of the old `run-*.sh` scripts.
+
+| Service | Module | Ports | Replaces |
+|---|---|---|---|
+| `core` | `chat-deploy` | 6790 rsocket, 6791 mgmt | `run-core.sh` |
+| `rest` | `chat-deploy` | 6792 http, 6793 mgmt | `run-rest.sh` |
+| `gateway` | `chat-deploy` | 80 http, 8080 mgmt | `run-gateway.sh` |
+| `authserv` | `chat-authorization-server` | 9000 http, 9001 mgmt | `run-authserv.sh` |
+| `shell` | `chat-deploy` | 9101 mgmt | `run-shell.sh` |
+
+`chat-build <service> --help` lists exactly the features that service accepts.
+
+---
+
+## Features
+
+Features are composable. Each one maps to Maven profiles, Spring properties and
+JVM flags. Options within a group are mutually exclusive.
+
+### Backends (pick one)
+
+| Flag | Maven profile | Notes |
+|---|---|---|
+| `--memory` | `memory-backend` | Memory persistence + pubsub + Lucene index. Default for `core`. |
+| `--cassandra` | `cassandra-backend` | Cassandra persistence + index. |
+| `--client` | `client-backend` | RSocket client, no local datastore. Default for `rest`, `gateway`, `authserv`, `shell`. |
+| `--redis` | `redis-backend` | Placeholder — the profile exists but declares no dependencies yet. |
+
+The module never changes. Backends are `chat-deploy` profiles that pull the
+matching deploy module in as a dependency, so `--cassandra` still builds
+`chat-deploy` with `chat-deploy-cassandra` on the classpath.
+
+### Add-ons (combine freely)
+
+| Flag | Maven profile | Effect |
+|---|---|---|
+| `--kafka` | `kafka-backend` | Kafka messaging in place of the in-memory pubsub. Reads `KAFKA_BOOTSTRAP_SERVERS`. |
+| `--e2ee` | `e2ee` | E2EE substrate: sets `app.service.e2ee.enabled`, `app.service.crypto.backend`, `app.service.presence.backend`. |
+
+Both pull modules that are not yet published to the local repository
+(`chat-deploy-kafka`, `chat-deploy-e2ee`, `chat-crypto`, `chat-presence`). Run
+`mvn -DskipTests install` from the repo root once before using either flag, or
+the single-module build cannot resolve them.
+
+### Transport (pick one)
+
+| Flag | Maven profile |
+|---|---|
+| `--rsocket` | `expose-rsocket` (default for `core`) |
+| `--rest` | `expose-webflux` (default for `rest`) |
+| `--shell` | `shell` (default for `shell`) |
+| `--gateway` | `expose-gateway` (default for `gateway`) |
+
+### Discovery (pick one)
+
+| Flag | Effect |
+|---|---|
+| `--local` | Default. Disables Consul. When `rootkeys` is *not* an init phase, adds the HTTP root-key consume chain so a joining node pulls keys off a peer's actuator. |
+| `--consul` | Adds `register-consul`. When `rootkeys` *is* an init phase, publishes keys to Consul KV instead. Falls back to `docker inspect` to find the Consul IP if `CONSUL_HOST` is unset. |
+
+### Key type (pick one)
+
+`--long` (Snowflake, default) or `--uuid`.
+
+### Other
+
+| Flag | Effect |
+|---|---|
+| `--tls DIR` | Enable TLS with certificates from `DIR`. Requires `KEYSTORE_PASS`. |
+| `--notls` | Disable TLS. |
+| `--websocket` | WebSocket transport for RSocket. |
+| `--debug` | RSocket frame logging plus a JDWP agent on `DEBUG_PORT`. |
+| `--init PHASES` | Comma-separated: `users`, `rootkeys`. |
+| `--profile NAME` | Additional Spring profile. Repeatable. |
+| `--run` / `--build` | `spring-boot:run` (default) or `spring-boot:build-image`. |
+| `--bake` | Pass options via the env file rather than inheriting them. |
+| `--env-file PATH` | Where to write the env file. |
+| `--dry-run` | Print everything, execute nothing. |
+| `--native` | Rejected — GraalVM native builds are still unsupported. |
+
+**TLS is fail-closed.** You must pass `--tls <dir>` or `--notls`; there is no
+implicit default, matching `build-app.sh`.
+
+---
+
+## Migration
+
+| Old | New |
+|---|---|
+| `run-core.sh runlocal memory -c notls` | `chat-build core --memory --run --notls --init users,rootkeys` |
+| `run-core.sh runlocal cassandra -c notls` | `chat-build core --cassandra --run --notls --init users,rootkeys` |
+| `run-core.sh runlocal kafka` | `chat-build core --memory --kafka --run --notls` |
+| `run-core.sh build memory -c notls` | `chat-build core --memory --build --notls` |
+| `run-rest.sh local` | `chat-build rest --run --notls` |
+| `run-gateway.sh local` | `chat-build gateway --run --notls` |
+| `run-authserv.sh local` | `chat-build authserv --run --notls` |
+| `run-shell.sh local` | `chat-build shell --run --notls` |
+| `build-app.sh ... -x` | `chat-build ... --dry-run` |
+| `-g` | `--debug` |
+| `-w` | `--websocket` |
+| `-k long` / `-k uuid` | `--long` / `--uuid` |
+| `-i users,rootkeys` | `--init users,rootkeys` |
+| `-p prod` | Implied by the backend; `--profile` adds extras. |
+| `-o` | `--bake` |
+| `-s` / `-e` / `-d` / `-m` | Implied by the service and its features. |
+
+Two old invocations have no direct equivalent because they were broken:
+`run-rest.sh local` and `run-gateway.sh local` never passed `-s`, so
+`build-app.sh` exited with "you forgot to select a backend". `chat-build` gives
+both services a `client` backend by default.
+
+---
+
+## Ports
+
+Everything derives from `CORE_PORT` (default 6790), matching `ports.sh`.
+
+| Variable | Derivation | Default |
+|---|---|---|
+| `CORE_PORT` | — | 6790 |
+| `CORE_MGMT_PORT` | `CORE_PORT + 1` | 6791 |
+| `HTTP_PORT` | `CORE_PORT + 2` | 6792 |
+| `HTTP_MGMT_PORT` | `HTTP_PORT + 1` | 6793 |
+| `AUTHSERV_HTTP_PORT` | — | 9000 |
+| `AUTHSERV_MGMT_PORT` | — | 9001 |
+| `GATEWAY_HTTP_PORT` | — | 80 |
+| `GATEWAY_HTTP_MGMT_PORT` | — | 8080 |
+| `SHELL_MGMT_PORT` | — | 9101 |
+| `DEBUG_PORT` | — | 9060 |
+
+Any of these can be overridden in the environment. Setting `CORE_PORT=7000`
+moves the whole core/rest allocation.
+
+---
+
+## Environment variables
+
+| Variable | Used for |
+|---|---|
+| `KEYSTORE_PASS` | Required with `--tls`. |
+| `CONSUL_HOST` / `CONSUL_PORT` | Consul location. Host is auto-detected from a running container if unset. |
+| `KAFKA_BOOTSTRAP_SERVERS` | Kafka brokers. Defaults to `localhost:9092`. |
+| `ROOTKEY_SOURCE_URI` | Peer to fetch root keys from. Defaults to `http://$CORE_HOST:$CORE_MGMT_PORT`. |
+| `DEBUG_SUSPEND` | `y` to have the JDWP agent wait for a debugger. Defaults to `n`. |
+
+---
+
+## The env file
+
+Written to `/tmp/chat-build-<service>-<image>.env` unless `--env-file` says
+otherwise, as real `KEY=VALUE` pairs:
+
+```
+JAVA_TOOL_OPTIONS=...
+MAVEN_PROFILES=-Pdeploy,memory-backend,expose-rsocket
+MAVEN_GOAL=spring-boot:run
+CWD=/path/to/chat-deploy
+IMAGE_NAME=memory-core-service-rsocket
+```
+
+`build-app.sh` wrote literal `echo KEY = VALUE` lines here, which
+`docker --env-file` cannot parse. If anything downstream depended on the old
+shape, it needs updating.
+
+---
+
+## Parity testing
+
+```bash
+./shell-scripts/test-parity.sh     # -v to dump both flag sets
+```
+
+Runs `build-app.sh -x` and `chat-build --dry-run` over four configurations
+(core/memory/local, core/memory/consul, core/memory/TLS, shell/client/local) and
+diffs the flag sets and Maven profiles. Any undeclared difference fails the run.
+
+Comparison ignores three non-semantic differences: shell quoting that never
+needed to reach the JVM, `-P` ordering, and repeated entries inside comma-lists.
+
+Two intentional behavioural differences are declared in the harness:
+
+1. `build-app.sh` emits `client-<proto>-<discovery>.yml` twice for client
+   services. `chat-build` emits it once.
+2. `build-app.sh` overwrites `MAIN_FLAGS` after sourcing the run script, so
+   `run-shell.sh`'s `spring.shell.interactive.enabled` and
+   `web-application-type=reactive` never reach the JVM. `chat-build` carries
+   them through.
+
+---
+
+## Adding a feature
+
+Add one `Feature` to the `FEATURES` dict in `chat-build`, then list its name in
+the `available_features` of every service that should accept it:
+
+```python
+"myfeature": Feature(
+    name="myfeature",
+    description="What it does",
+    maven_profiles=["my-profile"],
+    spring_properties={"app.service.mine.enabled": "true"},
+    service_flags=["-Dapp.service.mine"],
+    group=None,          # or "backend"/"expose"/"discovery"/"keytype"
+    conflicts=["other"],
+),
+```
+
+If the feature needs code on the classpath, it also needs a matching profile in
+`chat-deploy/pom.xml` that declares the dependency — see `kafka-backend` and
+`e2ee` for the pattern. A feature that only sets properties for classes that
+aren't packaged will silently do nothing.

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -1,0 +1,889 @@
+#!/usr/bin/env python3
+"""chat-build — build CLI for demo-chat.
+
+A declarative replacement for build-app.sh + run-*.sh. Every backend, transport
+and discovery mode is a Feature: a mapping from one CLI flag to Maven profiles,
+Spring properties and JVM flags. The CLI resolves the requested features against
+a Service definition, composes JAVA_TOOL_OPTIONS in the same order build-app.sh
+does, writes an env file, and runs Maven.
+
+    chat-build core --memory --run --notls
+    chat-build core --cassandra --kafka --build --notls --uuid
+    chat-build rest --run --notls --dry-run
+
+The module is always chat-deploy (or chat-authorization-server for authserv);
+backends are Maven profiles that pull their deploy module in as a dependency.
+
+Python 3.10+ stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO_ROOT = HERE.parent
+
+
+# --------------------------------------------------------------------------
+# Ports — mirrors shell-scripts/ports.sh
+# --------------------------------------------------------------------------
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        sys.exit(f"chat-build: {name} must be an integer, got {raw!r}")
+
+
+CORE_PORT = _env_int("CORE_PORT", 6790)
+CORE_RSOCKET_PORT = CORE_PORT
+CORE_MGMT_PORT = _env_int("CORE_MGMT_PORT", CORE_PORT + 1)
+HTTP_PORT = CORE_PORT + 2
+HTTP_MGMT_PORT = HTTP_PORT + 1
+
+CONSUL_HOST = os.environ.get("CONSUL_HOST", "127.0.0.1")
+CONSUL_PORT = _env_int("CONSUL_PORT", 8500)
+DEBUG_PORT = _env_int("DEBUG_PORT", 9060)
+
+AUTHSERV_HTTP_PORT = _env_int("AUTHSERV_HTTP_PORT", 9000)
+AUTHSERV_MGMT_PORT = _env_int("AUTHSERV_MGMT_PORT", 9001)
+
+GATEWAY_HTTP_PORT = _env_int("GATEWAY_HTTP_PORT", 80)
+GATEWAY_HTTP_MGMT_PORT = _env_int("GATEWAY_HTTP_MGMT_PORT", 8080)
+
+SHELL_MGMT_PORT = _env_int("SHELL_MGMT_PORT", 9101)
+
+CORE_HOST = os.environ.get("CORE_HOST", "127.0.0.1")
+ROOTKEY_SOURCE_URI = os.environ.get(
+    "ROOTKEY_SOURCE_URI", f"http://{CORE_HOST}:{CORE_MGMT_PORT}"
+)
+
+# Always-on Spring config imports, prepended by build-app.sh.
+BASE_ADDITIONAL_CONFIGS = [
+    "classpath:/config/logging.yml",
+    "classpath:/config/management-defaults.yml",
+]
+
+
+# --------------------------------------------------------------------------
+# Feature registry
+# --------------------------------------------------------------------------
+
+@dataclass
+class Feature:
+    """One composable build option.
+
+    maven_profiles are appended to -P. service_flags/client_flags/opt_flags land
+    in the matching JAVA_TOOL_OPTIONS group, preserving build-app.sh's ordering.
+    """
+
+    name: str
+    description: str
+    maven_profiles: list[str] = field(default_factory=list)
+    spring_properties: dict[str, str] = field(default_factory=dict)
+    service_flags: list[str] = field(default_factory=list)
+    client_flags: list[str] = field(default_factory=list)
+    opt_flags: list[str] = field(default_factory=list)
+    additional_configs: list[str] = field(default_factory=list)
+    spring_profiles: list[str] = field(default_factory=list)
+    conflicts: list[str] = field(default_factory=list)
+    # Backends are mutually exclusive within a group; transports are not.
+    group: str | None = None
+
+
+# Backends map to a chat-deploy profile that pulls the matching deploy module in
+# as a dependency. The module itself never changes -- see chat-deploy/pom.xml.
+FEATURES: dict[str, Feature] = {
+    "memory": Feature(
+        name="memory",
+        description="Memory persistence + pubsub + Lucene index",
+        maven_profiles=["memory-backend"],
+        spring_profiles=["prod"],
+        additional_configs=["classpath:/config/server-rsocket-consul.yml"],
+        group="backend",
+    ),
+    "cassandra": Feature(
+        name="cassandra",
+        description="Cassandra persistence + index",
+        maven_profiles=["cassandra-backend"],
+        spring_profiles=["cassandra-contact-point"],
+        group="backend",
+    ),
+    "client": Feature(
+        name="client",
+        description="RSocket client backend (no local datastore)",
+        maven_profiles=["client-backend"],
+        group="backend",
+    ),
+    "redis": Feature(
+        name="redis",
+        description="Redis persistence (profile is a placeholder, no deps yet)",
+        maven_profiles=["redis-backend"],
+        group="backend",
+    ),
+    "kafka": Feature(
+        name="kafka",
+        description="Kafka messaging (replaces the in-memory pubsub)",
+        maven_profiles=["kafka-backend"],
+        spring_profiles=["kafka"],
+        opt_flags=[
+            "-Dspring.kafka.bootstrap-servers="
+            + os.environ.get("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092")
+        ],
+    ),
+    "e2ee": Feature(
+        name="e2ee",
+        description="E2EE substrate (crypto + presence services)",
+        maven_profiles=["e2ee"],
+        spring_properties={
+            "app.service.e2ee.enabled": "true",
+            "app.service.crypto.backend": "memory",
+            "app.service.presence.backend": "memory",
+        },
+    ),
+
+    # ---- transports -----------------------------------------------------
+    "rsocket": Feature(
+        name="rsocket",
+        description="RSocket server transport",
+        maven_profiles=["expose-rsocket"],
+        service_flags=[
+            "-Dapp.server.proto=rsocket",
+            "-Dspring.main.web-application-type=reactive",
+        ],
+        group="expose",
+    ),
+    "rest": Feature(
+        name="rest",
+        description="WebFlux REST controllers",
+        maven_profiles=["expose-webflux"],
+        service_flags=["-Dapp.server.proto=http"],
+        group="expose",
+    ),
+    "shell": Feature(
+        name="shell",
+        description="Spring Shell CLI",
+        maven_profiles=["shell"],
+        spring_profiles=["shell"],
+        group="expose",
+    ),
+    "gateway": Feature(
+        name="gateway",
+        description="Spring Cloud Gateway edge routing",
+        maven_profiles=["expose-gateway"],
+        group="expose",
+    ),
+
+    # ---- discovery ------------------------------------------------------
+    "local": Feature(
+        name="local",
+        description="Local discovery; root keys consumed over HTTP",
+        conflicts=["consul"],
+        group="discovery",
+    ),
+    "consul": Feature(
+        name="consul",
+        description="Consul service discovery + KV",
+        maven_profiles=["register-consul"],
+        conflicts=["local"],
+        group="discovery",
+    ),
+
+    # ---- key type -------------------------------------------------------
+    "long": Feature(
+        name="long",
+        description="Long (Snowflake) key type",
+        conflicts=["uuid"],
+        group="keytype",
+    ),
+    "uuid": Feature(
+        name="uuid",
+        description="UUID key type",
+        conflicts=["long"],
+        group="keytype",
+    ),
+
+    # ---- misc -----------------------------------------------------------
+    "websocket": Feature(
+        name="websocket",
+        description="WebSocket transport for RSocket",
+    ),
+    "debug": Feature(
+        name="debug",
+        description="Enable RSocket frame logging and a JDWP agent",
+    ),
+}
+
+BACKENDS = [n for n, f in FEATURES.items() if f.group == "backend"]
+
+
+# --------------------------------------------------------------------------
+# Service registry
+# --------------------------------------------------------------------------
+
+@dataclass
+class Service:
+    name: str
+    description: str
+    module: str
+    app_primary: str
+    deployment_name: str
+    image_name: str
+    default_backend: str
+    default_features: list[str] = field(default_factory=list)
+    service_flags: list[str] = field(default_factory=list)
+    client_flags: list[str] = field(default_factory=list)
+    opt_flags: list[str] = field(default_factory=list)
+    additional_configs: list[str] = field(default_factory=list)
+    management_endpoints: list[str] = field(default_factory=list)
+    maven_profiles: list[str] = field(default_factory=list)
+    run_arguments: str = ""
+    client_proto: str = ""
+    available_features: list[str] = field(default_factory=list)
+    # Ports are computed late so CORE_PORT overrides still apply.
+    port_flags_fn: object = None
+
+    def port_flags(self) -> list[str]:
+        return list(self.port_flags_fn()) if self.port_flags_fn else []
+
+    def image_name_for(self, backend: str) -> str:
+        if "{backend}" in self.image_name:
+            return self.image_name.format(backend=backend)
+        return self.image_name
+
+
+CORE_SERVICE_FLAGS = [
+    "-Dapp.service.core.key",
+    "-Dapp.service.core.pubsub",
+    "-Dapp.service.core.index",
+    "-Dapp.service.core.persistence",
+    "-Dapp.service.core.secrets",
+    "-Dapp.service.composite",
+    "-Dapp.service.composite.auth",
+    "-Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message",
+    "-Dapp.controller.persistence",
+    "-Dapp.controller.index",
+    "-Dapp.controller.key",
+    "-Dapp.controller.pubsub",
+    "-Dapp.controller.secrets",
+    "-Dapp.controller.user",
+    "-Dapp.controller.topic",
+    "-Dapp.controller.message",
+]
+
+RSOCKET_SERVER_AUTOCONFIG_EXCLUDE = (
+    "-Dspring.autoconfigure.exclude="
+    "org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
+)
+
+COMMON_FEATURES = ["local", "consul", "long", "uuid", "websocket", "debug"]
+
+SERVICES: dict[str, Service] = {
+    "core": Service(
+        name="core",
+        description="Core RSocket service (persistence, pubsub, index, security)",
+        module="chat-deploy",
+        app_primary="core-service",
+        deployment_name="core-service-rsocket",
+        image_name="{backend}-core-service-rsocket",
+        default_backend="memory",
+        default_features=["rsocket", "local", "long"],
+        service_flags=CORE_SERVICE_FLAGS,
+        opt_flags=["-Dlogging.level.io.rsocket.FrameLogger=OFF"],
+        management_endpoints=["shutdown", "health", "rootkeys"],
+        port_flags_fn=lambda: [
+            f"-Dserver.port={CORE_MGMT_PORT}",
+            f"-Dmanagement.server.port={CORE_MGMT_PORT}",
+            f"-Dspring.rsocket.server.port={CORE_RSOCKET_PORT}",
+        ],
+        available_features=["memory", "cassandra", "redis", "kafka", "e2ee",
+                            "rsocket", "rest"] + COMMON_FEATURES,
+    ),
+    "rest": Service(
+        name="rest",
+        description="REST facade over the core RSocket service",
+        module="chat-deploy",
+        app_primary="REST",
+        deployment_name="core-service-http",
+        image_name="chat-rest",
+        default_backend="client",
+        default_features=["rest", "local", "long"],
+        client_proto="rsocket",
+        client_flags=[
+            "-Dapp.client.protocol=rsocket",
+            "-Dapp.server.proto=http",
+            "-Dapp.client.rsocket.composite.user",
+            "-Dapp.client.rsocket.composite.topic",
+            "-Dapp.client.rsocket.composite.message",
+            "-Dapp.controller.user",
+            "-Dapp.controller.topic",
+            "-Dapp.controller.message",
+        ],
+        opt_flags=[
+            RSOCKET_SERVER_AUTOCONFIG_EXCLUDE,
+            "-Dlogging.level.com.demo.chat.client.rsocket=DEBUG",
+        ],
+        management_endpoints=["shutdown", "health"],
+        port_flags_fn=lambda: [
+            f"-Dserver.port={HTTP_PORT}",
+            f"-Dmanagement.server.port={HTTP_MGMT_PORT}",
+        ],
+        available_features=["client", "rest", "e2ee"] + COMMON_FEATURES,
+    ),
+    "gateway": Service(
+        name="gateway",
+        description="Spring Cloud Gateway edge router",
+        module="chat-deploy",
+        app_primary="gateway",
+        deployment_name="chat-gateway",
+        image_name="chat-gateway",
+        default_backend="client",
+        default_features=["gateway", "local", "long"],
+        opt_flags=[f"-Dapp.rest.port={CORE_MGMT_PORT}"],
+        management_endpoints=["shutdown", "health"],
+        port_flags_fn=lambda: [
+            f"-Dserver.port={GATEWAY_HTTP_PORT}",
+            f"-Dmanagement.server.port={GATEWAY_HTTP_MGMT_PORT}",
+        ],
+        available_features=["client", "gateway"] + COMMON_FEATURES,
+    ),
+    "authserv": Service(
+        name="authserv",
+        description="OAuth2 authorization server (JDBC-backed)",
+        module="chat-authorization-server",
+        app_primary="authserv",
+        deployment_name="chat-authserv",
+        image_name="chat-authserv",
+        default_backend="client",
+        default_features=["local", "long"],
+        client_proto="rsocket",
+        maven_profiles=["jdbc"],
+        client_flags=[
+            "-Dapp.client.protocol=rsocket",
+            "-Dapp.client.rsocket.core.key",
+            "-Dapp.client.rsocket.core.persistence",
+            "-Dapp.client.rsocket.core.index",
+            "-Dapp.oauth2.entrypoint-path=localhost:9090",
+            "-Dapp.client.rsocket.core.secrets",
+            "-Dapp.client.rsocket.composite.user",
+            "-Dapp.service.composite.auth",
+        ],
+        opt_flags=[
+            RSOCKET_SERVER_AUTOCONFIG_EXCLUDE,
+            "-Dspring.main.web-application-type=servlet",
+            "-Dlogging.level.com.demo.chat.client.rsocket=DEBUG",
+        ],
+        additional_configs=[
+            "classpath:/config/server-authserv-consul.yml",
+            "classpath:/config/oauth2-client.yml",
+        ],
+        management_endpoints=["shutdown", "health"],
+        run_arguments="--clientpath='classpath:client.json'",
+        port_flags_fn=lambda: [
+            f"-Dserver.port={AUTHSERV_HTTP_PORT}",
+            f"-Dmanagement.server.port={AUTHSERV_MGMT_PORT}",
+        ],
+        available_features=["client"] + COMMON_FEATURES,
+    ),
+    "shell": Service(
+        name="shell",
+        description="Interactive Spring Shell client",
+        module="chat-deploy",
+        app_primary="shell",
+        deployment_name="chat-shell",
+        image_name="chat-shell",
+        default_backend="client",
+        default_features=["shell", "local", "long"],
+        client_proto="rsocket",
+        client_flags=[
+            "-Dapp.client.protocol=rsocket",
+            RSOCKET_SERVER_AUTOCONFIG_EXCLUDE,
+            "-Dapp.client.rsocket.core.key",
+            "-Dapp.client.rsocket.core.persistence",
+            "-Dapp.client.rsocket.core.index",
+            "-Dapp.client.rsocket.core.pubsub",
+            "-Dapp.client.rsocket.core.secrets",
+            "-Dapp.client.rsocket.composite.user",
+            "-Dapp.client.rsocket.composite.message",
+            "-Dapp.client.rsocket.composite.topic",
+        ],
+        service_flags=[
+            "-Dapp.service.core.key",
+            "-Dapp.service.composite.auth",
+        ],
+        opt_flags=[
+            "-Dspring.shell.interactive.enabled=true",
+            "-Dspring.main.web-application-type=reactive",
+            "-Dlogging.level.io.rsocket.FrameLogger=OFF",
+        ],
+        management_endpoints=["shutdown", "health", "rootkeys"],
+        port_flags_fn=lambda: [
+            f"-Dserver.port={SHELL_MGMT_PORT}",
+            f"-Dmanagement.server.port={SHELL_MGMT_PORT}",
+        ],
+        available_features=["client", "shell"] + COMMON_FEATURES,
+    ),
+}
+
+
+# --------------------------------------------------------------------------
+# Build context
+# --------------------------------------------------------------------------
+
+class BuildContext:
+    """Resolves features against a service and composes the Maven invocation."""
+
+    def __init__(self, service: Service, args: argparse.Namespace):
+        self.service = service
+        self.args = args
+        self.selected = self._resolve_features()
+        self.backend = self._resolve_backend()
+        self.key_type = "uuid" if "uuid" in self.selected else "long"
+        self.discovery = "consul" if "consul" in self.selected else "local"
+        self.init_phases = [p.strip() for p in (args.init or "").split(",") if p.strip()]
+        self.tls_dir: str | None = args.tls
+        self.image_name = service.image_name_for(self.backend)
+
+    # -- resolution ------------------------------------------------------
+
+    def _resolve_features(self) -> list[str]:
+        chosen = [
+            name for name in self.service.available_features
+            if getattr(self.args, name.replace("-", "_"), False)
+        ]
+        for name in self.service.default_features:
+            if name not in chosen and not self._group_taken(chosen, name):
+                chosen.append(name)
+
+        for name in chosen:
+            for other in FEATURES[name].conflicts:
+                if other in chosen:
+                    sys.exit(f"chat-build: --{name} conflicts with --{other}")
+
+        seen: dict[str, str] = {}
+        for name in chosen:
+            group = FEATURES[name].group
+            if group in (None, "backend"):
+                continue
+            if group in seen and seen[group] != name:
+                sys.exit(
+                    f"chat-build: --{name} and --{seen[group]} are both "
+                    f"'{group}' options; pick one"
+                )
+            seen[group] = name
+        return chosen
+
+    def _group_taken(self, chosen: list[str], candidate: str) -> bool:
+        group = FEATURES[candidate].group
+        if group is None:
+            return False
+        return any(FEATURES[c].group == group for c in chosen)
+
+    def _resolve_backend(self) -> str:
+        picked = [n for n in self.selected if FEATURES[n].group == "backend"]
+        if len(picked) > 1:
+            sys.exit(
+                "chat-build: pick exactly one backend, got "
+                + ", ".join(f"--{p}" for p in picked)
+            )
+        if picked:
+            return picked[0]
+        default = self.service.default_backend
+        self.selected.append(default)
+        return default
+
+    def _features(self) -> list[Feature]:
+        return [FEATURES[n] for n in self.selected]
+
+    # -- Maven -----------------------------------------------------------
+
+    def maven_profiles(self) -> list[str]:
+        profiles = ["deploy"]
+        profiles += list(self.service.maven_profiles)
+        for feat in self._features():
+            profiles += feat.maven_profiles
+        if self.discovery == "consul" and self.service.client_proto:
+            profiles.append("discovery-consul")
+        # Preserve order, drop duplicates.
+        return list(dict.fromkeys(profiles))
+
+    def spring_profiles(self) -> list[str]:
+        profiles: list[str] = []
+        for feat in self._features():
+            profiles += feat.spring_profiles
+        profiles += self.args.profile
+        return list(dict.fromkeys(profiles))
+
+    def maven_goal(self) -> str:
+        return "spring-boot:build-image" if self.args.build else "spring-boot:run"
+
+    def module_dir(self) -> Path:
+        return REPO_ROOT / self.service.module
+
+    def compose_maven_command(self) -> list[str]:
+        return [
+            "mvn",
+            f"-DimageName={self.image_name}",
+            "-P" + ",".join(self.maven_profiles()),
+            "-DskipTests",
+            self.maven_goal(),
+        ]
+
+    # -- JAVA_TOOL_OPTIONS groups, in build-app.sh order -----------------
+
+    def endpoint_flags(self) -> list[str]:
+        endpoints = list(self.service.management_endpoints)
+        if self.discovery == "consul" and "health" not in endpoints:
+            endpoints.append("health")
+        if not endpoints:
+            return []
+        flags = [f"-Dmanagement.endpoint.{e}.enabled=true" for e in endpoints]
+        flags.append("-Dmanagement.endpoints.web.exposure.include=" + ",".join(endpoints))
+        return flags
+
+    def main_flags(self) -> list[str]:
+        flags = [f"-Dspring.profiles.active={','.join(self.spring_profiles())}"]
+        flags += self.endpoint_flags()
+        flags += [
+            f"-Dapp.key.type={self.key_type}",
+            f"-Dapp.primary={self.service.app_primary}",
+            f"-Dspring.application.name={self.service.deployment_name}",
+            "-Djava.security.egd=file:/dev/./urandom",
+        ]
+        for feat in self._features():
+            for key, value in feat.spring_properties.items():
+                flags.append(f"-D{key}={value}")
+        return flags
+
+    def tls_flags(self) -> list[str]:
+        """Server TLS for services, client TLS for client-shaped services.
+
+        build-app.sh branches on whether CLIENT_FLAGS is set; this mirrors that.
+        """
+        is_client = bool(self.service.client_flags)
+        if self.tls_dir is None:
+            if is_client and self.service.client_proto == "rsocket":
+                return ["-Dapp.rsocket.transport.security.type=unprotected"]
+            return ["-Dspring.rsocket.server.ssl.enabled=false"]
+
+        keystore_pass = os.environ.get("KEYSTORE_PASS", "")
+        if is_client and self.service.client_proto == "rsocket":
+            return [
+                "-Dapp.rsocket.transport.security.type=pkcs12",
+                f"-Dapp.rsocket.transport.security.truststore.path={self.tls_dir}/client_truststore.p12",
+                f"-Dapp.rsocket.transport.security.keystore.path={self.tls_dir}/client_keystore.p12",
+                f"-Dapp.rsocket.transport.security.keyfile.pass={keystore_pass}",
+            ]
+        return [
+            "-Dspring.rsocket.server.ssl.enabled=true",
+            "-Dspring.rsocket.server.ssl.client-auth=none",
+            "-Dspring.rsocket.server.ssl.protocol=TLS",
+            "-Dspring.rsocket.server.ssl.enabled-protocols=TLSv1.2",
+            f"-Dspring.rsocket.server.ssl.key-store={self.tls_dir}/server_keystore.p12",
+            "-Dspring.rsocket.server.ssl.key-store-type=PKCS12",
+            f"-Dspring.rsocket.server.ssl.key-store-password={keystore_pass}",
+        ]
+
+    def ports_flags(self) -> list[str]:
+        return self.service.port_flags()
+
+    def init_flags(self) -> list[str]:
+        flags: list[str] = []
+        if "users" in self.init_phases:
+            flags.append("-Dapp.users.create=true")
+        if "rootkeys" in self.init_phases:
+            flags.append("-Dapp.rootkeys.create=true")
+
+        if self.discovery == "consul" and "rootkeys" in self.init_phases:
+            # This node mints the root keys, so publish them to Consul KV.
+            flags += [
+                "-Dapp.kv.store=consul",
+                "-Dapp.kv.prefix=/chat",
+                "-Dapp.kv.rootkeys=rootkeys",
+                "-Dapp.rootkeys.publish.scheme=kv",
+            ]
+        elif self.discovery == "local" and "rootkeys" not in self.init_phases:
+            # Joining node: pull the root keys off a peer's actuator endpoint.
+            flags += [
+                "-Dapp.kv.store=none",
+                "-Dapp.rootkeys.consume.scheme=http",
+                f"-Dapp.rootkeys.consume.source={ROOTKEY_SOURCE_URI}",
+            ]
+        return flags
+
+    def discovery_flags(self) -> list[str]:
+        actuator_user = [
+            "-Dspring.security.user.name=actuator",
+            "-Dspring.security.user.password=actuator",
+            "-Dspring.security.user.roles=ACTUATOR",
+        ]
+        if self.discovery == "consul":
+            host = os.environ.get("CONSUL_HOST") or find_consul_host()
+            flags = [
+                f"-Dspring.cloud.consul.host={host}",
+                f"-Dspring.cloud.consul.port={CONSUL_PORT}",
+                "-Dspring.cloud.consul.discovery.enabled=true",
+                "-Dspring.cloud.consul.discovery.preferIpAddress=true",
+                "-Dspring.cloud.consul.discovery.health-check-headers[0]="
+                "'Authorization: Basic QXV0aG9yaXphdGlvbjogQmFzaWMg'",
+            ] + actuator_user
+            if self.service.client_proto:
+                flags.append("-Dapp.client.discovery=consul")
+            return flags
+
+        flags = [
+            "-Dspring.cloud.consul.enabled=false",
+            "-Dspring.cloud.service-registry.auto-registration.enabled=false",
+            "-Dspring.cloud.consul.config.enabled=false",
+            "-Dspring.cloud.consul.config.watch.enabled=false",
+            "-Dspring.cloud.consul.discovery.enabled=false",
+        ] + actuator_user
+        if self.service.client_proto:
+            flags.append("-Dapp.client.discovery=properties")
+        return flags
+
+    def client_flags(self) -> list[str]:
+        flags = list(self.service.client_flags)
+        if flags and "websocket" in self.selected:
+            flags.append("-Dapp.rsocket.transport.websocket.enabled=true")
+        return flags
+
+    def service_flags(self) -> list[str]:
+        flags = list(self.service.service_flags)
+        for feat in self._features():
+            flags += feat.service_flags
+        if flags and "websocket" in self.selected:
+            flags += [
+                "-Dspring.rsocket.server.transport=websocket",
+                "-Dspring.rsocket.server.mapping-path=/",
+            ]
+        return flags
+
+    def additional_configs(self) -> list[str]:
+        configs = list(BASE_ADDITIONAL_CONFIGS)
+        configs += self.service.additional_configs
+        for feat in self._features():
+            configs += feat.additional_configs
+        if "users" in self.init_phases:
+            configs.append("classpath:/config/userinit.yml")
+        if self.service.client_proto:
+            configs.append(
+                f"classpath:/config/client-{self.service.client_proto}-{self.discovery}.yml"
+            )
+        return list(dict.fromkeys(configs))
+
+    def opt_flags(self) -> list[str]:
+        flags = list(self.service.opt_flags)
+        for feat in self._features():
+            flags += feat.opt_flags
+        if "debug" in self.selected:
+            flags.append("-Dlogging.level.io.rsocket.FrameLogger=DEBUG")
+            if self.service.client_proto:
+                flags += [
+                    "-Dlogging.level.com.demo.chat.client.rsocket=DEBUG",
+                    "-Dlogging.level.reactor.netty.http.client=DEBUG",
+                ]
+        flags.append(
+            "-Dspring.config.additional-location=" + ",".join(self.additional_configs())
+        )
+        return flags
+
+    def run_args(self) -> list[str]:
+        jvm_args = ""
+        if "debug" in self.selected and not self.args.build:
+            suspend = os.environ.get("DEBUG_SUSPEND", "n")
+            jvm_args = (
+                f"-agentlib:jdwp=transport=dt_socket,server=y,"
+                f"suspend={suspend},address={DEBUG_PORT}"
+            )
+        return [
+            f'-Dspring-boot.run.arguments="{self.service.run_arguments}"',
+            f'-Dspring-boot.run.jvmArguments="{jvm_args}"',
+        ]
+
+    def java_tool_options_list(self) -> list[str]:
+        groups = [
+            self.main_flags(),
+            self.tls_flags(),
+            self.ports_flags(),
+            self.init_flags(),
+            self.discovery_flags(),
+            self.client_flags(),
+            self.service_flags(),
+            self.opt_flags(),
+            self.run_args(),
+        ]
+        return [flag for group in groups for flag in group]
+
+    def java_tool_options(self) -> str:
+        return " ".join(self.java_tool_options_list())
+
+    # -- output ----------------------------------------------------------
+
+    def env_file_path(self) -> Path:
+        if self.args.env_file:
+            return Path(self.args.env_file)
+        return Path(f"/tmp/chat-build-{self.service.name}-{self.image_name}.env")
+
+    def env_file_content(self) -> str:
+        """Real KEY=VALUE pairs.
+
+        build-app.sh wrote literal `echo KEY = VALUE` lines here, which docker
+        --env-file cannot parse. This emits something docker can actually read.
+        """
+        return "\n".join([
+            f"JAVA_TOOL_OPTIONS={self.java_tool_options()}",
+            "MAVEN_PROFILES=-P" + ",".join(self.maven_profiles()),
+            f"MAVEN_GOAL={self.maven_goal()}",
+            f"CWD={self.module_dir()}",
+            f"IMAGE_NAME={self.image_name}",
+        ]) + "\n"
+
+    def write_env_file(self) -> Path:
+        path = self.env_file_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(self.env_file_content())
+        return path
+
+    def execute(self) -> int:
+        env_file = self.write_env_file()
+        print(f"ENV_FILE={env_file}", file=sys.stderr)
+
+        env = os.environ.copy()
+        if self.args.bake:
+            # The image build reads the env file instead of inheriting options.
+            env.pop("JAVA_TOOL_OPTIONS", None)
+        else:
+            env["JAVA_TOOL_OPTIONS"] = self.java_tool_options()
+
+        cmd = self.compose_maven_command()
+        print("+ " + " ".join(shlex.quote(c) for c in cmd), file=sys.stderr)
+        return subprocess.run(cmd, cwd=self.module_dir(), env=env).returncode
+
+
+def find_consul_host() -> str:
+    """Mirror util.sh find_consul: locate a running consul container's IP."""
+    try:
+        cid = subprocess.run(
+            ["docker", "ps", "-aqf", "name=consul"],
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        cid = ""
+    if not cid:
+        sys.exit(
+            "chat-build: no consul container found and CONSUL_HOST is unset.\n"
+            "Run consul in docker, or set CONSUL_HOST and CONSUL_PORT."
+        )
+    ip = subprocess.run(
+        ["docker", "inspect", "-f",
+         "{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}", cid],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    return ip or CONSUL_HOST
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def add_common_args(parser: argparse.ArgumentParser) -> None:
+    tls = parser.add_mutually_exclusive_group()
+    tls.add_argument("--tls", metavar="DIR",
+                     help="enable TLS using certificates in DIR")
+    tls.add_argument("--notls", action="store_true",
+                     help="disable TLS (required if --tls is not given)")
+
+    goal = parser.add_mutually_exclusive_group()
+    goal.add_argument("--run", action="store_true",
+                      help="run locally via spring-boot:run (default)")
+    goal.add_argument("--build", action="store_true",
+                      help="build a container image via spring-boot:build-image")
+
+    parser.add_argument("--init", default="", metavar="PHASES",
+                        help="init phases, comma separated: users,rootkeys")
+    parser.add_argument("--profile", action="append", default=[], metavar="NAME",
+                        help="additional Spring profile (repeatable)")
+    parser.add_argument("--env-file", metavar="PATH",
+                        help="where to write the env file")
+    parser.add_argument("--bake", action="store_true",
+                        help="pass options via the env file instead of inheriting them")
+    parser.add_argument("--native", action="store_true",
+                        help="GraalVM native build (not supported)")
+    parser.add_argument("--dry-run", action="store_true",
+                        help="print the resolved command and options, run nothing")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="chat-build",
+        description="Compose and run demo-chat Maven builds from feature flags.",
+        epilog="Example: chat-build core --memory --run --notls --init users,rootkeys",
+    )
+    subparsers = parser.add_subparsers(dest="service", required=True,
+                                       metavar="SERVICE")
+    for service in SERVICES.values():
+        sub = subparsers.add_parser(service.name, help=service.description)
+        add_common_args(sub)
+        group = sub.add_argument_group("features")
+        for name in service.available_features:
+            feat = FEATURES[name]
+            suffix = ""
+            if name == service.default_backend or name in service.default_features:
+                suffix = " (default)"
+            group.add_argument(f"--{name}", action="store_true",
+                               help=feat.description + suffix)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+
+    if args.native:
+        print("chat-build: native builds are not supported at this time",
+              file=sys.stderr)
+        return 1
+
+    if not args.tls and not args.notls:
+        print("chat-build: specify --tls <dir> or --notls", file=sys.stderr)
+        return 1
+
+    if args.tls and not os.environ.get("KEYSTORE_PASS"):
+        print("chat-build: KEYSTORE_PASS must be set when using --tls",
+              file=sys.stderr)
+        return 1
+
+    ctx = BuildContext(SERVICES[args.service], args)
+
+    if args.dry_run:
+        cmd = ctx.compose_maven_command()
+        print(f"# service:  {ctx.service.name}")
+        print(f"# module:   {ctx.module_dir()}")
+        print(f"# features: {' '.join(sorted(ctx.selected))}")
+        print(f"# image:    {ctx.image_name}")
+        print()
+        print("# maven command:")
+        print(" ".join(shlex.quote(c) for c in cmd))
+        print()
+        print("# JAVA_TOOL_OPTIONS:")
+        for flag in ctx.java_tool_options_list():
+            print(f"  {flag}")
+        print()
+        print(f"# env file would be written to: {ctx.env_file_path()}")
+        return 0
+
+    return ctx.execute()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -670,10 +670,13 @@ class BuildContext:
         return flags
 
     def additional_configs(self) -> list[str]:
-        configs = list(BASE_ADDITIONAL_CONFIGS)
-        configs += self.service.additional_configs
+        # Order is load order, and later locations win in Spring. build-app.sh
+        # appends the base pair onto whatever the run script exported, so
+        # service and feature configs come first and the base overrides them.
+        configs = list(self.service.additional_configs)
         for feat in self._features():
             configs += feat.additional_configs
+        configs += BASE_ADDITIONAL_CONFIGS
         if "users" in self.init_phases:
             configs.append("classpath:/config/userinit.yml")
         if self.service.client_proto:

--- a/shell-scripts/run
+++ b/shell-scripts/run
@@ -1,0 +1,5 @@
+#!/bin/bash
+# run — convenience wrapper for chat-build.
+#   ./run core --memory --run --notls
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+exec python3 "$DIR/chat-build" "$@"

--- a/shell-scripts/test-parity.sh
+++ b/shell-scripts/test-parity.sh
@@ -1,0 +1,241 @@
+#!/bin/bash
+# test-parity.sh — assert chat-build produces the same JVM flags as build-app.sh.
+#
+# For each case, this runs build-app.sh -x with the environment its matching
+# run-*.sh script exports, runs the equivalent chat-build --dry-run, and diffs
+# the two flag sets. Known-intentional differences are declared per case in
+# EXPECTED_ONLY_OLD / EXPECTED_ONLY_NEW; anything else fails the run.
+#
+# Usage: ./test-parity.sh [-v]
+
+set -uo pipefail
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+VERBOSE=0
+[[ "${1:-}" == "-v" ]] && VERBOSE=1
+
+PASS=0
+FAIL=0
+
+# Pull JAVA_TOOL_OPTIONS out of build-app.sh -x output and split it one flag
+# per line. The env file build-app.sh writes is a set of `echo K = V` lines,
+# and the options span several physical lines, so take everything between the
+# JAVA_TOOL_OPTIONS marker and the next marker.
+extract_old() {
+  awk '
+    /echo JAVA_TOOL_OPTIONS =/ { sub(/.*echo JAVA_TOOL_OPTIONS =/, ""); capture=1 }
+    /echo MAVEN ARGS=/ { capture=0 }
+    capture { print }
+  ' | tr ' ' '\n' | sed '/^$/d'
+}
+
+extract_new() {
+  sed -n '/^# JAVA_TOOL_OPTIONS:/,/^$/p' | sed '1d;/^$/d' | sed 's/^  //' \
+    | tr ' ' '\n' | sed '/^$/d'
+}
+
+extract_old_profiles() { grep -o 'MAVEN ARGS=.*' | sed 's/MAVEN ARGS=//'; }
+extract_new_profiles() { grep -oE '^mvn .*' | grep -oE '\-P[^ ]+'; }
+
+# normalise: strip shell quoting that never needed to reach the JVM, collapse
+# repeated entries inside comma-lists (build-app.sh emits client-<proto>-<disc>
+# .yml twice for client services), and sort.
+normalise() {
+  sed "s/'//g" | sed 's/"//g' | python3 -c '
+import sys
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    if "=" in line and "," in line.split("=", 1)[1]:
+        key, value = line.split("=", 1)
+        value = ",".join(dict.fromkeys(value.split(",")))
+        line = f"{key}={value}"
+    print(line)
+' | LC_ALL=C sort -u
+}
+
+# Maven treats -P as a set, so compare profiles order-insensitively.
+sort_profiles() { tr ',' '\n' | sed '/^$/d' | LC_ALL=C sort | paste -sd, -; }
+
+run_case() {
+  local name="$1"; shift
+  local old_out new_out
+  old_out=$(eval "$OLD_CMD" 2>&1)
+  new_out=$("$DIR/chat-build" "$@" 2>&1)
+
+  local old_flags new_flags
+  old_flags=$(echo "$old_out" | extract_old | normalise)
+  new_flags=$(echo "$new_out" | extract_new | normalise)
+
+  local only_old only_new
+  only_old=$(comm -23 <(echo "$old_flags") <(echo "$new_flags"))
+  only_new=$(comm -13 <(echo "$old_flags") <(echo "$new_flags"))
+
+  # Drop the differences this case declares as intentional.
+  [[ -n "${EXPECTED_ONLY_OLD:-}" ]] && only_old=$(echo "$only_old" | grep -vE "$EXPECTED_ONLY_OLD")
+  [[ -n "${EXPECTED_ONLY_NEW:-}" ]] && only_new=$(echo "$only_new" | grep -vE "$EXPECTED_ONLY_NEW")
+  only_old=$(echo "$only_old" | sed '/^$/d')
+  only_new=$(echo "$only_new" | sed '/^$/d')
+
+  local old_p new_p
+  old_p=$(echo "$old_out" | extract_old_profiles | sed 's/^-P//' | sort_profiles)
+  new_p=$(echo "$new_out" | extract_new_profiles | sed 's/^-P//' | sort_profiles)
+
+  local failed=0
+  if [[ "$old_p" != "$new_p" ]]; then
+    echo "FAIL  $name — maven profiles differ"
+    echo "        build-app.sh: $old_p"
+    echo "        chat-build:   $new_p"
+    failed=1
+  fi
+  if [[ -n "$only_old" || -n "$only_new" ]]; then
+    [[ $failed -eq 0 ]] && echo "FAIL  $name — flag sets differ"
+    [[ -n "$only_old" ]] && echo "$only_old" | sed 's/^/        only build-app.sh: /'
+    [[ -n "$only_new" ]] && echo "$only_new" | sed 's/^/        only chat-build:   /'
+    failed=1
+  fi
+
+  if [[ $failed -eq 0 ]]; then
+    echo "ok    $name"
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+  fi
+
+  if [[ $VERBOSE -eq 1 ]]; then
+    echo "      --- build-app.sh flags ---"; echo "$old_flags" | sed 's/^/      /'
+    echo "      --- chat-build flags ---";   echo "$new_flags" | sed 's/^/      /'
+  fi
+
+  unset EXPECTED_ONLY_OLD EXPECTED_ONLY_NEW
+}
+
+# --------------------------------------------------------------------------
+# Case 1 — core, memory backend, local discovery, no TLS
+#   old: run-core.sh runlocal memory  (env below is what run-core.sh exports)
+# --------------------------------------------------------------------------
+(
+export APP_PRIMARY="core-service"
+export APP_IMAGE_NAME="memory-core-service-rsocket"
+export ADDITIONAL_CONFIGS="classpath:/config/server-rsocket-consul.yml,"
+export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
+export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
+export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
+export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
+-Dapp.service.core.key -Dapp.service.core.pubsub -Dapp.service.core.index \
+-Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.composite.auth \
+-Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
+-Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
+-Dapp.controller.pubsub -Dapp.controller.secrets -Dapp.controller.user \
+-Dapp.controller.topic -Dapp.controller.message"
+
+OLD_CMD="$DIR/build-app.sh -m chat-deploy -s memory -e rsocket -p prod \
+-n core-service-rsocket -k long -b runlocal -i users,rootkeys -c notls -x"
+
+PASS=0; FAIL=0
+run_case "core --memory --notls --init users,rootkeys" \
+  core --memory --run --notls --long --init users,rootkeys --dry-run
+exit $FAIL
+) ; R1=$?
+
+# --------------------------------------------------------------------------
+# Case 2 — core, memory backend, consul discovery
+# --------------------------------------------------------------------------
+(
+export APP_PRIMARY="core-service"
+export APP_IMAGE_NAME="memory-core-service-rsocket"
+export ADDITIONAL_CONFIGS="classpath:/config/server-rsocket-consul.yml,"
+export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
+export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
+export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
+export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
+-Dapp.service.core.key -Dapp.service.core.pubsub -Dapp.service.core.index \
+-Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.composite.auth \
+-Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
+-Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
+-Dapp.controller.pubsub -Dapp.controller.secrets -Dapp.controller.user \
+-Dapp.controller.topic -Dapp.controller.message"
+export CONSUL_HOST=10.0.0.5
+export CONSUL_PORT=8500
+
+OLD_CMD="$DIR/build-app.sh -m chat-deploy -s memory -e rsocket -p prod \
+-n core-service-rsocket -k long -b runlocal -i users,rootkeys -d consul -c notls -x"
+
+PASS=0; FAIL=0
+run_case "core --memory --consul --notls" \
+  core --memory --consul --run --notls --long --init users,rootkeys --dry-run
+exit $FAIL
+) ; R2=$?
+
+# --------------------------------------------------------------------------
+# Case 3 — core, memory, TLS on
+# --------------------------------------------------------------------------
+(
+export APP_PRIMARY="core-service"
+export APP_IMAGE_NAME="memory-core-service-rsocket"
+export ADDITIONAL_CONFIGS="classpath:/config/server-rsocket-consul.yml,"
+export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
+export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
+export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
+export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
+-Dapp.service.core.key -Dapp.service.core.pubsub -Dapp.service.core.index \
+-Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.composite.auth \
+-Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
+-Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
+-Dapp.controller.pubsub -Dapp.controller.secrets -Dapp.controller.user \
+-Dapp.controller.topic -Dapp.controller.message"
+export KEYSTORE_PASS="parity-test-pass"
+
+OLD_CMD="$DIR/build-app.sh -m chat-deploy -s memory -e rsocket -p prod \
+-n core-service-rsocket -k long -b runlocal -i users,rootkeys -c /etc/keys -x"
+
+PASS=0; FAIL=0
+run_case "core --memory --tls /etc/keys" \
+  core --memory --run --tls /etc/keys --long --init users,rootkeys --dry-run
+exit $FAIL
+) ; R3=$?
+
+# --------------------------------------------------------------------------
+# Case 4 — shell, client backend, local discovery
+#   run-shell.sh sets MAIN_FLAGS, but build-app.sh overwrites MAIN_FLAGS
+#   wholesale, so the shell interactive flags never reach the JVM through the
+#   old path. chat-build keeps them in opt_flags, which is the fix, so they
+#   are declared as an expected new-only difference.
+# --------------------------------------------------------------------------
+(
+export CLIENT_PROTO="rsocket"
+export APP_PRIMARY="shell"
+export APP_IMAGE_NAME="chat-shell"
+export PORTS_FLAGS="-Dserver.port=9101 -Dmanagement.server.port=9101"
+export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
+export CLIENT_FLAGS="-Dapp.client.protocol=rsocket \
+-Dspring.autoconfigure.exclude=org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration \
+-Dapp.client.rsocket.core.key -Dapp.client.rsocket.core.persistence \
+-Dapp.client.rsocket.core.index -Dapp.client.rsocket.core.pubsub \
+-Dapp.client.rsocket.core.secrets -Dapp.client.rsocket.composite.user \
+-Dapp.client.rsocket.composite.message -Dapp.client.rsocket.composite.topic"
+export SERVICE_FLAGS="-Dapp.service.core.key -Dapp.service.composite.auth"
+export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF -Dspring.autoconfigure.exclude=org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
+
+OLD_CMD="$DIR/build-app.sh -m chat-deploy -k long -p shell -e shell -s client \
+-n chat-shell -b runlocal -d local -c notls -x"
+
+EXPECTED_ONLY_NEW='spring.shell.interactive.enabled|spring.main.web-application-type'
+PASS=0; FAIL=0
+run_case "shell --client --notls" \
+  shell --run --notls --long --dry-run
+exit $FAIL
+) ; R4=$?
+
+TOTAL_FAIL=$((R1 + R2 + R3 + R4))
+echo
+if [[ $TOTAL_FAIL -eq 0 ]]; then
+  echo "parity: all cases passed"
+else
+  echo "parity: $TOTAL_FAIL case(s) failed"
+fi
+exit $TOTAL_FAIL


### PR DESCRIPTION
Implements `.hermes/plans/2026-08-20_174500-build-system-modernisation.md`.

Replaces the flag assembly spread across `build-app.sh` and the five `run-*.sh` scripts with a single Python CLI driven by a declarative Feature/Service registry. Additions only — **no existing script is modified or deleted**, so both paths work side by side.

```bash
chat-build core --memory --run --notls --init users,rootkeys
chat-build core --cassandra --kafka --e2ee --build --notls --uuid
chat-build rest --run --notls --dry-run
```

## What's here

| File | |
|---|---|
| `shell-scripts/chat-build` | The CLI. Python 3.10+, stdlib only. |
| `shell-scripts/run` | Convenience wrapper. |
| `shell-scripts/test-parity.sh` | Asserting parity harness against `build-app.sh -x`. |
| `shell-scripts/README-chat-build.md` | Usage, flag reference, migration table. |
| `chat-deploy/pom.xml` | Adds the `e2ee` profile (+10 lines). |

## Verification

- Parity harness passes on all four cases — core/memory/local, core/memory/consul, core/memory/TLS, shell/client/local — matching both flag sets and Maven profiles.
- **Proved non-vacuous:** mutated `-Dapp.service.core.secrets` in the CLI, confirmed two cases fail with the exact diff, restored, re-passed.
- `mvn -o -Pdeploy,memory-backend,expose-rsocket,e2ee validate` → BUILD SUCCESS.
- Error paths exercised: missing TLS choice, `--tls` without `KEYSTORE_PASS`, two backends, `--long --uuid`, `--local --consul`, `--native` — each exits 1 with a useful message.
- `execute()` verified against a stub `mvn` on PATH; env file confirmed as 5 lines of real `KEY=VALUE`.

## Corrections against the plan

The plan was written against a tree four commits old and had several mappings that don't match the poms. Verified each against the source:

1. **`--cassandra` must not override the module.** The `cassandra-backend` profile already pulls `chat-deploy-cassandra` in as a dependency, and that module has no `expose-*` profiles of its own — a module override would have silently dropped the transport. `chat-deploy` stays the module throughout.
2. **TLS branches on client vs server**, as `build-app.sh` does. Client-shaped services (`rest`, `shell`, `authserv`) get `app.rsocket.transport.security.*`; server-shaped ones get `spring.rsocket.server.ssl.*`. The plan only implemented the server branch.
3. **`--local` re-adds the root-key HTTP consume chain** (`app.kv.store=none`, `app.rootkeys.consume.*`) when `rootkeys` is not an init phase. Without it a joining node never receives root keys.
4. **`--consul` re-adds** KV publish flags, health-check headers, the `find_consul` docker fallback and `app.client.discovery=consul`.
5. **Management endpoint flags are rendered.** The plan declared the field but never emitted it; core needs the `rootkeys` endpoint exposed for HTTP root-key handoff.
6. **Base config imports included** — `logging.yml`, `management-defaults.yml`, and the per-client `client-<proto>-<discovery>.yml`.
7. **Env file emits real `KEY=VALUE`.** `build-app.sh` wrote literal `echo KEY = VALUE` lines that `docker --env-file` cannot parse.
8. **TLS stays fail-closed** — `--tls <dir>` or `--notls` must be given explicitly, matching `build-app.sh` rather than the plan's notls-by-default.

Two more surfaced while building the parity harness:

9. **`build-app.sh` emits `client-<proto>-<discovery>.yml` twice** for client services, appending it in both the discovery/client block and the local-discovery block. Deduped here.
10. **`run-shell.sh`'s `MAIN_FLAGS` never reach the JVM.** `build-app.sh` overwrites `MAIN_FLAGS` wholesale after sourcing the run script, so `spring.shell.interactive.enabled` and `web-application-type=reactive` are silently dropped today. `chat-build` carries them through; declared as an expected difference in the harness.

Config-location **ordering** also matches `build-app.sh` now — service and feature configs load before the logging/management base pair, since later locations win in Spring.

## Notes for reviewers

- **`--kafka` and `--e2ee` need `mvn -DskipTests install` from the repo root first.** `chat-deploy-kafka`, `chat-deploy-e2ee`, `chat-crypto` and `chat-presence` are absent from the local repository. Pre-existing for kafka, not introduced here.
- **Behaviour change:** `run-rest.sh local` and `run-gateway.sh local` are broken today — neither passes `-s`, so `build-app.sh` exits with "you forgot to select a backend". `chat-build` defaults both services to the `client` backend, so they go from erroring to working.
- The `e2ee` profile addition is the one change outside the plan's stated file list, agreed up front: without it `--e2ee` would set properties for classes that aren't on the classpath.
- The duplicate `spring-boot-maven-plugin` warning in `chat-deploy`'s `deploy` profile is pre-existing — confirmed by stashing and re-running against `HEAD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Gee, thanks, Claude.
