### PR TITLE
test: generate the authorization server signing key per run

### DIFF
--- a/chat-authorization-server/src/test/kotlin/com/demo/chat/AuthorizationServerDeployTests.kt
+++ b/chat-authorization-server/src/test/kotlin/com/demo/chat/AuthorizationServerDeployTests.kt
@@ -4,6 +4,8 @@ import com.demo.chat.service.client.discovery.LocalhostDiscovery
 import com.demo.chat.domain.TypeUtil
 import com.demo.chat.security.service.CoreUserDetailsService
 import com.demo.chat.service.client.ClientDiscovery
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -11,7 +13,12 @@ import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.cloud.client.ServiceInstance
 import org.springframework.context.annotation.Bean
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import reactor.core.publisher.Mono
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.UUID
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -23,7 +30,6 @@ import reactor.core.publisher.Mono
         "app.client.rsocket.composite.message", "app.client.rsocket.composite.topic",
         "app.client.rsocket.core.persistence",
         "app.client.rsocket.core.index", "app.service.composite.auth",
-        "app.oauth2.jwk.path=classpath:server_keycert.jwk",
     "app.rsocket.transport.security.type=unprotected"
 
     ]
@@ -31,6 +37,39 @@ import reactor.core.publisher.Mono
 @ActiveProfiles("memory")
 //@Disabled
 class AuthorizationServerDeployTests {
+
+    companion object {
+        /**
+         * The signing key is generated per run rather than committed.
+         *
+         * AuthorizationServerConfig reads it from `app.oauth2.jwk.path`, and the
+         * repository has no `server_keycert.jwk` on the test classpath —
+         * `gen-dckeys.sh` produces one and copies it here, but nothing in the
+         * build runs that script, so the context failed to start on any machine
+         * where it had not been run by hand.
+         *
+         * EC P-256, because jwtCustomizer signs with ES256. No x5c chain: the
+         * production key carries one, but nothing in this context verifies it.
+         */
+        private val jwkFile: Path = generateSigningKey()
+
+        private fun generateSigningKey(): Path {
+            val jwk = ECKeyGenerator(Curve.P_256)
+                .keyID(UUID.randomUUID().toString())
+                .generate()
+
+            val file = Files.createTempFile("authserver-test-signing-key", ".jwk")
+            file.toFile().deleteOnExit()
+            Files.writeString(file, jwk.toJSONString())
+            return file
+        }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun signingKey(registry: DynamicPropertyRegistry) {
+            registry.add("app.oauth2.jwk.path") { "file:" + jwkFile.toAbsolutePath() }
+        }
+    }
 
     @Autowired
     private lateinit var typeUtil: TypeUtil<Long>


### PR DESCRIPTION
Fixes B4 (`CHAT-rsvgtqbp`), and with it **the full default reactor is `BUILD SUCCESS` for the first time** — no failures, nothing skipped.

## The failure

```
AuthorizationServerDeployTests.contextLoads
FileNotFoundException: class path resource [server_keycert.jwk] cannot be opened because it does not exist
  ... creating bean 'jwkSetSource' in AuthorizationServerConfig
```

The fixture is not in the repository. `gen-dckeys.sh` generates it and copies it into `src/test/resources`, but nothing in the build runs that script — so this test passed only on a machine where someone had run it by hand, and failed everywhere else.

## The fix

`AuthorizationServerConfig` reads the key from a **property**:

```kotlin
class AuthorizationServerConfig(@Value("\${app.oauth2.jwk.path}") val resource: Resource)
```

So the test generates a key into a temp file and points that property at it via `@DynamicPropertySource`. No production code changes, no bean overridden, and no signing key enters the repository.

## Three decisions worth knowing

**EC P-256, not RSA.** `jwtCustomizer` signs with `ES256`. An RSA key would load fine and then fail at *signing* time — a later and more confusing failure than the one being fixed.

**No `x5c` chain.** The production key carries one, added by `gen-dckeys.sh`. Nothing in this context verifies it, so generating one would be ceremony.

**The stale property is removed, not overridden.** `app.oauth2.jwk.path=classpath:server_keycert.jwk` is deleted from the `@SpringBootTest` properties. `@DynamicPropertySource` takes precedence and would have won anyway, but a path pointing at a file that does not exist is exactly what misleads the next reader.

## Result

| | Before | After |
|---|---|---|
| `chat-authorization-server` | 3 tests, 1 error | **3/3** |
| Full default reactor | 1 module failing | **BUILD SUCCESS** |

## Why this one mattered

B4 was the last failure in a default build, which made it the blocker for **B5** (`CHAT-uortzsbx`) — CI runs `mvn clean test-compile` and never executes a test. Turning tests on while master was red would have produced a check that is always red, which gets ignored just as thoroughly as a check that always passes.

With this merged, Task 3 of the B5 plan is safe to do: `mvn -B clean test` in CI is green.

The container-backed suites are a separate question. Under `-Pintegration` the only remaining failure is `chat-shell`, which is B2, blocked on B1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
