### PR TITLE
fix: name what is missing when a root key is absent

### DIFF
--- a/chat-core/src/main/kotlin/com/demo/chat/domain/knownkey/RootKeys.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/knownkey/RootKeys.kt
@@ -1,5 +1,6 @@
 package com.demo.chat.domain.knownkey
 
+import com.demo.chat.domain.ChatException
 import com.demo.chat.domain.Key
 import java.util.concurrent.ConcurrentHashMap
 
@@ -16,8 +17,40 @@ class RootKeys<T> {
         keyMap.putAll(other)
     }
     fun getMapOfKeyMap(): Map<String, Key<T>> = keyMap.toMap()
-    fun <S> getRootKey(domain: Class<S>): Key<T> = keyMap[domain.simpleName]!!
-    fun getRootKey(domain: String) = keyMap[domain]!!
+
+    fun <S> getRootKey(domain: Class<S>): Key<T> = getRootKey(domain.simpleName)
+
+    /**
+     * Both overloads route through here so they cannot drift.
+     *
+     * This used to be `keyMap[domain]!!`, which turned a missing key into a
+     * bare NullPointerException naming neither the domain requested nor what
+     * the map held. Those two cases look identical from the stack trace and
+     * are entirely different faults:
+     *
+     *  - the map is empty, so root-key initialization never ran; or
+     *  - the map is populated and this one domain is genuinely absent.
+     *
+     * The first is a deployment or startup-ordering problem, the second a
+     * caller asking for something that was never registered. Naming the
+     * contents is what separates them.
+     *
+     * The return stays non-null. Every one of the callers - authentication,
+     * access checks, the anonymous payload interceptor, shell identity -
+     * requires the key to proceed, so a nullable return would only push an
+     * unhandleable condition outward.
+     */
+    fun getRootKey(domain: String): Key<T> =
+        keyMap[domain] ?: throw ChatException(
+            if (keyMap.isEmpty()) {
+                "No root key '$domain': no root keys are initialized at all. " +
+                    "Root keys are populated at startup - locally when app.rootkeys.create is set, " +
+                    "or fetched from a peer's /actuator/rootkeys when app.rootkeys.consume.scheme=http. " +
+                    "An empty map means neither ran, or ran before the source was ready."
+            } else {
+                "No root key '$domain'. Known root keys: ${keyMap.keys.sorted().joinToString(", ")}"
+            }
+        )
     fun <S> addRootKey(domain: Class<S>, key: Key<T>) = keyMap.put(domain.simpleName, key)
     fun <S> isRootKeyWithValue(domain: Class<S>) = keyMap.containsKey(domain.simpleName)
     fun hasKey(key: String) = keyMap.containsKey(key)

