### PR TITLE
fix: make the redis backend a composition root that starts

### DIFF
--- a/chat-deploy-redis/pom.xml
+++ b/chat-deploy-redis/pom.xml
@@ -34,12 +34,41 @@
         </dependency>
         <dependency>
             <groupId>com.demo</groupId>
-            <artifactId>chat-service-controller</artifactId>
+            <artifactId>chat-service-composite</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <!-- The shared deploy layer: root key initialisation, initial users and
+             the EmptyMessageUtil the composite services need. chat-deploy-memory
+             and chat-deploy-cassandra both carry it; this module did not, so it
+             was a composition root missing part of the composition. -->
+        <dependency>
+            <groupId>com.demo</groupId>
+            <artifactId>chat-deploy</artifactId>
             <version>0.0.1</version>
         </dependency>
         <dependency>
             <groupId>com.demo</groupId>
-            <artifactId>chat-client-rsocket</artifactId>
+            <artifactId>shared-deploy-configuration</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <!-- Redis provides key, persistence and pubsub. It provides no index
+             and no secrets store, so the two selectors this backend is launched
+             with - index=lucene, secrets=memory - need their providers here.
+             Without them the context fails on SecretsStoreBeans and
+             IndexServiceBeans rather than falling back to anything. -->
+        <dependency>
+            <groupId>com.demo</groupId>
+            <artifactId>chat-index-lucene</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.demo</groupId>
+            <artifactId>chat-persistence-memory</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.demo</groupId>
+            <artifactId>chat-service-controller</artifactId>
             <version>0.0.1</version>
         </dependency>
         <dependency>
@@ -115,7 +144,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <mainClass>com.demo.chat.deploy.redis.App</mainClass>
+                    <mainClass>com.demo.chat.ChatApp</mainClass>
                 </configuration>
             </plugin>
             <plugin>

--- a/chat-deploy-redis/src/main/kotlin/com/demo/chat/config/deploy/redis/RedisAppConfiguration.kt
+++ b/chat-deploy-redis/src/main/kotlin/com/demo/chat/config/deploy/redis/RedisAppConfiguration.kt
@@ -1,0 +1,28 @@
+package com.demo.chat.config.deploy.redis
+
+import com.demo.chat.domain.IndexSearchRequest
+import com.demo.chat.domain.IndexSearchRequestConverters
+import com.demo.chat.domain.RequestToQueryConverters
+import org.springframework.boot.autoconfigure.jackson.JacksonAutoConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.web.reactive.config.EnableWebFlux
+
+/**
+ * The redis backend's half of the composition, mirroring
+ * `ChatAppConfiguration` in chat-deploy-memory and `CassandraAppConfiguration`
+ * in chat-deploy-cassandra.
+ *
+ * The query converter type follows the index, not the persistence: this backend
+ * indexes with Lucene, which queries by [IndexSearchRequest], so it takes the
+ * same converters memory does. Cassandra differs because its index queries by
+ * `Map<String, String>`.
+ */
+@Configuration(proxyBeanMethods = false)
+@Import(JacksonAutoConfiguration::class)
+@EnableWebFlux
+class RedisAppConfiguration {
+    @Bean
+    fun requestToQueryConverters(): RequestToQueryConverters<IndexSearchRequest> = IndexSearchRequestConverters()
+}

--- a/chat-deploy-redis/src/main/kotlin/com/demo/chat/deploy/redis/App.kt
+++ b/chat-deploy-redis/src/main/kotlin/com/demo/chat/deploy/redis/App.kt
@@ -1,5 +1,0 @@
-package com.demo.chat.deploy.redis
-
-class App {
-
-}

--- a/chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisDeployBootTests.kt
+++ b/chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisDeployBootTests.kt
@@ -1,6 +1,5 @@
 package com.demo.chat.test.deploy.redis
 
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,19 +22,27 @@ import java.time.Duration
  * secrets=memory, composite + auth, all controllers) against a
  * Testcontainers Redis.
  *
