### PR TITLE
fix(test): use KotlinModule.Builder in the last three call sites

### DIFF
--- a/chat-authorization-server/src/test/kotlin/com/demo/chat/ClientInitializerTest.kt
+++ b/chat-authorization-server/src/test/kotlin/com/demo/chat/ClientInitializerTest.kt
@@ -81,6 +81,6 @@ class FooBar {
     @Bean
     fun mapper(): ObjectMapper = ObjectMapper().apply {
         registerModules(DefaultChatJacksonModules().allModules())
-        registerModule(KotlinModule())
+        registerModule(KotlinModule.Builder().build())
     }
 }

--- a/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/SerializationTests.kt
+++ b/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/SerializationTests.kt
@@ -68,7 +68,7 @@ class SerializationTests {
         fun mapper(): ObjectMapper {
             return ObjectMapper().apply {
                 setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                registerModule(KotlinModule())
+                registerModule(KotlinModule.Builder().build())
                 val module = JacksonModules(JsonNodeToAnyConverter, JsonNodeToAnyConverter)
                 registerModules(
                     module.keyModule(),

--- a/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/serialization/SerializationTests.kt
+++ b/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/serialization/SerializationTests.kt
@@ -69,7 +69,7 @@ class SerializationTests {
         fun mapper(): ObjectMapper {
             return ObjectMapper().apply {
                 setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                registerModule(KotlinModule())
+                registerModule(KotlinModule.Builder().build())
                 val module = JacksonModules(JsonNodeToAnyConverter, JsonNodeToAnyConverter)
                 registerModules(
                     module.keyModule(),


### PR DESCRIPTION
Three lines. `mvn clean install` cannot complete on master without them.

## The problem

The named-constructor form of `KotlinModule` is an **error**, not a warning, under the `jackson-module-kotlin` version managed by Spring Boot 3.3.13. It was fixed in `chat-persistence-xstream` under #13; three call sites were missed:

- `chat-client-rsocket/src/test/.../SerializationTests.kt:71`
- `chat-client-rsocket/src/test/.../serialization/SerializationTests.kt:72`
- `chat-authorization-server/src/test/.../ClientInitializerTest.kt:84`

`chat-client-rsocket` failing test-compile stops the reactor, and takes **`chat-deploy-redis`, `chat-shell` and `chat-authorization-server`** down as SKIPPED with it. Those three modules were not being built at all — which is why the recent redis work never appeared in a full reactor run.

## After

No module is skipped. `chat-client-rsocket` runs **57 tests that were previously unreachable, all passing**.

A commented-out occurrence in `ClientInitializerTest.kt:48` is deliberately left as-is — dead code, no reason to touch it.

## Two failures remain, neither caused by this change

Both were hidden behind the compile error rather than introduced by fixing it:

1. **`chat-authorization-server` `ClientInitializerTest`** errors on a missing classpath resource, `server_keycert.jwk`, which is not in the repository. 3 tests, 1 error. This module has not compiled its tests for some time, so the missing fixture has been invisible. Needs a decision about whether that key belongs in the repo or should be generated in test setup — not something to guess at here.

2. **`chat-deploy-memory-integration-tests`** runs `spring-boot:build-image` as part of the build and fails against Docker 29.x: *"client version 1.24 is too old. Minimum supported API version is 1.40"*. Unrelated to Kotlin; it is the Maven plugin's Docker client. Arguably that goal should sit behind a profile rather than run on every `install`.

## Verification

- `mvn clean install -DskipTests -fae` — every module builds; only `chat-deploy-memory-integration-tests` fails, on the Docker issue above
- `chat-client-rsocket` — 57/57 pass
- `chat-authorization-server` — 3 tests, 1 error, the missing-fixture failure described above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
