### PR TITLE
refactor: make app.service.core.persistence a valued selector

### DIFF
--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
@@ -20,7 +20,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "app.service.core.key",
-        "app.service.core.pubsub=memory", "app.service.core.index=cassandra", "app.service.core.persistence",
+        "app.service.core.pubsub=memory", "app.service.core.index=cassandra", "app.service.core.persistence=cassandra",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",

--- a/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
+++ b/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
@@ -32,7 +32,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",
         "app.service.core.key",
         "app.service.core.pubsub=kafka",
-        "app.service.core.index=lucene", "app.service.core.persistence",
+        "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence",
         "app.controller.index", "app.controller.user", "app.controller.message",

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
@@ -19,7 +19,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.application.name=test-deployment", "app.server.proto=rsocket",
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "app.service.core.key",
-        "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence",
+        "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",

--- a/chat-deploy-redis/build-core.sh
+++ b/chat-deploy-redis/build-core.sh
@@ -13,7 +13,7 @@ export APP_VERSION=0.0.1
 export JAVA_TOOL_OPTIONS=" -Dspring.profiles.active=${SPRING_PROFILE} \
 -Dserver.port=$((CORE_PORT+1)) -Dspring.rsocket.server.port=${CORE_PORT} \
 -Dapp.service.core.key -Dapp.service.core.pubsub=redis-pubsub \
--Dapp.service.core.persistence -Dapp.service.edge.topic \
+-Dapp.service.edge.topic \
 -Dapp.service.edge.user -Dapp.service.edge.messaging \
 -Dapp.primary=core -Dspring.cloud.consul.host=${CONSUL_HOST} \
 -Dspring.cloud.consul.port=${CONSUL_PORT} "

