### PR TITLE
build: align testcontainers on 1.21.4 so it can talk to Docker 29.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,10 @@
         <jackson.version>2.14.1</jackson.version>
         <io-reactor.version>3.6.4</io-reactor.version>
         <datastax-java-driver.version>4.17.0</datastax-java-driver.version>
+        <!-- Spring Boot 3.3.13 manages testcontainers at 1.19.8, whose docker-java
+             client cannot negotiate with Docker Engine 29.x. Modules that declare
+             testcontainers artifacts at 1.21.4 were still getting the 1.19.8 core. -->
+        <testcontainers.version>1.21.4</testcontainers.version>
         <lognet.version>2.1.4</lognet.version>
     </properties>
 


### PR DESCRIPTION
One property. It takes the Cassandra test suites from mostly-erroring to fully green.

## The problem

Modules declare `org.testcontainers:cassandra` and `org.testcontainers:junit-jupiter` at `1.21.4`, but Spring Boot 3.3.13 manages the **core** `org.testcontainers:testcontainers` artifact at `1.19.8` — so that is what they actually resolved:

```
org.testcontainers:cassandra:1.21.4          <- declared
org.testcontainers:junit-jupiter:1.21.4      <- declared
org.testcontainers:testcontainers:1.19.8     <- from Spring Boot's BOM
org.testcontainers:database-commons:1.19.8   <- from Spring Boot's BOM
com.github.docker-java:docker-java-api:3.3.6 <- too old
```

`docker-java` 3.3.6 cannot negotiate an API version with Docker Engine 29.x, and reports it as:

> Could not find a valid Docker environment. Please see logs and check configuration

which is thoroughly misleading — the daemon is running and the CLI works fine. That message is why this looked for a while like a broken local Docker setup rather than a dependency problem.

`chat-persistence-xstream` was unaffected because its pom pins the core artifact explicitly, resolving `docker-java-api:3.4.2`. That is the whole reason its Redis container tests passed while every Cassandra container test in the repository failed.

## The fix

Overriding `testcontainers.version` is the idiomatic approach under `spring-boot-starter-parent` — the BOM declares those artifacts with `${testcontainers.version}`, so redefining the property aligns all four.

## Results

| Module | Before | After |
|---|---|---|
| `chat-persistence-cassandra` | 41 tests, 15 errors | **71 tests, all pass** |
| `chat-index-cassandra` | 8 tests, 4 errors | **26 tests, all pass** |

The test counts rise because a failed container meant the application context never loaded, so most tests in those classes never ran at all.

This also **retroactively verifies the Cassandra-side selector work** from #16, #17 and #18, which I could only reason about while the containers refused to start — including the three integration tests in #18 whose property values changed (`UUIDKeyspaceAppTests`, `LongKeyspaceAppTests`, `KeyServiceTests`). They pass.

## Note

Fetching `1.21.4` requires a network-enabled build the first time; `database-commons:1.21.4` was not in the local repository.

`spring-boot:build-image` in `chat-deploy-memory-integration-tests` still fails against Docker 29.x — *"client version 1.24 is too old"*. That is the Maven plugin's own Docker client, a separate component from testcontainers, and is untouched here. Worth its own change; that goal arguably should not run on every `install` at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
