### PR TITLE
refactor: make app.service.core.key a valued selector

### DIFF
--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
@@ -19,7 +19,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.config.location=classpath:/application.yml",
         "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
-        "app.service.core.key",
+        "app.service.core.key=cassandra",
         "app.service.core.pubsub=memory", "app.service.core.index=cassandra", "app.service.core.persistence=cassandra",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",

--- a/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
+++ b/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
@@ -30,7 +30,7 @@ import org.springframework.test.context.TestPropertySource
         "app.server.proto=rsocket",
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "spring.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",
-        "app.service.core.key",
+        "app.service.core.key=memory",
         "app.service.core.pubsub=kafka",
         "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
@@ -18,7 +18,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
         "spring.application.name=test-deployment", "app.server.proto=rsocket",
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
-        "app.service.core.key",
+        "app.service.core.key=memory",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",

--- a/chat-deploy-redis/build-core.sh
+++ b/chat-deploy-redis/build-core.sh
@@ -12,7 +12,7 @@ export APP_VERSION=0.0.1
 # TODO: difference between '-D' and '--'
 export JAVA_TOOL_OPTIONS=" -Dspring.profiles.active=${SPRING_PROFILE} \
 -Dserver.port=$((CORE_PORT+1)) -Dspring.rsocket.server.port=${CORE_PORT} \
--Dapp.service.core.key -Dapp.service.core.pubsub=redis-pubsub \
+-Dapp.service.core.pubsub=redis-pubsub \
 -Dapp.service.edge.topic \
 -Dapp.service.edge.user -Dapp.service.edge.messaging \
 -Dapp.primary=core -Dspring.cloud.consul.host=${CONSUL_HOST} \

