### PR TITLE
fix: chat-build must name a backend for every core selector

### DIFF
--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -117,6 +117,12 @@ FEATURES: dict[str, Feature] = {
         description="Cassandra persistence + index",
         maven_profiles=["cassandra-backend"],
         spring_profiles=["cassandra-contact-point"],
+        spring_properties={
+            "app.service.core.key": "cassandra",
+            "app.service.core.index": "cassandra",
+            "app.service.core.persistence": "cassandra",
+            "app.service.core.secrets": "cassandra",
+        },
         group="backend",
     ),
     "client": Feature(
@@ -264,12 +270,16 @@ class Service:
         return self.image_name
 
 
+# Every app.service.core.* selector names a backend. A bare flag matches no
+# havingValue and does not trigger matchIfMissing either, so it activates
+# nothing at all -- see docs/BUILD-HEALTH.md and the selector work of Aug 2026.
+# Backend features override these via spring_properties.
 CORE_SERVICE_FLAGS = [
-    "-Dapp.service.core.key",
+    "-Dapp.service.core.key=memory",
     "-Dapp.service.core.pubsub=memory",
-    "-Dapp.service.core.index",
-    "-Dapp.service.core.persistence",
-    "-Dapp.service.core.secrets",
+    "-Dapp.service.core.index=lucene",
+    "-Dapp.service.core.persistence=memory",
+    "-Dapp.service.core.secrets=memory",
     "-Dapp.service.composite",
     "-Dapp.service.composite.auth",
     "-Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message",
@@ -420,7 +430,7 @@ SERVICES: dict[str, Service] = {
             "-Dapp.client.rsocket.composite.topic",
         ],
         service_flags=[
-            "-Dapp.service.core.key",
+            "-Dapp.service.core.key=memory",
             "-Dapp.service.composite.auth",
         ],
         opt_flags=[
@@ -564,8 +574,8 @@ class BuildContext:
         ]
         for feat in self._features():
             for key, value in feat.spring_properties.items():
-                if key == "app.service.core.pubsub":
-                    continue  # emitted in service_flags, which owns the default
+                if key.startswith("app.service.core."):
+                    continue  # emitted in service_flags, which owns the defaults
                 flags.append(f"-D{key}={value}")
         return flags
 
@@ -666,17 +676,18 @@ class BuildContext:
         flags = list(self.service.service_flags)
         for feat in self._features():
             flags += feat.service_flags
-        # A feature that names a pubsub implementation replaces the default.
-        pubsub = next(
-            (f.spring_properties["app.service.core.pubsub"]
-             for f in self._features()
-             if "app.service.core.pubsub" in f.spring_properties),
-            None,
-        )
-        if pubsub:
+        # A feature that names a backend for any app.service.core.* selector
+        # replaces the default. Later features win, matching profile order.
+        selectors: dict[str, str] = {}
+        for feat in self._features():
+            for key, value in feat.spring_properties.items():
+                if key.startswith("app.service.core."):
+                    selectors[key] = value
+        for key, value in selectors.items():
+            prefix = f"-D{key}"
             flags = [
-                f"-Dapp.service.core.pubsub={pubsub}"
-                if f.startswith("-Dapp.service.core.pubsub") else f
+                f"{prefix}={value}"
+                if f == prefix or f.startswith(prefix + "=") else f
                 for f in flags
             ]
         if flags and "websocket" in self.selected:


### PR DESCRIPTION
A regression I introduced across #16, #17, #18 and #21, live on master right now.

## What broke

Those PRs turned `app.service.core.key`, `index`, `persistence` and `secrets` from bare-presence flags into valued selectors. I updated every shell launcher and every deployment test. I did not update `chat-build` — the Python CLI that *replaces* those launchers and is the documented way to run anything.

It kept emitting the bare form:

```
-Dapp.service.core.key
-Dapp.service.core.index
-Dapp.service.core.persistence
-Dapp.service.core.secrets
```

A bare flag is present-but-empty. It matches no `havingValue`, and `matchIfMissing` does not apply to a property that *is* present — so it activates nothing at all. Anything launched through `chat-build` on master today comes up with no key, index, persistence or secrets beans.

The irony is precise: the legacy scripts `chat-build` exists to replace were correct, and the replacement was broken.

## The fix

Defaults in `CORE_SERVICE_FLAGS` now name `memory` and `lucene`. Backends override per selector through `spring_properties`, so `--cassandra` names itself for the four selectors it implements.

Two mechanisms were already there for `pubsub` alone and are now generalised rather than special-cased a second time:

- the substitution in `service_flags()` applies to every `app.service.core.*` key
- the skip in spring-property emission widens the same way, so a backend's selectors are not emitted twice (they were, on the first attempt at this fix — visible immediately in `--dry-run`)

Verified per backend:

```
--memory     key=memory     pubsub=memory  index=lucene     persistence=memory     secrets=memory
--cassandra  key=cassandra  pubsub=memory  index=cassandra  persistence=cassandra  secrets=cassandra
--kafka      key=memory     pubsub=kafka   index=lucene     persistence=memory     secrets=memory
shell        key=memory
```

`--redis` is left alone; that profile is still a placeholder that declares no dependencies.

## How it was caught

`test-parity.sh` diffs `chat-build`'s flags against `build-app.sh`'s. It **failed all four cases** before this change and passes all four after:

```
ok    core --memory --notls --init users,rootkeys
ok    core --memory --consul --notls
ok    core --memory --tls /etc/keys
ok    shell --client --notls

parity: all cases passed
```

That harness is the only reason this surfaced. It came up while answering "can the legacy shell scripts be deleted now?" — and the answer is no, not yet, precisely because deleting `build-app.sh` deletes the thing that just caught a live bug in its replacement. Coverage is also only 4 cases: no cassandra, kafka, e2ee, uuid, or `rest`/`gateway`/`authserv` case exists, and `chat-build` has no `astra` mode at all while `run-core.sh` does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
