### PR TITLE
refactor: land app.service.core.secrets valued selector on master

### DIFF
--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
@@ -21,7 +21,7 @@ import org.springframework.test.context.TestPropertySource
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "app.service.core.key",
         "app.service.core.pubsub=memory", "app.service.core.index=cassandra", "app.service.core.persistence=cassandra",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=cassandra", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",
         "app.service.security.userdetails"

--- a/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
+++ b/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
@@ -33,7 +33,7 @@ import org.springframework.test.context.TestPropertySource
         "app.service.core.key",
         "app.service.core.pubsub=kafka",
         "app.service.core.index=lucene", "app.service.core.persistence=memory",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence",
         "app.controller.index", "app.controller.user", "app.controller.message",
         "app.controller.topic", "app.controller.pubsub",

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
@@ -20,7 +20,7 @@ import org.springframework.test.context.TestPropertySource
         "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
         "app.service.core.key",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",
         "app.service.security.userdetails"

--- a/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
+++ b/chat-deploy/src/test/kotlin/com/demo/chat/deploy/test/DeployTests.kt
@@ -17,7 +17,7 @@ import org.springframework.test.context.TestPropertySource
         "server.port=0", "spring.rsocket.server.port=0",
         "app.service.core.key",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
-        "app.service.core.secrets", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
         "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
         "app.controller.user", "app.controller.message","app.controller.topic", "app.controller.pubsub",
         "spring.config.location=classpath:/application.yml",

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/SecretStoreConfig.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/SecretStoreConfig.kt
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"])
+@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"], havingValue = "cassandra")
 class SecretStoreConfig<T>(
     val keyService: IKeyService<T>,
     val repo: KeyCredentialRepository<T>

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/SecretStoreConfigConditionTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/cassandra/SecretStoreConfigConditionTests.kt
@@ -1,0 +1,79 @@
+package com.demo.chat.test.persistence.cassandra
+
+import com.demo.chat.config.persistence.cassandra.SecretStoreConfig
+import com.demo.chat.persistence.cassandra.repository.KeyCredentialRepository
+import com.demo.chat.service.core.IKeyService
+import com.demo.chat.test.TestLongKeyService
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+/**
+ * `app.service.core.secrets` names one secrets-store backend. Cassandra
+ * activates only when the selector names it — never by default, and never
+ * alongside the in-memory backend.
+ *
+ * The credential repository is mocked because the condition, not the query
+ * behaviour, is under test; the configuration stores its dependencies and
+ * builds the store lazily, so no Cassandra connection is involved.
+ */
+class SecretStoreConfigConditionTests {
+
+    @Suppress("UNCHECKED_CAST")
+    @Configuration(proxyBeanMethods = false)
+    class CassandraDependencyStubs {
+        @Bean
+        fun keyService(): IKeyService<Long> = TestLongKeyService()
+
+        @Bean
+        fun credentialRepo(): KeyCredentialRepository<Long> =
+            mock(KeyCredentialRepository::class.java) as KeyCredentialRepository<Long>
+    }
+
+    /**
+     * Registers SecretStoreConfig as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(CassandraDependencyStubs::class.java)
+        .withUserConfiguration(SecretStoreConfig::class.java)
+
+    @Test
+    fun `activates when the selector names cassandra`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=cassandra")
+            .run { context ->
+                assertThat(context).hasSingleBean(SecretStoreConfig::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=memory")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(SecretStoreConfig::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).doesNotHaveBean(SecretStoreConfig::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(SecretStoreConfig::class.java)
+            }
+    }
+}

--- a/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemorySecretsStoreServiceBeans.kt
+++ b/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/MemorySecretsStoreServiceBeans.kt
@@ -9,7 +9,12 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@ConditionalOnProperty(prefix = "app.service.core", name = ["secrets"])
+@ConditionalOnProperty(
+    prefix = "app.service.core",
+    name = ["secrets"],
+    havingValue = "memory",
+    matchIfMissing = true
+)
 class MemorySecretsStoreServiceBeans<T> : SecretsStoreBeans<T> {
 
     @Bean

--- a/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemorySecretsStoreConditionTests.kt
+++ b/chat-persistence-memory/src/test/kotlin/com/demo/chat/test/persistence/memory/MemorySecretsStoreConditionTests.kt
@@ -1,0 +1,57 @@
+package com.demo.chat.test.persistence.memory
+
+import com.demo.chat.config.persistence.memory.MemorySecretsStoreServiceBeans
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+/**
+ * `app.service.core.secrets` names one secrets-store backend. Memory is the
+ * in-process default, so it activates when the selector is absent — but never
+ * when the selector names a different backend.
+ */
+class MemorySecretsStoreConditionTests {
+
+    /**
+     * Registers MemorySecretsStoreServiceBeans as an annotated class so its
+     * @ConditionalOnProperty is evaluated. Do not use withBean() here — a
+     * supplied bean bypasses conditions entirely, which is the thing under
+     * test.
+     */
+    private fun runner() = ApplicationContextRunner()
+        .withUserConfiguration(MemorySecretsStoreServiceBeans::class.java)
+
+    @Test
+    fun `activates when the selector names memory`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=memory")
+            .run { context ->
+                assertThat(context).hasSingleBean(MemorySecretsStoreServiceBeans::class.java)
+            }
+    }
+
+    @Test
+    fun `activates when the selector is absent`() {
+        runner().run { context ->
+            assertThat(context).hasSingleBean(MemorySecretsStoreServiceBeans::class.java)
+        }
+    }
+
+    @Test
+    fun `does not activate when the selector names another implementation`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=cassandra")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemorySecretsStoreServiceBeans::class.java)
+            }
+    }
+
+    @Test
+    fun `does not activate when the selector is the empty string`() {
+        runner()
+            .withPropertyValues("app.service.core.secrets=")
+            .run { context ->
+                assertThat(context).doesNotHaveBean(MemorySecretsStoreServiceBeans::class.java)
+            }
+    }
+}