--- a/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
+++ b/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
@@ -15,7 +15,7 @@ import org.springframework.test.context.TestPropertySource
 @TestPropertySource(
     properties = [
         "server.port=0", "spring.rsocket.server.port=0",
-        "app.service.core.key",
+        "app.service.core.key=memory",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/CoreKeyServices.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/CoreKeyServices.kt
@@ -11,7 +11,7 @@ import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
 
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["key"])
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "cassandra")
 class CoreKeyServices<T>(
     val reactiveTemplate: ReactiveCassandraTemplate,
     val keyGenerator: IKeyGenerator<T>

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/CoreKeyServicesConditionTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/CoreKeyServicesConditionTests.kt
@@ -1,0 +1,77 @@
+package com.demo.chat.test.persistence.cassandra
+
+import com.demo.chat.config.persistence.cassandra.CoreKeyServices
+import com.demo.chat.service.core.IKeyGenerator
+import com.demo.chat.test.TestLongKeyService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+
+/**
+ * `app.service.core.key` names one key-service backend. Cassandra activates
+ * only when the selector names it — never by default, and never alongside the
+ * in-memory backend.
+ *
+ * The template is mocked because the condition, not the query behaviour, is
+ * under test; the configuration stores it and builds the key service lazily,
+ * so no Cassandra connection is involved.
+ */
+class CoreKeyServicesConditionTests {
+
+    @Configuration(proxyBeanMethods = false)
+    class CassandraDependencyStubs {
+        @Bean
+        fun keyGenerator(): IKeyGenerator<Long> = TestLongKeyService()
+
+        @Bean
+        fun cassandraTemplate(): ReactiveCassandraTemplate = mock(ReactiveCassandraTemplate::class.java)
+    }
+
+    /**
+     * Registers CoreKeyServices as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(CassandraDependencyStubs::class.java)
+        .withUserConfiguration(CoreKeyServices::class.java)
+
+    @Test
+    fun `activates when the selector names cassandra`() {
+        runner()
+            .withPropertyValues("app.service.core.key=cassandra")
+            .run { context ->
+                assertThat(context).hasSingleBean(CoreKeyServices::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.key=memory")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(CoreKeyServices::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).doesNotHaveBean(CoreKeyServices::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.key=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(CoreKeyServices::class.java)
+            }
+    }
+}

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/KeyServiceTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/KeyServiceTests.kt
@@ -22,7 +22,7 @@ import java.util.*
     webEnvironment = SpringBootTest.WebEnvironment.NONE,
     classes = [RepositoryTestConfiguration::class]
 )
-@TestPropertySource(properties = ["app.service.core.key", "app.key.type=uuid"])
+@TestPropertySource(properties = ["app.service.core.key=cassandra", "app.key.type=uuid"])
 class KeyServiceTests : CassandraSchemaTest<UUID>(TestUUIDKeyGenerator()) {
     lateinit var svc: IKeyService<UUID>
 

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/LongKeyspaceAppTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/LongKeyspaceAppTests.kt
@@ -31,7 +31,7 @@ import reactor.test.StepVerifier
         CorePersistenceServices::class
     ]
 )
-@TestPropertySource(properties = ["app.service.core.key","app.key.type=long"])
+@TestPropertySource(properties = ["app.service.core.key=cassandra","app.key.type=long"])
 class LongKeyspaceAppTests : CassandraSchemaTest<Long>(TestLongKeyGenerator()) {
 
     @Autowired

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/UUIDKeyspaceAppTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/UUIDKeyspaceAppTests.kt
@@ -32,7 +32,7 @@ import java.util.*
         CorePersistenceServices::class
     ]
 )
-@TestPropertySource(properties = ["app.service.core.key","app.key.type=uuid"])
+@TestPropertySource(properties = ["app.service.core.key=cassandra","app.key.type=uuid"])
 class UUIDKeyspaceAppTests : CassandraSchemaTest<UUID>(TestUUIDKeyGenerator()) {
 
     @Autowired

--- a/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemoryKeyServices.kt
+++ b/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemoryKeyServices.kt
@@ -9,7 +9,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["key"])
+@ConditionalOnProperty(
+    prefix = "app.service.core",
+    name = ["key"],
+    havingValue = "memory",
+    matchIfMissing = true
+)
 class MemoryKeyServices<T>(
     val keyGenerator: IKeyGenerator<T>
 ) : KeyServiceBeans<T> {

--- a/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemoryKeyServicesConditionTests.kt
+++ b/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemoryKeyServicesConditionTests.kt
@@ -1,0 +1,68 @@
+package com.demo.chat.test.persistence.memory
+
+import com.demo.chat.config.persistence.memory.MemoryKeyServices
+import com.demo.chat.service.core.IKeyGenerator
+import com.demo.chat.test.TestLongKeyService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * `app.service.core.key` names one key-service backend. Memory is the
+ * in-process default, so it activates when the selector is absent — but never
+ * when the selector names a different backend.
+ */
+class MemoryKeyServicesConditionTests {
+
+    @Configuration(proxyBeanMethods = false)
+    class KeyGeneratorStub {
+        @Bean
+        fun keyGenerator(): IKeyGenerator<Long> = TestLongKeyService()
+    }
+
+    /**
+     * Registers MemoryKeyServices as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(KeyGeneratorStub::class.java)
+        .withUserConfiguration(MemoryKeyServices::class.java)
+
+    @Test
+    fun `activates when the selector names memory`() {
+        runner()
+            .withPropertyValues("app.service.core.key=memory")
+            .run { context ->
+                assertThat(context).hasSingleBean(MemoryKeyServices::class.java)
+            }
+    }
+
+    @Test
+    fun `activates when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).hasSingleBean(MemoryKeyServices::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.key=cassandra")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemoryKeyServices::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.key=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemoryKeyServices::class.java)
+            }
+    }
+}

--- a/shell-scripts/run-core.sh
+++ b/shell-scripts/run-core.sh
@@ -33,7 +33,7 @@ export DOCKER_ARGS=" --expose ${CORE_RSOCKET_PORT} -p ${CORE_RSOCKET_PORT}:${COR
 --expose ${CORE_MGMT_PORT} -p ${CORE_MGMT_PORT}:${CORE_MGMT_PORT}/tcp"
 export PORTS_FLAGS="-Dserver.port=${CORE_MGMT_PORT} -Dmanagement.server.port=${CORE_MGMT_PORT} \
 -Dspring.rsocket.server.port=${CORE_RSOCKET_PORT}"
-export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket -Dapp.service.core.key \
+export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket -Dapp.service.core.key=memory \
 -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \

--- a/shell-scripts/run-shell.sh
+++ b/shell-scripts/run-shell.sh
@@ -15,7 +15,7 @@ export CLIENT_FLAGS="-Dapp.client.protocol=rsocket \
 -Dapp.client.rsocket.core.persistence -Dapp.client.rsocket.core.index -Dapp.client.rsocket.core.pubsub \
 -Dapp.client.rsocket.core.secrets -Dapp.client.rsocket.composite.user -Dapp.client.rsocket.composite.message \
 -Dapp.client.rsocket.composite.topic"
-export SERVICE_FLAGS="-Dapp.service.core.key -Dapp.service.composite.auth"
+export SERVICE_FLAGS="-Dapp.service.core.key=memory -Dapp.service.composite.auth"
 OPT_FLAGS+=" -Dlogging.level.io.rsocket.FrameLogger=OFF -Dspring.autoconfigure.exclude=org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
 
 function local() {

--- a/shell-scripts/test-parity.sh
+++ b/shell-scripts/test-parity.sh
@@ -123,7 +123,7 @@ export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
 export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
--Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
+-Dapp.service.core.key=memory -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
@@ -151,7 +151,7 @@ export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
 export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
--Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
+-Dapp.service.core.key=memory -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
@@ -181,7 +181,7 @@ export MANAGEMENT_ENDPOINTS="shutdown,health,rootkeys"
 export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
--Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
+-Dapp.service.core.key=memory -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
@@ -218,7 +218,7 @@ export CLIENT_FLAGS="-Dapp.client.protocol=rsocket \
 -Dapp.client.rsocket.core.index -Dapp.client.rsocket.core.pubsub \
 -Dapp.client.rsocket.core.secrets -Dapp.client.rsocket.composite.user \
 -Dapp.client.rsocket.composite.message -Dapp.client.rsocket.composite.topic"
-export SERVICE_FLAGS="-Dapp.service.core.key -Dapp.service.composite.auth"
+export SERVICE_FLAGS="-Dapp.service.core.key=memory -Dapp.service.composite.auth"
 export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF -Dspring.autoconfigure.exclude=org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
 
 OLD_CMD="$DIR/build-app.sh -m chat-deploy -k long -p shell -e shell -s client \


### PR DESCRIPTION
Third of four. Base is `index-selector-values` (which now carries both #16 and the merged #17), so this diff shows only the key-selector change and retargets to `master` when #16 lands. `secrets` follows as a separate PR on the same base.

## The problem

`MemoryKeyServices` and `CoreKeyServices` both answered to:

```kotlin
@ConditionalOnProperty(prefix = "app.service.core", name = ["key"])
```

Two key backends on one classpath means two `KeyServiceBeans` beans and `NoUniqueBeanDefinitionException` wherever one is injected. Same defect as #16 and #17, and since almost everything downstream needs an `IKeyService`, this is the selector with the widest blast radius.

## The change

| Value | Activates |
|---|---|
| `memory` (default, `matchIfMissing = true`) | `MemoryKeyServices` |
| `cassandra` | `CoreKeyServices` |

`app.key.type`, which chooses the key *generator* (uuid/long), is untouched — it was already a valued selector and is orthogonal to which backend stores the keys.

## This selector reaches further than the previous two

Beyond the deployment tests and core launchers, two other groups set it:

- **Three Cassandra integration tests** — `UUIDKeyspaceAppTests`, `LongKeyspaceAppTests`, `KeyServiceTests` — set the flag bare while exercising the Cassandra key service. They now name `cassandra`. Left bare they would have silently lost the bean they exist to test.
- **The shell launchers** — `run-shell.sh` and the shell block in `test-parity.sh` — set `app.service.core.key` alongside the rsocket *client* flags. These now name `memory`, preserving today's behaviour. The shell is a pure client, so the flag may well be inert there, but naming the in-process default is the change that cannot alter behaviour, whereas blanking it could.

`chat-deploy-redis/build-core.sh` loses the flag entirely — that image has no key backend on its classpath. Absent beats empty there: if a backend is added later, absent lets the `memory` default apply, while an empty value matches neither.

## Tests

Written first, watched fail, then implemented. `MemoryKeyServicesConditionTests` failed 3 of 4 and `CoreKeyServicesConditionTests` 2 of 4 — the same signature as the previous two PRs, each backend activating when the selector names the other.

Four cases each: names this backend, names another, absent, empty string. The Cassandra template is mocked because the condition rather than query behaviour is under test.

- `chat-persistence-memory` — 52/52 pass
- `chat-persistence-cassandra` — new condition test 4/4; **error count unchanged at 15** against the pre-change run (37 tests/15 errors → 41 tests/15 errors)
- `chat-deploy-memory` — 3/3 pass, booting the application with `key=memory`
- `chat-deploy`, `chat-deploy-cassandra`, `chat-deploy-kafka` — test-compile clean

**Not verified here:** container-backed Cassandra tests, including the three integration tests this PR edits. Testcontainers cannot reach the Docker socket from the Maven JVM in this environment though the CLI can. The unchanged-error-count comparison is the evidence this branch did not cause those failures, but the three edited integration tests specifically deserve a green run on a machine with working Docker before merge — they are the ones whose property values changed.

## Still to do

`app.service.core.secrets` — `MemorySecretsStoreServiceBeans` vs `SecretStoreConfig`. Separate PR, same base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