- * DISABLED: with the current classpath the context fails to start with
- * `NoSuchBeanDefinitionException: No qualifying bean of type
- * 'com.demo.chat.config.IndexServiceBeans<?, ?, ?>'` — index=lucene is
- * selected (matchIfMissing) but chat-index-lucene is not a dependency of
- * chat-deploy-redis, and secrets=memory likewise has no provider
- * (chat-persistence-memory absent). This is the known gap the
- * redis-backend profile wiring plan closes
- * (.hermes/plans/2026-08-21_141027-redis-backend-profile-wiring.md,
- * Tasks 1 + 2). Re-enable after those tasks (switching
- * `app.service.core.secrets` to `redis`) — this test is the boot proof
- * for that work.
+ * Enabled. It was disabled while the classpath could not satisfy those
+ * flags, and re-enabling it is what drove the six gaps below out into the
+ * open, one boot failure at a time. Keep it enabled: it is the only thing
+ * standing between this backend and silently rotting again.
  *
- * Boot bugs this test caught and that are now fixed in main code:
+ * Gaps it exposed, in the order the context hit them:
+ * 1. secrets=memory had no provider — chat-persistence-memory absent.
+ * 2. index=lucene had no provider — chat-index-lucene absent.
+ * 3. Memory and redis both ship a `KeyGenConfiguration`, ungated, sharing
+ *    a simple class name. With both on one classpath the context failed on
+ *    a conflicting bean definition. Each is now gated on the key selector.
+ * 4. EmptyMessageUtil had no provider — chat-deploy absent, so this
+ *    composition root was missing the shared deploy layer entirely.
+ * 5. RequestToQueryConverters had no provider — every other backend module
+ *    has an AppConfiguration supplying it and this one had none.
+ * 6. chat-client-rsocket was on the classpath of a server deployment,
+ *    which made `app.rsocket.transport.security.type` mandatory. Nothing
+ *    needed the client; it is gone, and chat-service-composite, which had
+ *    been arriving through it, is now declared directly.
+ *
+ * Boot bugs this test caught earlier and that are fixed in main code:
  * 1. ConfigurationPropertiesRedisTopics declared @ConstructorBinding on a
  *    constructor with default arguments — Kotlin copies the annotation
  *    onto the synthetic no-args constructor and the binder rejects it
