### PR TITLE
docs: retire B3, and let the verifier see the integration surface

### DIFF
--- a/docs/BUILD-HEALTH.md
+++ b/docs/BUILD-HEALTH.md
@@ -2,7 +2,7 @@
 
 Known build-time deficiencies, what causes them, and what they take down with them.
 
-**Verified against master `0842082a` on 2026-08-22** by a full `mvn clean test -fae` plus targeted per-module runs.
+**Verified against master `c4dc9a57` on 2026-08-22** by a full `mvn clean test -fae` plus targeted per-module runs.
 
 Do not trust this file on its own — run the verifier:
 
@@ -15,14 +15,15 @@ It runs the build, diffs the failing modules against the list below, and exits n
 
 ## Current state
 
-`mvn clean test -fae` — three modules fail, nothing is skipped.
+`mvn clean test -fae` — one module fails, nothing is skipped.
 `mvn clean install` — additionally fails at `chat-deploy-memory-integration-test`, which stops the build before packaging.
+
+Note what the default run no longer covers. Since #32 the container-backed tests are tagged `integration` and excluded unless `-Pintegration` is passed, so roughly 160 tests are not exercised by a plain build. `chat-shell` passing by default means its tests did not run — not that B2 is fixed.
 
 | ID | Deficiency | Blocks | Status |
 |----|-----------|--------|--------|
 | B1 | `spring-boot:build-image` cannot talk to Docker 29.x, and the image it would build does not boot | `mvn install` for the whole reactor | Open — fix proven, plan written |
-| B2 | `chat-shell` integration tests need an image B1 never builds | 4 test classes | Open — tests now opt-in (#32) |
-| B3 | `chat-webflux` `LongTopicRestTests` returns 500 where 200 is expected | 2 tests | Open, uninvestigated |
+| B2 | `chat-shell` integration tests need an image B1 never builds | 4 test classes, only under `-Pintegration` | Open — no longer fails the default build (#32) |
 | B4 | `chat-authorization-server` missing `server_keycert.jwk` fixture | 1 test | Open, needs a decision |
 | B5 | CI compiles but never runs a test | all of B2–B4 invisible to CI | Open, may be deliberate |
 | B6 | Stale `target/` across branch switches produces phantom results | correctness of any non-clean run | Workaround only |
@@ -78,23 +79,6 @@ NotFoundException: Status 404: pull access denied for chat-deploy-long-memory-in
 
 ---
 
-### B3 — `chat-webflux` `LongTopicRestTests` returns 500 where 200 is expected
-
-**Symptom**
-
-```
-LongTopicRestTests > TopicRestTestBase.join a room:199   expected <200 OK> but was <500 INTERNAL_SERVER_ERROR>
-LongTopicRestTests > TopicRestTestBase.leave topic:224   expected <200 OK> but was <500 INTERNAL_SERVER_ERROR>
-```
-
-**Cause.** Unknown — not investigated. Long-standing; predates the selector and messaging work of August 2026. The module depends only on `chat-core` and `chat-security`, so it is independent of the persistence, index and messaging backends.
-
-**Blast radius.** 2 tests of 77 in the module.
-
-**Reproduce.** `mvn -pl chat-webflux test`
-
----
-
 ### B4 — `chat-authorization-server` missing `server_keycert.jwk` fixture
 
 **Symptom**
@@ -142,6 +126,7 @@ Kept so the list can be trusted — an entry disappearing without explanation is
 
 | ID | Deficiency | Fixed by |
 |----|-----------|----------|
+| B3 | `joinRestRoom` and `leaveRestRoom` declared `id: T` with no annotation, so Spring treated it as a model attribute and failed to instantiate the erased type variable — `IllegalStateException: Insufficient type information to create instance of ?`. Adding `@PathVariable` binds from the URI template instead. Not an authentication problem, which was the first hypothesis. | #34 |
 | R1 | `KotlinModule` named-constructor form is a compile error under the jackson version Spring Boot 3.3.13 manages. `chat-client-rsocket` failing test-compile stopped the reactor and took `chat-deploy-redis`, `chat-shell` and `chat-authorization-server` down as SKIPPED. | #13, #22 |
 | R2 | Modules declared `org.testcontainers:cassandra` at 1.21.4 but Spring Boot's BOM pinned the core `testcontainers` artifact at 1.19.8, whose `docker-java` 3.3.6 cannot negotiate with Docker Engine 29.x — reported as the misleading "Could not find a valid Docker environment". | #23 |
 

--- a/shell-scripts/build-health.sh
+++ b/shell-scripts/build-health.sh
@@ -11,6 +11,7 @@
 #   ./shell-scripts/build-health.sh              # offline, test phase only
 #   ./shell-scripts/build-health.sh --online     # allow artifact downloads
 #   ./shell-scripts/build-health.sh --install    # include package/install, covers build-image
+#   ./shell-scripts/build-health.sh --integration # also run the container-backed tests
 #
 # Exit status: 0 when reality matches the document, 1 when it does not.
 
@@ -22,33 +23,41 @@ DOC="docs/BUILD-HEALTH.md"
 
 # Modules expected to fail, from docs/BUILD-HEALTH.md. Keep these two in sync:
 # if you change this list, change the document, and vice versa.
-KNOWN_FAILING="chat-authorization-server chat-shell chat-webflux"
+KNOWN_FAILING="chat-authorization-server"
 # Additionally expected to fail once the build reaches package/install.
+# Names here are Maven project names as printed in the reactor summary, which is
+# why this one is plural while its directory is singular.
 KNOWN_FAILING_INSTALL="chat-deploy-memory-integration-tests"
+# Additionally expected to fail under -Pintegration, which runs the
+# container-backed tests excluded from a default build.
+KNOWN_FAILING_INTEGRATION="chat-shell"
 
 PHASE="test"
 OFFLINE="-o"
+INTEGRATION=""
 for arg in "$@"; do
     case "$arg" in
         --online)  OFFLINE="" ;;
         --install) PHASE="install" ;;
