### PR TITLE
fix: bind the topic id as a path variable in join and leave

### DIFF
--- a/chat-webflux/src/main/kotlin/com/demo/chat/controller/webflux/composite/mapping/ChatTopicServiceRestMapping.kt
+++ b/chat-webflux/src/main/kotlin/com/demo/chat/controller/webflux/composite/mapping/ChatTopicServiceRestMapping.kt
@@ -30,12 +30,12 @@ interface ChatTopicServiceRestMapping<T> : ChatTopicService<T, String> {
 
     @PutMapping("/leave/{id}")
     @ResponseStatus(HttpStatus.OK)
-    fun leaveRestRoom(id: T, @AuthenticationPrincipal user: ChatUserDetails<T>): Mono<Void> =
+    fun leaveRestRoom(@PathVariable id: T, @AuthenticationPrincipal user: ChatUserDetails<T>): Mono<Void> =
         leaveRoom(MembershipRequest(user.user.key.id, id))
 
     @PutMapping("/join/{id}")
     @ResponseStatus(HttpStatus.OK)
-    fun joinRestRoom(id: T, @AuthenticationPrincipal user: ChatUserDetails<T>): Mono<Void> =
+    fun joinRestRoom(@PathVariable id: T, @AuthenticationPrincipal user: ChatUserDetails<T>): Mono<Void> =
         joinRoom(MembershipRequest(user.user.key.id, id))
 
     @GetMapping("/id/{id}", produces = [MediaType.APPLICATION_JSON_VALUE])


### PR DESCRIPTION
Fixes B3 (`CHAT-myyzsssi`) — the oldest failures on master, and the last build-health entry whose cause was unknown.

Two words of production code.

## The failure

```
LongTopicRestTests > TopicRestTestBase.join a room:199   expected <200 OK> but was <500 INTERNAL_SERVER_ERROR>
LongTopicRestTests > TopicRestTestBase.leave topic:224   expected <200 OK> but was <500 INTERNAL_SERVER_ERROR>
```

Server side:

```
java.lang.IllegalStateException: Insufficient type information to create instance of ?
```

## The cause

```kotlin
fun joinRestRoom(id: T, @AuthenticationPrincipal user: ChatUserDetails<T>): Mono<Void>
```

`id: T` carries no annotation. An unannotated non-simple parameter is treated as a **model attribute**, so Spring tried to instantiate the erased type variable `T` and could not. The `?` in the exception message is that type variable.

`@PathVariable` binds from the URI template instead. The generic then resolves against the concrete controller class — `T` becomes `Long` for `LongTopicRestController` — and the conversion service handles the string.

## Not the authentication

Worth stating, because it was the first hypothesis and it is wrong: `@WithLongCustomChatUser(userId = 1L, roles = ["TEST"])` is applied by both tests, and the security filter chain passed through to the handler. `@AuthenticationPrincipal` was resolving fine. The failure happened after authentication, during argument binding.

The sibling endpoints in the same interface already carry `@PathVariable` or `@ModelAttribute`. These two were simply missed.

## Result

`chat-webflux`: **77/77**, from 75 passing with 2 failures. No other test changed.

## Same shape elsewhere

Checked, since a missed annotation tends not to be unique:

- `PubSubRestMapping.sendRestMessage` — annotates its parameters on following lines. Fine.
- `ChatMessageServiceRestMapping.messageById` — takes an unannotated `ByIdRequest<T>` where its sibling `listenTopic` uses `@ModelAttribute`. That is a concrete class Spring can instantiate, it is covered by a test hitting `/message/id/1234566`, and it passes. **Inconsistent rather than broken**, so left alone rather than changed speculatively.

## Note

These were the oldest failures on master — present before the selector and messaging work of August 2026, and untouched by all of it. They survived because CI runs `mvn clean test-compile` and never executes a test (B5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