--- a/shell-scripts/run-core.sh
+++ b/shell-scripts/run-core.sh
@@ -35,7 +35,7 @@ export PORTS_FLAGS="-Dserver.port=${CORE_MGMT_PORT} -Dmanagement.server.port=${C
 -Dspring.rsocket.server.port=${CORE_RSOCKET_PORT}"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket -Dapp.service.core.key \
 -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite -Dapp.service.composite.auth \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
 -Dapp.controller.pubsub -Dapp.controller.secrets -Dapp.controller.user -Dapp.controller.topic -Dapp.controller.message"

--- a/shell-scripts/test-parity.sh
+++ b/shell-scripts/test-parity.sh
@@ -124,7 +124,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
@@ -152,7 +152,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \
@@ -182,7 +182,7 @@ export OPT_FLAGS=" -Dlogging.level.io.rsocket.FrameLogger=OFF"
 export PORTS_FLAGS="-Dserver.port=6791 -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790"
 export SERVICE_FLAGS="-Dspring.main.web-application-type=reactive -Dapp.server.proto=rsocket \
 -Dapp.service.core.key -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene \
--Dapp.service.core.persistence=memory -Dapp.service.core.secrets -Dapp.service.composite \
+-Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite \
 -Dapp.service.composite.auth \
 -Dapp.core.controllers='persistence,index,key,pubsub,secrets,user,topic,message' \
 -Dapp.controller.persistence -Dapp.controller.index -Dapp.controller.key \


### PR DESCRIPTION
Carries the already-reviewed #19 to master. No new code — the same commit `b3819bc8` plus its merge.

## Why this is needed

#19 was opened against `index-selector-values` while that branch was the integration point for the stacked selector work. By the time #19 merged, #16 had already carried `index-selector-values` to master, so the secrets commit landed on a branch nothing re-merged. It has been sitting there since.

Master is not broken by this — the stranded commit carries both the condition change and its launcher/test updates together, so master is internally consistent with bare-presence conditions and bare flags. It simply still has the defect the other four selectors no longer have.

My mistake in the stacking: #19 should have been retargeted to master once #16 landed.

## What it contains

| Value | Activates |
|---|---|
| `memory` (default, `matchIfMissing = true`) | `MemorySecretsStoreServiceBeans` |
| `cassandra` | `SecretStoreConfig` |

Plus the callers that must name a backend, since an empty value matches no `havingValue`: `run-core.sh`, `test-parity.sh` (×3), `MemoryDeploymentTests`, `KafkaDeploymentTests`, `DeployTests` → `=memory`; `CassandraDeployTest` → `=cassandra`.

With this landed, every `app.service.core.*` selector names its backend and no two implementations can activate at once:

| Selector | Default | Alternatives |
|---|---|---|
| `pubsub` | `memory` | `kafka`, `redis-pubsub`, `redis-xstream` |
| `index` | `lucene` | `cassandra` |
| `persistence` | `memory` | `cassandra` |
| `key` | `memory` | `cassandra` |
| `secrets` | `memory` | `cassandra` |

## Verification

Unchanged from #19 — `chat-persistence-memory` 52/52, `chat-persistence-cassandra` condition test 4/4, `chat-deploy-memory` 3/3 booting with `secrets=memory`, deploy modules test-compile clean. Re-confirmed that the branch is exactly two commits ahead of master and conflict-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