+        --integration) INTEGRATION="-Pintegration" ;;
         --help|-h) awk 'NR>1 && /^#/ {sub(/^# ?/,""); print; next} NR>1 {exit}' "$0"; exit 0 ;;
         *) echo "unknown option: $arg" >&2; exit 2 ;;
     esac
 done
 
 expected="$KNOWN_FAILING"
-[ "$PHASE" = "install" ] && expected="$KNOWN_FAILING $KNOWN_FAILING_INSTALL"
+[ "$PHASE" = "install" ] && expected="$expected $KNOWN_FAILING_INSTALL"
+[ -n "$INTEGRATION" ] && expected="$expected $KNOWN_FAILING_INTEGRATION"
 
 log="$(mktemp -t build-health)"
 trap 'rm -f "$log"' EXIT
 
-echo "running: mvn $OFFLINE clean $PHASE -fae"
+echo "running: mvn $OFFLINE clean $PHASE -fae $INTEGRATION"
 echo "(a full run takes several minutes; container-backed modules dominate)"
 echo
 
 # shellcheck disable=SC2086
-(cd "$ROOT" && mvn $OFFLINE clean "$PHASE" -fae) > "$log" 2>&1
+(cd "$ROOT" && mvn $OFFLINE clean "$PHASE" -fae $INTEGRATION) > "$log" 2>&1
 
 summary="$(sed -n '/Reactor Summary/,/^\[INFO\] -\{20,\}$/p' "$log")"
 if [ -z "$summary" ]; then


### PR DESCRIPTION
The verifier's own maintenance loop, run after #32, #33 and #34 merged.

## It caught its document being stale

```
$ ./shell-scripts/build-health.sh

failing modules:
  chat-authorization-server

RESOLVED — recorded in docs/BUILD-HEALTH.md but passing now:
  chat-shell
  chat-webflux
  → move the entry to the Resolved section, with the PR that fixed it

docs/BUILD-HEALTH.md is out of date
exit=1
```

First real outing, and it did the job it exists for.

## What changed

**B3 moves to Resolved** with its cause and #34. `KNOWN_FAILING` drops to `chat-authorization-server`.

**`chat-shell` does not move**, and the document now says why. It passes by default because #32 excluded its tests — **not** because B2 is fixed. Marking it resolved would have made the table read as progress that did not happen. Its blast-radius column now reads "4 test classes, only under `-Pintegration`".

## A blind spot we created, now closed

Excluding the container-backed tests by default put roughly **160 tests beyond the verifier's reach**. The largest test surface in the repo became invisible to the tool meant to watch it — a gap #32 introduced, not one that pre-existed.

Added `--integration`, which runs with `-Pintegration` and compares against a separate `KNOWN_FAILING_INTEGRATION`.

## Both modes measured on master `c4dc9a57`

| Mode | Failing | Verdict |
|---|---|---|
| default | `chat-authorization-server` | matches |
| `--integration` | `chat-authorization-server`, `chat-shell` | `reality matches docs/BUILD-HEALTH.md`, exit 0 |

Everything else passes **with containers running** — cassandra, redis, xstream, index-cassandra and the deploy tests. The tests #32 moved behind the flag are healthy; they simply need somewhere to be run from, which is B5's question and now has a concrete answer: `-Pintegration` is green apart from two known, tracked failures.

## Sharper scope for what remains

- **B2** is now precisely bounded — the only `-Pintegration` failure besides B4. Once B1 lands and the image exists, it should reduce to the wait-strategy problem already flagged on that issue: `withRegEx("*Netty RSocket started*")` is not a valid pattern.
- **B4** is unchanged and unblocked by any of this.

## One trap documented

`KNOWN_FAILING_INSTALL` is `chat-deploy-memory-integration-tests` (plural) while the directory is `chat-deploy-memory-integration-test` (singular). The script matches **Maven project names as printed in the reactor summary**, not directories. There is now a comment saying so, because that difference is easy to "correct" into a bug — I nearly did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
