### PR TITLE
refactor: make app.service.core.secrets a valued selector

### DIFF
--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.context.TestPropertySource
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "app.service.core.key",
         "app.service.core.pubsub=memory", "app.service.core.index=cassandra", "app.service.core.persistence=cassandra",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=cassandra", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",
         "app.service.security.userdetails"

--- a/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
+++ b/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
@@ -33,7 +33,7 @@ import org.springframework.test.context.TestPropertySource
         "app.service.core.key",
         "app.service.core.pubsub=kafka",
         "app.service.core.index=lucene", "app.service.core.persistence=memory",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence",
         "app.controller.index", "app.controller.user", "app.controller.message",
         "app.controller.topic", "app.controller.pubsub",

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
@@ -20,7 +20,7 @@ import org.springframework.test.context.TestPropertySource
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "app.service.core.key",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",
         "app.service.security.userdetails"

--- a/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
+++ b/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
@@ -17,7 +17,7 @@ import org.springframework.test.context.TestPropertySource
         "server.port=0", "spring.rsocket.server.port=0",
         "app.service.core.key",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message","app.controller.topic", "app.controller.pubsub",
         "spring.config.location=classpath:/application.yml",

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/SecretStoreConfig.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/SecretStoreConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"])
+@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"], havingValue = "cassandra")
 class SecretStoreConfig<T>(
     val keyService: IKeyService<T>,
     val repo: KeyCredentialRepository<T>

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/SecretStoreConfigConditionTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/SecretStoreConfigConditionTests.kt
@@ -1,0 +1,79 @@
+package com.demo.chat.test.persistence.cassandra
+
+import com.demo.chat.config.persistence.cassandra.SecretStoreConfig
+import com.demo.chat.persistence.cassandra.repository.KeyCredentialRepository
+import com.demo.chat.service.core.IKeyService
+import com.demo.chat.test.TestLongKeyService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * `app.service.core.secrets` names one secrets-store backend. Cassandra
+ * activates only when the selector names it — never by default, and never
+ * alongside the in-memory backend.
+ *
+ * The credential repository is mocked because the condition, not the query
+ * behaviour, is under test; the configuration stores its dependencies and
+ * builds the store lazily, so no Cassandra connection is involved.
+ */
+class SecretStoreConfigConditionTests {
+
+    @Suppress("UNCHECKED_CAST")
+    @Configuration(proxyBeanMethods = false)
+    class CassandraDependencyStubs {
+        @Bean
+        fun keyService(): IKeyService<Long> = TestLongKeyService()
+
+        @Bean
+        fun credentialRepo(): KeyCredentialRepository<Long> =
+            mock(KeyCredentialRepository::class.java) as KeyCredentialRepository<Long>
+    }
+
+    /**
+     * Registers SecretStoreConfig as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(CassandraDependencyStubs::class.java)
+        .withUserConfiguration(SecretStoreConfig::class.java)
+
+    @Test
+    fun `activates when the selector names cassandra`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=cassandra")
+            .run { context ->
+                assertThat(context).hasSingleBean(SecretStoreConfig::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=memory")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(SecretStoreConfig::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).doesNotHaveBean(SecretStoreConfig::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(SecretStoreConfig::class.java)
+            }
+    }
+}

--- a/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemorySecretsStoreServiceBeans.kt
+++ b/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemorySecretsStoreServiceBeans.kt
@@ -9,7 +9,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"])
+@ConditionalOnProperty(
+    prefix = "app.service.core",
+    name = ["secrets"],
+    havingValue = "memory",
+    matchIfMissing = true
+)
 class MemorySecretsStoreServiceBeans<T> : SecretsStoreBeans<T> {
 
     @Bean

--- a/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemorySecretsStoreConditionTests.kt
+++ b/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemorySecretsStoreConditionTests.kt
@@ -1,0 +1,57 @@
+package com.demo.chat.test.persistence.memory
+
+import com.demo.chat.config.persistence.memory.MemorySecretsStoreServiceBeans
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+/**
+ * `app.service.core.secrets` names one secrets-store backend. Memory is the
+ * in-process default, so it activates when the selector is absent — but never
+ * when the selector names a different backend.
+ */
+class MemorySecretsStoreConditionTests {
+
+    /**
+     * Registers MemorySecretsStoreServiceBeans as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(MemorySecretsStoreServiceBeans::class.java)
+
+    @Test
+    fun `activates when the selector names memory`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=memory")
+            .run { context ->
+                assertThat(context).hasSingleBean(MemorySecretsStoreServiceBeans::class.java)
+            }
+    }
+
+    @Test
+    fun `activates when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).hasSingleBean(MemorySecretsStoreServiceBeans::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=cassandra")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemorySecretsStoreServiceBeans::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemorySecretsStoreServiceBeans::class.java)
+            }
+    }
+}

--- a/shell-scripts/run-core.sh
+++ b/shell-scripts/run-core.sh
@@ -35,7 +35,7 @@ export PORTS_FLAGS="-Dserver.port=${CORE_MGMT_PORT} -Dmanagement.server.port=${C
 -Dspring.rsocket.server.port=${CORE_RSOCKET_PORT}"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket -Dapp.service.core.key \
 -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite -Dapp.service.composite.auth \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
 -Dapp.controller.pubsub -Dapp.controller.secrets -Dapp.controller.user -Dapp.controller.topic -Dapp.controller.message"

--- a/shell-scripts/test-parity.sh
+++ b/shell-scripts/test-parity.sh
@@ -124,7 +124,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
@@ -152,7 +152,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
@@ -182,7 +182,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \


### PR DESCRIPTION
Last of four. Base is `index-selector-values`, same as #18, and the two are independent — they touch different lines, so either can merge first.

## The problem

`MemorySecretsStoreServiceBeans` and `SecretStoreConfig` both answered to:

```kotlin
@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"])
```

Two secrets backends on one classpath means two `SecretsStoreBeans` beans and `NoUniqueBeanDefinitionException` wherever one is injected.

## The change

| Value | Activates |
|---|---|
| `memory` (default, `matchIfMissing = true`) | `MemorySecretsStoreServiceBeans` |
| `cassandra` | `SecretStoreConfig` |

The smallest of the four. The memory implementation takes no constructor dependencies at all, so there is no dependency leak to fix here — only the discrimination problem. The selector appears in just the four deployment tests and the core launchers; `chat-deploy-redis` never set it, so `build-core.sh` is untouched.

- `shell-scripts/run-core.sh`, `shell-scripts/test-parity.sh` (×3) → `=memory`
- `MemoryDeploymentTests`, `KafkaDeploymentTests`, `DeployTests` → `=memory`
- `CassandraDeployTest` → `=cassandra`

## Tests

Written first, watched fail, then implemented — 3 of 4 and 2 of 4 failing, the same signature as #16, #17 and #18: each backend activating when the selector names the other.

- `chat-persistence-memory` — 52/52 pass
- `chat-persistence-cassandra` — new condition test 4/4; **error count unchanged at 15** against the pre-change run (37 tests/15 errors → 41 tests/15 errors)
- `chat-deploy-memory` — 3/3 pass, booting the application with `secrets=memory`
- `chat-deploy`, `chat-deploy-cassandra`, `chat-deploy-kafka` — test-compile clean

All figures above are from `mvn clean test`. An earlier run on this branch reported three failures that turned out to be stale compiled classes in `target/test-classes` left by a sibling branch, not a real regression — worth knowing if you switch between these four branches locally without cleaning.

**Not verified here:** container-backed Cassandra tests. Testcontainers cannot reach the Docker socket from the Maven JVM in this environment though the CLI can. The unchanged-error-count comparison is the evidence this branch did not cause those failures.

## Completing the set

With #16, #17, #18 and this one, every `app.service.core.*` selector names its backend rather than merely being present, and no two implementations can activate at once:

| Selector | Default | Alternatives |
|---|---|---|
| `pubsub` | `memory` | `kafka`, `redis-pubsub`, `redis-xstream` |
| `index` | `lucene` | `cassandra` |
| `persistence` | `memory` | `cassandra` |
| `key` | `memory` | `cassandra` |
| `secrets` | `memory` | `cassandra` |

The practical payoff is that backend combinations become expressible in configuration rather than being decided by which jars happen to be on the classpath — cassandra persistence with a lucene index, for one, which could not be built before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