@@ -49,6 +56,8 @@ import java.time.Duration
  */
 @TestPropertySource(
     properties = [
+        // chat-build always passes this; the deployment event listeners read it.
+        "spring.application.name=redis-boot-test",
         "spring.main.web-application-type=reactive",
         "server.port=0",
         "spring.rsocket.server.port=0",
@@ -75,7 +84,6 @@ import java.time.Duration
     ]
 )
 @SpringBootTest(classes = [RedisDeployBootTests.BootApp::class], webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@Disabled
 @Tag("integration")
 class RedisDeployBootTests {
 

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt
@@ -9,7 +9,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.*
 
-@Configuration
+// One key generator per deployment. The selector that picks the key
+// backend picks its generator too, so exactly one of these registers.
+// Ungated they all registered, and two of them share this simple class
+// name - a classpath carrying both failed to start on a conflicting bean
+// definition rather than on anything meaningful. Cassandra is the one that differs: its uuid generator is CassandraUUIDKeyGenerator.
+@Configuration("cassandraKeyGenConfiguration")
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "cassandra")
 class KeyGenConfiguration {
 
     // enforce number on nodeid

--- a/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt
+++ b/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt
@@ -9,7 +9,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import java.util.*
 
-@Configuration
+// One key generator per deployment. The selector that picks the key
+// backend picks its generator too, so exactly one of these registers.
+// Ungated they all registered, and two of them share this simple class
+// name - a classpath carrying both failed to start on a conflicting bean
+// definition rather than on anything meaningful. Memory keeps matchIfMissing so an unset selector still boots.
+@Configuration("memoryKeyGenConfiguration")
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "memory", matchIfMissing = true)
 class KeyGenConfiguration {
     // enforce number on nodeid
     @Value("\${app.nodeid:0}")

--- a/chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt
+++ b/chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt
@@ -13,7 +13,13 @@ import java.util.*
  * Provides the [IKeyGenerator] bean for Redis deployments, mirroring the
  * memory/cassandra modules. Selected by `app.key.type` (uuid | long).
  */
-@Configuration
+// One key generator per deployment. The selector that picks the key
+// backend picks its generator too, so exactly one of these registers.
+// Ungated they all registered, and two of them share this simple class
+// name - a classpath carrying both failed to start on a conflicting bean
+// definition rather than on anything meaningful. Redis is selected explicitly or not at all.
+@Configuration("redisKeyGenConfiguration")
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "redis")
 class KeyGenConfiguration {
     // enforce number on nodeid
     @Value("\${app.nodeid:0}")


### PR DESCRIPTION
Closes the last open item on CHAT-ubmrxyqo.

## The finding was understated

The issue recorded it as *"the `redis-backend` profile is empty so `--redis` silently yields a memory deployment."* That profile is gone — #42 made `chat-deploy-<backend>` the only composition root — and `chat-build --redis` now emits exactly the right selectors:

```
-Dapp.service.core.key=redis
-Dapp.service.core.persistence=redis
-Dapp.service.core.pubsub=redis-pubsub
-Dapp.service.core.index=lucene
-Dapp.service.core.secrets=memory
```

It emits them at a module that cannot satisfy them. The deployment does not quietly become memory. **It does not start at all.** `RedisDeployBootTests` was `@Disabled` for that reason, which is precisely why nothing was saying so.

## Method

Re-enabled the boot proof and let each failure name the next gap, rather than reasoning about what a redis classpath ought to contain. Six, in the order the context hit them:

| # | Failure | Cause |
|---|---------|-------|
| 1 | `No qualifying bean of type SecretsStoreBeans` | `secrets=memory`, `chat-persistence-memory` absent |
| 2 | `No qualifying bean of type IndexServiceBeans` | `index=lucene`, `chat-index-lucene` absent |
| 3 | `ConflictingBeanDefinitionException: keyGenConfiguration` | memory and redis both ship an ungated `KeyGenConfiguration` sharing a simple class name |
| 4 | `No qualifying bean of type EmptyMessageUtil` | `chat-deploy` was not a dependency — the composition root had no shared deploy layer |
| 5 | `No qualifying bean of type RequestToQueryConverters` | every other backend module has an `AppConfiguration` supplying one; this had none |
| 6 | `Could not resolve placeholder 'app.rsocket.transport.security.type'` | `chat-client-rsocket` on a *server* deployment's classpath |

Redis supplies key, persistence and pubsub and nothing else, so 1 and 2 are dependencies now. For 3, each backend's `KeyGenConfiguration` is gated on `app.service.core.key` so exactly one registers, with a distinct bean name; memory keeps `matchIfMissing` so an unset selector still boots, and cassandra keeps its own generator — its uuid path is `CassandraUUIDKeyGenerator`, so it is not a duplicate. For 5, the converter type follows the **index**, not the persistence: this backend indexes with Lucene, so it takes the `IndexSearchRequest` converters memory uses, while cassandra's index queries by `Map<String, String>`.

For 6, no deploy module needs the rsocket client — memory, cassandra and kafka carry no such dependency. Removing it also removed `chat-service-composite`, which had been arriving transitively; it is now declared directly, as in `chat-deploy-memory`. Note the property that failure was about is *required and rejects unknown values*, which is correct behaviour: it failed loudly rather than defaulting to unprotected.

## Also: the main class was a stub

```xml
<mainClass>com.demo.chat.deploy.redis.App</mainClass>
```

```kotlin
package com.demo.chat.deploy.redis

class App {

}
```

`--redis --run` could not have started even with the wiring fixed. The pom now names `ChatApp`, which `chat-deploy` provides, and the stub is deleted.

## Verified

`RedisDeployBootTests` passes against a Testcontainers Redis and is no longer disabled — the context wires and starts.

The full verifier, both modes, after the changes:

| Mode | Result |
|------|--------|
| `./shell-scripts/build-health.sh` | exit 0, no drift |
| `./shell-scripts/build-health.sh --integration` | exit 0, no drift |

Nothing NEW, nothing RESOLVED, nothing SKIPPED. The `KeyGenConfiguration` gating touches memory and cassandra as well as redis, so that whole-tree run is the check that matters here, not the redis module alone.

## Worth a reviewer's attention

The gating change means a deployment that sets `app.service.core.key` to a backend whose module is absent now gets **no** key generator and fails, where previously an ungated config might have supplied one by accident. That is the intended direction — the selector should decide — but it is a real behaviour change for any launch relying on the accident.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D6snUGzLd8dhdCr4sueiiy
