### PR TITLE
docs: say why chat-shell reports 17 skipped under -Pintegration

### DIFF
--- a/docs/BUILD-HEALTH.md
+++ b/docs/BUILD-HEALTH.md
@@ -24,6 +24,8 @@ Note what the default run no longer covers. Since #32 the container-backed tests
 
 The `--integration` run is what settles that question, and it now passes with no module failing and none skipped. So `chat-shell` passes on its own merits, not by exclusion, and B2 holds up with containers running. Both remaining lists in the verifier — `KNOWN_FAILING_INSTALL` and `KNOWN_FAILING_INTEGRATION` — are empty and measured, not assumed.
 
+Read the `chat-shell` skip count with care. A `-Pintegration` run of that module reports 36 tests with 17 skipped, which looks like absent coverage and is not. Each `@Disabled` sits on a generic base class — `ShellUserCommandsTests`, `ShellLoginCommandsTests`, `ShellTopicCommandsTests` — and surefire discovers those as test classes in their own right and reports them skipped. JUnit does not inherit `@Disabled`, so the concrete `Long*` subclass runs. The 19 that do run include every container-backed one, against the singleton container `ShellIntegrationTestBase` starts from the `chat-deploy-memory-integration-test` image.
+
 | ID | Deficiency | Blocks | Status |
 |----|-----------|--------|--------|
 | B6 | Stale `target/` across branch switches produces phantom results | correctness of any non-clean run | Workaround only |


### PR DESCRIPTION
Follow-up to #45, found while closing out CHAT-wovtjjoq.

## What

A `-Pintegration` run of `chat-shell` reports **36 tests, 17 skipped**. That reads as absent coverage, and #45 asserts the opposite — that the integration run is what proves `chat-shell` passes on its own merits rather than by exclusion. Both are true, but only if you know why the number is what it is. This adds that paragraph.

## Why the count is misleading

Every `@Disabled` in that module sits on a **generic base class** — `ShellUserCommandsTests<T>`, `ShellLoginCommandsTests<T>`, `ShellTopicCommandsTests<T>` — with a concrete subclass beside it:

```kotlin
@Tag("integration")
class LongUserCommandsTests : ShellUserCommandsTests<Long>()

@Disabled
@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
@Tag("integration")
open class ShellUserCommandsTests<T> : ShellIntegrationTestBase() { ... }
```

Surefire discovers the base as a test class in its own right and reports it skipped. JUnit's `@Disabled` is not `@Inherited`, so the concrete `Long*` subclass runs. The same tests are counted twice — once skipped as the base, once run as the subclass.

Per-class, from the run:

| Class | Run | Skipped |
|-------|-----|---------|
| `LongUserCommandsTests` | 8 | 0 |
| `LongLoginCommandsTests` | 5 | 0 |
| `LongShellTopicCommandsTests` | 3 | 0 |
| `ShellRequesterTests` | 2 | 0 |
| `ContextTest` | 1 | 0 |
| `ShellUserCommandsTests` (base) | — | 8 |
| `ShellLoginCommandsTests` (base) | — | 5 |
| `ShellTopicCommandsTests` (base) | — | 3 |
| `ShellContextTests` | — | 1 |

The 19 that run include every container-backed one, against the singleton container `ShellIntegrationTestBase` starts from the `chat-deploy-memory-integration-test` image.

## Why record it

The number invites the wrong fix. Someone reading 17 skips as a gap would go looking for tests to re-enable that are already running, and the obvious move — deleting the `@Disabled` from a base class — would make the generic base execute directly with an unresolved type parameter.

## Verified

`mvn -Ptest-build install` on `chat-deploy-memory-integration-test` builds the image in 15s against Docker Engine 29.7.2, and `mvn -o -pl chat-shell -Pintegration test` is green against it — which exercises B2's wait-strategy fix rather than merely confirming the code is present. That was the last open item on CHAT-wovtjjoq; the issue is closed, no code change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
