### PR TITLE
ci: stop double-building every PR, and fix the cache key

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,16 @@
 name: Maven CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+# A branch pushed to this repository fires both push and pull_request, so every
+# PR built twice. Restricting push to master stops the duplicate; the
+# concurrency group cancels superseded runs on the same ref.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -8,24 +18,23 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Set up JDK 17
-      uses: actions/setup-java@v3
+      uses: actions/setup-java@v4
       with:
         java-version: '17'
-        distribution: 'adopt'
+        distribution: 'temurin'
 
     - name: Cache Maven packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           ~/.m2/repository
           ~/.m2/wrapper
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
+          ${{ runner.os }}-maven-
           ${{ runner.os }}-
     - name: Maven clean compile
       run: mvn clean test-compile


### PR DESCRIPTION
Tasks 1 and 2 of the B5 plan (`CHAT-uortzsbx`). **Neither turns tests on**, so neither depends on the rest of that plan — these are safe now.

## Every PR was built twice

`on: [push, pull_request]` fires both events for a branch pushed to this repository. Confirmed on `verify-health`:

```
pull_request   success    verify-health
push           success    verify-health
```

Same commit, two full builds. Push is now restricted to `master`, and a concurrency group cancels superseded runs on the same ref:

```yaml
on:
  push:
    branches: [master]
  pull_request:

concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

The first stops duplicate work, the second stops stale work. Both matter considerably more once the job actually runs tests.

## The cache key interpolated a variable that does not exist

```yaml
key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/pom.xml') }}
```

`env.cache-name` is defined nowhere in the workflow, so the real key was `Linux-build--<hash>`. It worked by accident and would confuse anyone who read it. Now `Linux-maven-<hash>`, with matching `restore-keys`.

## Also

`actions/checkout`, `actions/setup-java` and `actions/cache` move from v3 to v4 — the v3 releases still run, but on a deprecated Node runtime. JDK distribution moves from `adopt` to `temurin`, which is the current name for the same builds.

## What is deliberately not here

**Task 3 — actually running the tests.** It needs B4 on master first (#36). Enabling `mvn clean test` while master is red would produce a check that is always red, and that gets ignored exactly as thoroughly as one that always passes — which is the bug B5 describes in the first place.

Once #36 lands, the default reactor is `BUILD SUCCESS` end to end and Task 3 is a one-line change to this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
