### PR TITLE
docs: re-verify build health against current master

### DIFF
--- a/docs/BUILD-HEALTH.md
+++ b/docs/BUILD-HEALTH.md
@@ -2,7 +2,7 @@
 
 Known build-time deficiencies, what causes them, and what they take down with them.
 
-**Verified against master `f7d462a0` on 2026-08-23** by a full `mvn clean test -fae` plus targeted per-module runs.
+**Verified against master `d81f0859` on 2026-08-23** by all three verifier modes — default, `--install` and `--integration` — each reporting no drift.
 
 Do not trust this file on its own — run the verifier:
 
@@ -18,8 +18,11 @@ It runs the build, diffs the failing modules against the list below, and exits n
 
 `mvn clean test -fae` — **BUILD SUCCESS**. No module fails, nothing is skipped.
 `mvn clean install` — **BUILD SUCCESS**. Image building moved behind `-Ptest-build`, so no build needs a Docker daemon.
+`mvn clean test -fae -Pintegration` — **BUILD SUCCESS**, against Docker Engine 29.7.2.
 
 Note what the default run no longer covers. Since #32 the container-backed tests are tagged `integration` and excluded unless `-Pintegration` is passed, so roughly 160 tests are not exercised by a plain build. `chat-shell` passing by default means its tests did not run — not that B2 is fixed.
+
+The `--integration` run is what settles that question, and it now passes with no module failing and none skipped. So `chat-shell` passes on its own merits, not by exclusion, and B2 holds up with containers running. Both remaining lists in the verifier — `KNOWN_FAILING_INSTALL` and `KNOWN_FAILING_INTEGRATION` — are empty and measured, not assumed.
 
 | ID | Deficiency | Blocks | Status |
 |----|-----------|--------|--------|


### PR DESCRIPTION
## What

`docs/BUILD-HEALTH.md` claimed verification against `f7d462a0`, four merges behind. Re-ran the verifier on `d81f0859` and corrected the claim. One line of substance, plus a paragraph recording what the integration run settles.

## The runs

All three modes, each exit 0 and each reporting `reality matches docs/BUILD-HEALTH.md`:

| Mode | Command | Result |
|------|---------|--------|
| default | `mvn -o clean test -fae` | no drift |
| `--install` | `mvn -o clean install -fae` | no drift |
| `--integration` | `mvn -o clean test -fae -Pintegration` | no drift, against Docker Engine 29.7.2 |

Nothing **NEW**, nothing **RESOLVED**, nothing **SKIPPED**, in any mode. **No entry moved** — B6 stays open as workaround-only and every resolved entry stays resolved.

## Why the integration run is the part worth recording

The document already carried a warning that `chat-shell` passing by default means its tests did not run, because #32 put the container-backed tests behind the `integration` profile — roughly 160 tests outside a plain build. That warning is what kept the table from being misread as progress.

The `--integration` run answers the question the warning left open. It passes with no module failing and none skipped, so `chat-shell` passes on its own merits rather than by exclusion, and B2 holds up under the conditions that originally broke it. `KNOWN_FAILING_INSTALL` and `KNOWN_FAILING_INTEGRATION` are empty by measurement now, not by assumption.

## Found while verifying, not addressed here

- **CHAT-wovtjjoq is stale.** It lists `chat-webflux` `LongTopicRestTests` as two long-standing failures and `chat-authorization-server` as missing the `server_keycert.jwk` fixture. Both pass — the jwk by #36, which generates the key per run rather than relying on someone having run `gen-dckeys.sh` by hand. Recorded on CHAT-cikgeefc; that issue was left alone.
- **The verifier deletes its maven log on success.** A green run leaves the verdict and nothing else — no test counts, no per-module detail. Deliberate, and it keeps the output readable, but it does mean a "matches" result cannot be re-examined after the fact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