--- a/chat-core/src/test/kotlin/com/demo/chat/test/knownkey/RootKeysTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/knownkey/RootKeysTests.kt
@@ -1,0 +1,60 @@
+package com.demo.chat.test.knownkey
+
+import com.demo.chat.domain.ChatException
+import com.demo.chat.domain.Key
+import com.demo.chat.domain.User
+import com.demo.chat.domain.knownkey.Anon
+import com.demo.chat.domain.knownkey.RootKeys
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * A missing root key used to surface as a bare NullPointerException from
+ * `keyMap[domain]!!`, naming neither the domain requested nor the map's
+ * contents. Those two facts are what separate "initialization never ran" from
+ * "this one domain was never registered" — identical symptoms, different
+ * faults. These tests pin both messages.
+ */
+class RootKeysTests {
+
+    @Test
+    fun `an empty map says initialization never ran`() {
+        val rootKeys = RootKeys<Long>()
+
+        assertThatThrownBy { rootKeys.getRootKey(Anon::class.java) }
+            .isInstanceOf(ChatException::class.java)
+            .hasMessageContaining("Anon")
+            .hasMessageContaining("no root keys are initialized at all")
+    }
+
+    @Test
+    fun `a populated map names what it does hold`() {
+        val rootKeys = RootKeys<Long>()
+        rootKeys.addRootKey(User::class.java, Key.funKey(1L))
+        rootKeys.addRootKey("Topic", Key.funKey(2L))
+
+        assertThatThrownBy { rootKeys.getRootKey(Anon::class.java) }
+            .isInstanceOf(ChatException::class.java)
+            .hasMessageContaining("Anon")
+            .hasMessageContaining("Known root keys: Topic, User")
+    }
+
+    @Test
+    fun `both overloads agree`() {
+        val rootKeys = RootKeys<Long>()
+        rootKeys.addRootKey(User::class.java, Key.funKey(7L))
+
+        assertThat(rootKeys.getRootKey(User::class.java).id)
+            .isEqualTo(rootKeys.getRootKey("User").id)
+            .isEqualTo(7L)
+    }
+
+    @Test
+    fun `a present key is returned rather than thrown for`() {
+        val rootKeys = RootKeys<Long>()
+        rootKeys.addRootKey(Anon::class.java, Key.funKey(42L))
+
+        assertThat(rootKeys.getRootKey(Anon::class.java).id).isEqualTo(42L)
+    }
+}


### PR DESCRIPTION
Follow-up to #40, where this cost two wrong diagnoses.

## The site

`chat-core/.../knownkey/RootKeys.kt`:

```kotlin
fun <S> getRootKey(domain: Class<S>): Key<T> = keyMap[domain.simpleName]!!
fun getRootKey(domain: String) = keyMap[domain]!!
```

## What it did on failure

```
java.lang.NullPointerException
  at com.demo.chat.domain.knownkey.RootKeys.getRootKey(RootKeys.kt:20)
  at com.demo.chat.shell.commands.CommandsUtil.identity(CommandsUtil.kt:19)
```

The trace names neither the domain requested nor what the map contained. Those two facts are what separate faults that otherwise look identical:

- the map is **empty**, so root-key initialization never ran; or
- the map is **populated** and this one domain was never registered.

The first is a deployment or startup-ordering problem. The second is a caller asking for something that does not exist. In B2 this was the former, and read as the latter — the only evidence available was "something was null".

## After

Empty map:

> No root key 'Anon': no root keys are initialized at all. Root keys are populated at startup — locally when `app.rootkeys.create` is set, or fetched from a peer's `/actuator/rootkeys` when `app.rootkeys.consume.scheme=http`. An empty map means neither ran, or ran before the source was ready.

Populated map:

> No root key 'Anon'. Known root keys: MessageTopic, User

The empty-map message names the two mechanisms that populate the map, so the reader goes to the right property rather than to the map lookup.

## Design choices

**Non-null return kept.** All fourteen callers — `CoreAuthenticationService`, `CoreAuthBeans`, `SpringSecurityAccessBrokerService`, `TopicServiceAccess`, `UserServiceAccess`, `DefaultingAnonymousPayloadInterceptor`, `CommandsUtil`, `InitialUsersService` — need the key to proceed. A nullable or `Optional` return would push an unhandleable condition onto every one of them and force each to invent a response to "there is no Anon key".

**Both overloads route through one implementation**, so the `Class<S>` and `String` forms cannot drift.

**`ChatException`** rather than `IllegalStateException`, matching the rest of the domain and remaining catchable alongside it.

## Verification

Four tests pin both messages, that the overloads agree, and that a present key is still returned — 4/4.

Full reactor: **BUILD SUCCESS**. This is a `chat-core` change on a security-adjacent path, so the question was whether any existing test depended on the `NullPointerException`. None did.

## Left alone deliberately

`InitialUsersService.kt:69` calls `rootKeys.getRootKey(permission.user)!!` — a redundant `!!` on an already non-null return, left from an earlier signature. Harmless, and chasing it here would blur what this change is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