--- a/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
+++ b/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
@@ -16,7 +16,7 @@ import org.springframework.test.context.TestPropertySource
     properties = [
         "server.port=0", "spring.rsocket.server.port=0",
         "app.service.core.key",
-        "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence",
+        "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message","app.controller.topic", "app.controller.pubsub",

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/CorePersistenceServices.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/CorePersistenceServices.kt
@@ -8,7 +8,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["persistence"])
+@ConditionalOnProperty(prefix = "app.service.core", name = ["persistence"], havingValue = "cassandra")
 class CorePersistenceServices<T>(
     keyService: IKeyService<T>,
     userRepo: ChatUserRepository<T>,

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/CorePersistenceServicesConditionTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/CorePersistenceServicesConditionTests.kt
@@ -1,0 +1,102 @@
+package com.demo.chat.test.persistence.cassandra
+
+import com.demo.chat.config.persistence.cassandra.CorePersistenceServices
+import com.demo.chat.persistence.cassandra.repository.AuthMetadataRepository
+import com.demo.chat.persistence.cassandra.repository.ChatMessageRepository
+import com.demo.chat.persistence.cassandra.repository.ChatUserRepository
+import com.demo.chat.persistence.cassandra.repository.KeyValuePairRepository
+import com.demo.chat.persistence.cassandra.repository.TopicMembershipRepository
+import com.demo.chat.persistence.cassandra.repository.TopicRepository
+import com.demo.chat.service.core.IKeyService
+import com.demo.chat.test.TestLongKeyService
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * `app.service.core.persistence` names one persistence backend. Cassandra
+ * activates only when the selector names it — never by default, and never
+ * alongside the in-memory backend.
+ *
+ * The repositories are mocked because the condition, not the query behaviour,
+ * is under test; the configuration stores its dependencies and builds the
+ * persistence services lazily, so no Cassandra connection is involved.
+ */
+class CorePersistenceServicesConditionTests {
+
+    @Suppress("UNCHECKED_CAST")
+    @Configuration(proxyBeanMethods = false)
+    class CassandraDependencyStubs {
+        @Bean
+        fun keyService(): IKeyService<Long> = TestLongKeyService()
+
+        @Bean
+        fun mapper(): ObjectMapper = ObjectMapper()
+
+        @Bean
+        fun userRepo(): ChatUserRepository<Long> = mock(ChatUserRepository::class.java) as ChatUserRepository<Long>
+
+        @Bean
+        fun topicRepo(): TopicRepository<Long> = mock(TopicRepository::class.java) as TopicRepository<Long>
+
+        @Bean
+        fun messageRepo(): ChatMessageRepository<Long> = mock(ChatMessageRepository::class.java) as ChatMessageRepository<Long>
+
+        @Bean
+        fun membershipRepo(): TopicMembershipRepository<Long> = mock(TopicMembershipRepository::class.java) as TopicMembershipRepository<Long>
+
+        @Bean
+        fun authmetaRepo(): AuthMetadataRepository<Long> = mock(AuthMetadataRepository::class.java) as AuthMetadataRepository<Long>
+
+        @Bean
+        fun keyValueRepo(): KeyValuePairRepository<Long> = mock(KeyValuePairRepository::class.java) as KeyValuePairRepository<Long>
+    }
+
+    /**
+     * Registers CorePersistenceServices as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(CassandraDependencyStubs::class.java)
+        .withUserConfiguration(CorePersistenceServices::class.java)
+
+    @Test
+    fun `activates when the selector names cassandra`() {
+        runner()
+            .withPropertyValues("app.service.core.persistence=cassandra")
+            .run { context ->
+                assertThat(context).hasSingleBean(CorePersistenceServices::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.persistence=memory")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(CorePersistenceServices::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).doesNotHaveBean(CorePersistenceServices::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.persistence=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(CorePersistenceServices::class.java)
+            }
+    }
+}

--- a/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemoryPersistenceServices.kt
+++ b/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemoryPersistenceServices.kt
@@ -10,7 +10,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["persistence"])
+@ConditionalOnProperty(
+    prefix = "app.service.core",
+    name = ["persistence"],
+    havingValue = "memory",
+    matchIfMissing = true
+)
 class MemoryPersistenceServices<T, V>(private val keyService: IKeyService<T>) :
     PersistenceServiceBeans<T, V> {
 

--- a/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemoryPersistenceServicesConditionTests.kt
+++ b/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemoryPersistenceServicesConditionTests.kt
@@ -1,0 +1,68 @@
+package com.demo.chat.test.persistence.memory
+
+import com.demo.chat.config.persistence.memory.MemoryPersistenceServices
+import com.demo.chat.service.core.IKeyService
+import com.demo.chat.test.TestLongKeyService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * `app.service.core.persistence` names one persistence backend. Memory is the
+ * in-process default, so it activates when the selector is absent — but never
+ * when the selector names a different backend.
+ */
+class MemoryPersistenceServicesConditionTests {
+
+    @Configuration(proxyBeanMethods = false)
+    class KeyServiceStub {
+        @Bean
+        fun keyService(): IKeyService<Long> = TestLongKeyService()
+    }
+
+    /**
+     * Registers MemoryPersistenceServices as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(KeyServiceStub::class.java)
+        .withUserConfiguration(MemoryPersistenceServices::class.java)
+
+    @Test
+    fun `activates when the selector names memory`() {
+        runner()
+            .withPropertyValues("app.service.core.persistence=memory")
+            .run { context ->
+                assertThat(context).hasSingleBean(MemoryPersistenceServices::class.java)
+            }
+    }
+
+    @Test
+    fun `activates when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).hasSingleBean(MemoryPersistenceServices::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.persistence=cassandra")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemoryPersistenceServices::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.persistence=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemoryPersistenceServices::class.java)
+            }
+    }
+}

--- a/shell-scripts/run-core.sh
+++ b/shell-scripts/run-core.sh
@@ -35,7 +35,7 @@ export PORTS_FLAGS="-Dserver.port=${CORE_MGMT_PORT} -Dmanagement.server.port=${C
 -Dspring.rsocket.server.port=${CORE_RSOCKET_PORT}"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket -Dapp.service.core.key \
 -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite -Dapp.service.composite.auth \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
 -Dapp.controller.pubsub -Dapp.controller.secrets -Dapp.controller.user -Dapp.controller.topic -Dapp.controller.message"

--- a/shell-scripts/test-parity.sh
+++ b/shell-scripts/test-parity.sh
@@ -124,7 +124,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
@@ -152,7 +152,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
@@ -182,7 +182,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \


### PR DESCRIPTION
Second of four. **Stacked on #16** — base is `index-selector-values`, so this diff shows only the persistence change and will retarget to `master` automatically once #16 merges. Stacked rather than branched from master because both changes edit the same lines in `run-core.sh`, `test-parity.sh` and the four deployment tests; independent branches would conflict for no reason.

## The problem

Same defect as #16, one module deeper. `MemoryPersistenceServices` and `CorePersistenceServices` both answered to:

```kotlin
@ConditionalOnProperty(prefix = "app.service.core", name = ["persistence"])
```

Two persistence backends on one classpath means two `PersistenceServiceBeans` beans and `NoUniqueBeanDefinitionException` at every persistence controller. Only classpath composition keeps them apart.

**The dependency leak here is the worst in the codebase.** `CorePersistenceServices` takes a key service, six Cassandra repositories and an `ObjectMapper` through its constructor. Under a bare-presence condition every one of them had to resolve whenever the flag was present — including on a memory deployment that wants no Cassandra at all. Conditional bean, eight unconditional dependencies.

## The change

| Value | Activates |
|---|---|
| `memory` (default, `matchIfMissing = true`) | `MemoryPersistenceServices` |
| `cassandra` | `CorePersistenceServices` |

Callers name their backend, for the same reason as #16 — an empty value matches no `havingValue`, and `matchIfMissing` does not apply to a property that is present, so a bare flag would leave a deployment with no persistence at all.

- `shell-scripts/run-core.sh`, `shell-scripts/test-parity.sh` (×3) → `=memory`
- `MemoryDeploymentTests`, `KafkaDeploymentTests`, `DeployTests` → `=memory`
- `CassandraDeployTest` → `=cassandra`
- `chat-deploy-redis/build-core.sh` — that image has carried no persistence backend since `chat-persistence-xstream` became messaging-only, so the flag was inert. Dropped rather than given a value naming an absent module.

## Tests

Written first, watched fail, then implemented — `MemoryPersistenceServicesConditionTests` failed 3 of 4 and `CorePersistenceServicesConditionTests` 2 of 4, the same signature as #16: each backend activating when the selector names the *other* one.

Four cases each: names this backend, names another, absent, empty string. Cassandra repositories are mocked because the condition rather than query behaviour is under test; the configuration stores its dependencies and builds services lazily, so no Cassandra connection is involved.

- `chat-persistence-memory` — 48/48 pass
- `chat-persistence-cassandra` — new condition test 4/4 pass; **error count unchanged at 15** against the pre-change run (33 tests/15 errors → 37 tests/15 errors), all of them the container-backed tests
- `chat-deploy-memory` — 3/3 pass, booting the application with `persistence=memory`
- `chat-deploy`, `chat-deploy-cassandra`, `chat-deploy-kafka` — test-compile clean

**Not verified here:** container-backed Cassandra tests. Testcontainers cannot reach the Docker socket from the Maven JVM in this environment though the CLI can — it worked earlier in the same session and stopped. The unchanged-error-count comparison above is the evidence that this branch did not cause them. Worth a green run on a machine with working Docker before merge.

## Still to do

| Selector | Implementors |
|---|---|
| `app.service.core.key` | `MemoryKeyServices`, `CoreKeyServices` |
| `app.service.core.secrets` | `MemorySecretsStoreServiceBeans`, `SecretStoreConfig` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
