### PR TITLE
docs: record build-time deficiencies, with a verifier that detects drift

### DIFF
--- a/docs/BUILD-HEALTH.md
+++ b/docs/BUILD-HEALTH.md
@@ -1,0 +1,152 @@
+# Build Health
+
+Known build-time deficiencies, what causes them, and what they take down with them.
+
+**Verified against master `0842082a` on 2026-08-22** by a full `mvn clean test -fae` plus targeted per-module runs.
+
+Do not trust this file on its own — run the verifier:
+
+```bash
+./shell-scripts/build-health.sh            # test phase, offline
+./shell-scripts/build-health.sh --install  # includes package/install, covers B1
+```
+
+It runs the build, diffs the failing modules against the list below, and exits non-zero when the two disagree — reporting anything **NEW** (failing but undocumented), **RESOLVED** (documented but passing), or **SKIPPED** (never built, so unknown). When it complains, update this file; that is the maintenance loop.
+
+## Current state
+
+`mvn clean test -fae` — three modules fail, nothing is skipped.
+`mvn clean install` — additionally fails at `chat-deploy-memory-integration-test`, which stops the build before packaging.
+
+| ID | Deficiency | Blocks | Status |
+|----|-----------|--------|--------|
+| B1 | `spring-boot:build-image` cannot talk to Docker 29.x, and the image it would build does not boot | `mvn install` for the whole reactor | Open — fix proven, plan written |
+| B2 | `chat-shell` integration tests need an image B1 never builds | 4 test classes | Open — tests now opt-in (#32) |
+| B3 | `chat-webflux` `LongTopicRestTests` returns 500 where 200 is expected | 2 tests | Open, uninvestigated |
+| B4 | `chat-authorization-server` missing `server_keycert.jwk` fixture | 1 test | Open, needs a decision |
+| B5 | CI compiles but never runs a test | all of B2–B4 invisible to CI | Open, may be deliberate |
+| B6 | Stale `target/` across branch switches produces phantom results | correctness of any non-clean run | Workaround only |
+
+---
+
+### B1 — `spring-boot:build-image` cannot talk to Docker 29.x
+
+**Symptom**
+
+```
+Docker API call to '.../v1.24/images/create?fromImage=docker.io%2Fpaketobuildpacks%2Fbuilder-jammy-base%3Alatest'
+failed with status code 400 "Bad Request" and message
+"client version 1.24 is too old. Minimum supported API version is 1.40"
+```
+
+**Cause.** `chat-deploy-memory-integration-test` binds `spring-boot:build-image` to the default lifecycle, so it runs on every `install`. The plugin's own Docker client negotiates API 1.24; Docker Engine 29.x requires 1.40 or newer. This is a different Docker client from the one testcontainers uses — the testcontainers half of this problem was fixed separately (see R2), and that fix does not help here.
+
+**Blast radius.** Stops `mvn install` for the whole reactor, and starves B2 of its image.
+
+**Reproduce.** `mvn -pl chat-deploy-memory-integration-test install`
+
+**Fix proven, 2026-08-22.** `v1.24` is hardcoded in `spring-boot-buildpack-platform` 3.3.13's `DockerApi`; 3.5.x negotiates instead. Pinning `spring-boot-maven-plugin` to 3.5.12 for that module builds the image in 33s. `DOCKER_HOST` is *not* the fix — the module already passes it and the client still negotiates v1.24.
+
+**A second defect sits underneath B1.** Once the image builds it still fails to start:
+
+```
+APPLICATION FAILED TO START
+No qualifying bean of type 'com.demo.chat.config.PersistenceServiceBeans<?, ?>' available
+```
+
+That module's pom bakes **bare** `app.service.core.*` selectors into `BPE_APPEND_JAVA_TOOL_OPTIONS`. Since the selector conversion a bare flag matches no `havingValue` and activates nothing. It went unnoticed because the selector sweep covered `*.sh`, `*.kt` and `*.yml` but never `pom.xml`, and B1 hid it — an image that cannot be built cannot be seen failing.
+
+Full plan: `.hermes/plans/2026-08-22_133000-b1-build-image-docker-api.md` (`CHAT-gtcnjyit`).
+
+---
+
+### B2 — `chat-shell` integration tests need an image B1 never builds
+
+**Symptom**
+
+```
+ContainerFetchException: Can't get Docker image:
+  RemoteDockerImage(imageName=chat-deploy-long-memory-integration-test:0.0.1, ...)
+NotFoundException: Status 404: pull access denied for chat-deploy-long-memory-integration-test
+```
+
+**Cause.** Downstream of B1. These tests expect a locally built image; testcontainers cannot find it locally, falls back to pulling from Docker Hub, and gets a 404 because no such public image exists.
+
+**Blast radius.** `ShellRequesterTests`, `LongShellTopicCommandsTests`, `LongUserCommandsTests`, `LongLoginCommandsTests` error out. A further 17 tests in the module are `@Disabled`.
+
+**Note.** These failures were invisible until recently: `chat-shell` was being SKIPPED because `chat-client-rsocket` failed to compile (R1), so nobody saw them.
+
+---
+
+### B3 — `chat-webflux` `LongTopicRestTests` returns 500 where 200 is expected
+
+**Symptom**
+
+```
+LongTopicRestTests > TopicRestTestBase.join a room:199   expected <200 OK> but was <500 INTERNAL_SERVER_ERROR>
+LongTopicRestTests > TopicRestTestBase.leave topic:224   expected <200 OK> but was <500 INTERNAL_SERVER_ERROR>
+```
+
+**Cause.** Unknown — not investigated. Long-standing; predates the selector and messaging work of August 2026. The module depends only on `chat-core` and `chat-security`, so it is independent of the persistence, index and messaging backends.
+
+**Blast radius.** 2 tests of 77 in the module.
+
+**Reproduce.** `mvn -pl chat-webflux test`
+
+---
+
+### B4 — `chat-authorization-server` missing `server_keycert.jwk` fixture
+
+**Symptom**
+
+```
+FileNotFoundException: class path resource [server_keycert.jwk] cannot be opened because it does not exist
+  ... creating bean 'jwkSetSource' in AuthorizationServerConfig
+```
+
+**Cause.** The test context builds a `JWKSource` from a classpath resource that is not in the repository.
+
+**Blast radius.** 1 error of 3 tests in the module.
+
+**Needs a decision.** Either commit a test-only key, or generate one in test setup. Committing a real signing key is the wrong answer; a throwaway generated per run is likely right, but that is a call for whoever owns the auth server.
+
+**Note.** Like B2, this was hidden behind R1 — the module's tests had not compiled for some time.
+
+---
+
+### B5 — CI compiles but never runs a test
+
+`.github/workflows/maven.yml` runs:
+
+```yaml
+run: mvn clean test-compile
+```
+
+**Consequence.** A green check mark means every module compiles, including test sources. It does not mean any test passed. B3 and B4 are invisible to CI, and always have been.
+
+This may well be deliberate — the container-backed suites need a Docker daemon, and B1/B2 would fail a CI run today regardless. Recorded so that nobody reads a green tick as more than it is.
+
+---
+
+### B6 — stale `target/` across branch switches produces phantom results
+
+**Symptom.** `mvn test` without `clean` runs compiled test classes left in `target/test-classes` by a previously checked-out branch, against production code that no longer matches. Observed during the selector work: three failures that did not correspond to any source file present in the tree.
+
+**Mitigation.** Use `mvn clean test` when switching branches. The verifier script always cleans.
+
+---
+
+## Resolved
+
+Kept so the list can be trusted — an entry disappearing without explanation is indistinguishable from an entry being forgotten.
+
+| ID | Deficiency | Fixed by |
+|----|-----------|----------|
+| R1 | `KotlinModule` named-constructor form is a compile error under the jackson version Spring Boot 3.3.13 manages. `chat-client-rsocket` failing test-compile stopped the reactor and took `chat-deploy-redis`, `chat-shell` and `chat-authorization-server` down as SKIPPED. | #13, #22 |
+| R2 | Modules declared `org.testcontainers:cassandra` at 1.21.4 but Spring Boot's BOM pinned the core `testcontainers` artifact at 1.19.8, whose `docker-java` 3.3.6 cannot negotiate with Docker Engine 29.x — reported as the misleading "Could not find a valid Docker environment". | #23 |
+
+R2 moved `chat-persistence-cassandra` from 41 tests with 15 errors to 71 passing, and `chat-index-cassandra` from 8 tests with 4 errors to 26 passing.
+
+## One-time notes
+
+- The first build after R2 needs network access: `org.testcontainers:database-commons:1.21.4` is not in a local repository that predates the bump, so `mvn -o` fails until it is fetched once.

--- a/shell-scripts/build-health.sh
+++ b/shell-scripts/build-health.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+#
+# Reports which modules currently fail the reactor test phase, and diffs that
+# against the deficiencies recorded in docs/BUILD-HEALTH.md.
+#
+# The point is drift detection. A hand-maintained list goes stale the moment
+# someone fixes something and forgets to say so, or breaks something and does
+# not notice. This runs the build and tells you which entries in the document
+# are still true.
+#
+#   ./shell-scripts/build-health.sh              # offline, test phase only
+#   ./shell-scripts/build-health.sh --online     # allow artifact downloads
+#   ./shell-scripts/build-health.sh --install    # include package/install, covers build-image
+#
+# Exit status: 0 when reality matches the document, 1 when it does not.
+
+set -uo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$( cd "$DIR/.." && pwd )"
+DOC="docs/BUILD-HEALTH.md"
+
+# Modules expected to fail, from docs/BUILD-HEALTH.md. Keep these two in sync:
+# if you change this list, change the document, and vice versa.
+KNOWN_FAILING="chat-authorization-server chat-shell chat-webflux"
+# Additionally expected to fail once the build reaches package/install.
+KNOWN_FAILING_INSTALL="chat-deploy-memory-integration-tests"
+
+PHASE="test"
+OFFLINE="-o"
+for arg in "$@"; do
+    case "$arg" in
+        --online)  OFFLINE="" ;;
+        --install) PHASE="install" ;;
+        --help|-h) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
+        *) echo "unknown option: $arg" >&2; exit 2 ;;
+    esac
+done
+
+expected="$KNOWN_FAILING"
+[ "$PHASE" = "install" ] && expected="$KNOWN_FAILING $KNOWN_FAILING_INSTALL"
+
+log="$(mktemp -t build-health)"
+trap 'rm -f "$log"' EXIT
+
+echo "running: mvn $OFFLINE clean $PHASE -fae"
+echo "(a full run takes several minutes; container-backed modules dominate)"
+echo
+
+# shellcheck disable=SC2086
+(cd "$ROOT" && mvn $OFFLINE clean "$PHASE" -fae) > "$log" 2>&1
+
+summary="$(sed -n '/Reactor Summary/,/^\[INFO\] -\{20,\}$/p' "$log")"
+if [ -z "$summary" ]; then
+    echo "could not find a reactor summary in the build output; last 30 lines:" >&2
+    tail -30 "$log" >&2
+    exit 2
+fi
+
+actual="$(echo "$summary" | awk '/FAILURE \[/ {print $2}' | sort)"
+skipped="$(echo "$summary" | awk '/SKIPPED$/ {print $2}' | sort)"
+expected_sorted="$(echo "$expected" | tr ' ' '\n' | grep -v '^$' | sort)"
+
+new="$(comm -13 <(echo "$expected_sorted") <(echo "$actual"))"
+resolved="$(comm -23 <(echo "$expected_sorted") <(echo "$actual"))"
+
+status=0
+
+if [ -n "$actual" ]; then
+    echo "failing modules:"
+    echo "$actual" | sed 's/^/  /'
+    echo
+fi
+
+if [ -n "$new" ]; then
+    echo "NEW — failing but not recorded in $DOC:"
+    echo "$new" | sed 's/^/  /'
+    echo "  → investigate, then add an entry or fix it"
+    echo
+    status=1
+fi
+
+if [ -n "$resolved" ]; then
+    echo "RESOLVED — recorded in $DOC but passing now:"
+    echo "$resolved" | sed 's/^/  /'
+    echo "  → move the entry to the Resolved section, with the PR that fixed it"
+    echo
+    status=1
+fi
+
+if [ -n "$skipped" ]; then
+    # A skipped module is not a passing module. Skips mean an upstream module
+    # failed to build, which hides everything downstream of it.
+    echo "SKIPPED — never built, so their state is unknown:"
+    echo "$skipped" | sed 's/^/  /'
+    echo
+    status=1
+fi
+
+if [ "$status" -eq 0 ]; then
+    echo "reality matches $DOC"
+else
+    echo "$DOC is out of date — see above"
+    echo "full log: $log"
+    trap - EXIT
+fi
+
+exit "$status"


