### PR TITLE
docs: rewrite B6 in Simplified Technical English

### DIFF
--- a/docs/BUILD-HEALTH.md
+++ b/docs/BUILD-HEALTH.md
@@ -27,11 +27,16 @@ Note what the default run no longer covers. Since #32 the container-backed tests
 
 ---
 
-### B6 — stale `target/` across branch switches produces phantom results
+### B6 — a stale `target/` directory after a branch change gives false results
 
-**Symptom.** `mvn test` without `clean` runs compiled test classes left in `target/test-classes` by a previously checked-out branch, against production code that no longer matches. Observed during the selector work: three failures that did not correspond to any source file present in the tree.
+**Symptom.** `mvn test` without `clean` runs the compiled test classes in `target/test-classes`. A different branch put those classes there. They do not agree with the production code in the tree.
 
-**Mitigation.** Use `mvn clean test` when switching branches. The verifier script always cleans.
+This occurred during the selector work. Three tests failed. No source file in the tree contained those tests.
+
+**Mitigation.**
+
+1. Use `mvn clean test` after you change branches.
+2. The verifier script always cleans. It is not affected.
 
 ---
 


### PR DESCRIPTION
Rewrites the B6 entry using ASD-STE100 (Simplified Technical English).

**Mode: STE-flavored.** Structural rules applied in full; lexical rules as a direction of travel only, since this repository does not carry ASD's approved-word dictionary and cannot verify against it.

## Before

> **Symptom.** `mvn test` without `clean` runs compiled test classes left in `target/test-classes` by a previously checked-out branch, against production code that no longer matches. Observed during the selector work: three failures that did not correspond to any source file present in the tree.
>
> **Mitigation.** Use `mvn clean test` when switching branches. The verifier script always cleans.

## After

> **Symptom.** `mvn test` without `clean` runs the compiled test classes in `target/test-classes`. A different branch put those classes there. They do not agree with the production code in the tree.
>
> This occurred during the selector work. Three tests failed. No source file in the tree contained those tests.
>
> **Mitigation.**
>
> 1. Use `mvn clean test` after you change branches.
> 2. The verifier script always cleans. It is not affected.

## Rules applied

| Rule | Original | Simplified |
|---|---|---|
| Sentence length | one 34-word symptom sentence | four short sentences |
| Active voice | "classes **left** in `target/test-classes` **by** a previously checked-out branch" | "A different branch put those classes there." |
| Lists for sequences | two conditions in prose | numbered list |
| No ellipsis | "three failures that did not correspond to any source file present in the tree" | "Three tests failed. No source file in the tree contained those tests." |
| Noun cluster (4+) | "stale `target/` across branch switches" | "a stale `target/` directory after a branch change" |

The active-voice fix is the one that carries real meaning: the actor — a different branch — was hiding at the end of a passive clause, and it is the whole explanation for why the results are wrong.

## Kept as-is

**"They do not agree with the production code in the tree"**, rather than the shorter "They are stale". The problem is not age. It is disagreement between the compiled tests and the current source, which is what makes the results false rather than merely old. Shortening here would have cost the reader the actual mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