### PR DESCRIPTION
Two files: a list of build-time deficiencies, and a script that checks the list against reality.

Tracked as `CHAT-cikgeefc`. This is where the evidence for B1–B6 lives, including B3, which currently exists nowhere else.

## Why a script and not just a document

A hand-maintained list goes stale the moment someone fixes an entry and forgets to say so, or breaks something and does not notice. `shell-scripts/build-health.sh` runs the build, diffs the failing modules against the documented set, and exits non-zero when they disagree:

- **NEW** — failing but undocumented → investigate or fix
- **RESOLVED** — documented but passing → move it to the Resolved section
- **SKIPPED** — never built, so its state is unknown

That last one carries the most weight. A skipped module reads as "not failing" in a reactor summary, and that is precisely how R1 hid B2 and B4 for months: `chat-client-rsocket` failed to compile, three modules downstream were never built, and nobody saw what was wrong inside them.

## What is recorded

| ID | Deficiency | Status |
|----|-----------|--------|
| B1 | `build-image` cannot talk to Docker 29.x, **and** the image it would build does not boot | Fix proven, plan written |
| B2 | `chat-shell` needs an image B1 never builds | Tests now opt-in (#32) |
| B3 | `chat-webflux` `LongTopicRestTests` returns 500 where 200 expected | Open, uninvestigated |
| B4 | `chat-authorization-server` missing `server_keycert.jwk` | Open, needs a decision |
| B5 | CI compiles but never runs a test | Open, may be deliberate |
| B6 | Stale `target/` across branch switches produces phantom results | Workaround only |

Plus a **Resolved** section (R1 `KotlinModule`, R2 testcontainers version skew), kept deliberately — an entry vanishing without explanation is indistinguishable from an entry being forgotten.

Each entry carries symptom, cause, blast radius and a reproduce command, so none of them requires trusting a summary.

## Verified

`./shell-scripts/build-health.sh` against master `0842082a` reports the three failing modules and agrees with the document — exit 0, "reality matches docs/BUILD-HEALTH.md".

## Corrections since first drafting

- The module is `chat-deploy-memory-integration-test` (singular). Only its `<artifactId>` is plural, which is itself worth knowing.
- B1 gained a proven fix and a second defect underneath it: once the image builds it still fails to start, because that module's pom bakes **bare** `app.service.core.*` selectors that match no `havingValue`. The selector sweep covered `*.sh`, `*.kt` and `*.yml` and never `pom.xml`.
- B2's status reflects #32 making the container tests opt-in.

## Note

These two files were briefly and accidentally included in #32 — `git add -A` picked them up after they carried across a branch switch. They were removed from that branch and belong here instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
