### PR TITLE
Drop JSON wrapper from user, topic, membership types

### DIFF
--- a/chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt
@@ -1,11 +1,8 @@
 package com.demo.chat.domain
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 import java.util.*
 
-@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
-@JsonTypeName("topic")
 interface MessageTopic<T> : KeyValuePair<T, String> {
     companion object Factory {
         fun <T> create(key: Key<T>, name: String) = object : MessageTopic<T> {

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt
@@ -1,15 +1,10 @@
 package com.demo.chat.domain
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeName
-
 // I'd like to make memberships cross relational in the chat domain, thus
 // I've parameterized the types for Member, and Member-Of
 // Database Key = DK
 // Member Key = MK
 // topic Key = TK
-@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
-@JsonTypeName("membership")
 interface TopicMembership<T> {
     val key: T   // Key<T> !!!
     val memberOf: T

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/User.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/User.kt
@@ -1,12 +1,8 @@
 package com.demo.chat.domain
 
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeName
 import java.time.Instant
 import java.util.*
 
-@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
-@JsonTypeName("user")
 interface User<T> : KeyBearer<T> {
     val name: String
     val handle: String

--- a/chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt
@@ -1,0 +1,46 @@
+package com.demo.chat.test.serializers
+
+import com.demo.chat.config.DefaultChatJacksonModules
+import com.demo.chat.domain.Key
+import com.demo.chat.domain.MessageTopic
+import com.demo.chat.domain.TopicMembership
+import com.demo.chat.domain.User
+import com.demo.chat.test.TestBase
+import com.fasterxml.jackson.databind.JsonNode
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class DomainWireShapeTests : TestBase() {
+
+    private fun shapeNode(obj: Any): JsonNode {
+        mapper.apply { registerModules(DefaultChatJacksonModules().allModules()) }
+        return mapper.readTree(mapper.writeValueAsString(obj))
+    }
+
+    @Test
+    fun `User serialises flat without the user wrapper`() {
+        val node = shapeNode(User.create(Key.funKey(1L), "MOON", "LUNA", "http://"))
+        Assertions.assertFalse(node.has("user"), "User must not carry the user wrapper")
+        Assertions.assertEquals("MOON", node.get("name").asText())
+        Assertions.assertEquals("LUNA", node.get("handle").asText())
+        Assertions.assertEquals("http://", node.get("imageUri").asText())
+        Assertions.assertTrue(node.get("key").has("key"), "Key must stay wrapped")
+    }
+
+    @Test
+    fun `TopicMembership serialises flat without the membership wrapper`() {
+        val node = shapeNode(TopicMembership.create(1L, 2L, 3L))
+        Assertions.assertFalse(node.has("membership"), "TopicMembership must not carry the membership wrapper")
+        Assertions.assertEquals(1L, node.get("key").asLong())
+        Assertions.assertEquals(2L, node.get("member").asLong())
+        Assertions.assertEquals(3L, node.get("memberOf").asLong())
+    }
+
+    @Test
+    fun `MessageTopic serialises with the inherited keyValue wrapper`() {
+        val node = shapeNode(MessageTopic.create(Key.funKey(1L), "MOON"))
+        Assertions.assertTrue(node.has("keyValue"), "MessageTopic inherits the keyValue wrapper")
+        Assertions.assertFalse(node.has("topic"), "MessageTopic must not carry the topic wrapper")
+        Assertions.assertEquals("MOON", node.get("keyValue").get("data").asText())
+    }
+}

--- a/chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/KeyValuePersistenceRedis.kt
+++ b/chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/KeyValuePersistenceRedis.kt
@@ -4,8 +4,6 @@ import com.demo.chat.domain.Key
 import com.demo.chat.domain.KeyValuePair
 import com.demo.chat.service.core.IKeyService
 import com.demo.chat.service.core.KeyValueStore
-import com.fasterxml.jackson.annotation.JsonTypeInfo
-import com.fasterxml.jackson.annotation.JsonTypeName
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
 import reactor.core.publisher.Flux
@@ -78,57 +76,11 @@ class KeyValuePersistenceRedis<T>(
         Flux.fromIterable(keys).flatMap { key -> get(key) }
 
     override fun <E> typedGet(key: Key<T>, typeArgument: Class<E>): Mono<KeyValuePair<T, E>> =
-        get(key).map { kv -> KeyValuePair.create(kv.key, rebind(kv.data, typeArgument)) }
+        get(key).map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typeArgument)) }
 
     override fun <E> typedAll(typeArgument: Class<E>): Flux<KeyValuePair<T, E>> =
-        all().map { kv -> KeyValuePair.create(kv.key, rebind(kv.data, typeArgument)) }
+        all().map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typeArgument)) }
 
     override fun <E> typedByIds(ids: List<Key<T>>, typedArgument: Class<E>): Flux<KeyValuePair<T, E>> =
-        byIds(ids).map { kv -> KeyValuePair.create(kv.key, rebind(kv.data, typedArgument)) }
-
-    /**
-     * Re-binds the untyped `data` of a stored pair to [type].
-     *
-     * The round trip is asymmetric for polymorphic domain types, which is why
-     * a plain `convertValue` is not enough. Serialising a `User` on its own
-     * writes the type wrapper its `@JsonTypeInfo(WRAPPER_OBJECT)` declares:
-     *
-     *     {"user":{"name":"alice",...}}
-     *
-     * but as the `data` of a KeyValuePair it is written through the erased
-     * type parameter `E`, so no wrapper is emitted:
-     *
-     *     {"keyValue":{"key":{...},"data":{"name":"alice",...}}}
-     *
-     * Reading back gives a flat Map. Handing that to `convertValue` makes
-     * Jackson read the first property name as a type id and fail with
-     * "Could not resolve type id 'name' as a subtype of User".
-     *
-     * So when the target type declares a WRAPPER_OBJECT type name and the
-     * stored value does not already carry it, put it back before converting.
-     * Types without polymorphic annotations - String, Int, plain data classes -
-     * convert directly, unchanged.
-     *
-     * This is a workaround, not the fix. The cause is that the domain
-     * interfaces carry @JsonTypeInfo uniformly while chat-core also registers
-     * custom deserializers for the same types; for User the wrapper feeds
-     * nothing but Jackson's own type machinery. Removing it makes this method
-     * unnecessary - verified - but changes the REST wire format, which
-     * LongUserRestTests pins at $.user.name. Tracked as CHAT-gjggodpa; delete
-     * this helper when that lands.
-     */
-    private fun <E> rebind(data: Any?, type: Class<E>): E {
-        val typeInfo = type.getAnnotation(JsonTypeInfo::class.java)
-        val typeName = type.getAnnotation(JsonTypeName::class.java)?.value
-        val needsWrapper = typeInfo != null &&
-            typeInfo.include == JsonTypeInfo.As.WRAPPER_OBJECT &&
-            typeName != null &&
-            data is Map<*, *> &&
-            !data.containsKey(typeName)
-
-        return objectMapper.convertValue(
-            if (needsWrapper) mapOf(typeName to data) else data,
-            type,
-        )
-    }
+        byIds(ids).map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typedArgument)) }
 }

--- a/chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisKeyValueTypedDomainTests.kt
+++ b/chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisKeyValueTypedDomainTests.kt
@@ -43,7 +43,7 @@ class RedisKeyValueTypedDomainTests(
     }
 
     @Test
-    fun `typedGet rebinds a domain object stored as data`() {
+    fun `typedGet converts a domain object stored as data`() {
         val key = Key.funKey(UUID.randomUUID())
         val user = User.create(Key.funKey(UUID.randomUUID()), "alice", "alice", "http://img")
         keyValuePersistence.add(KeyValuePair.create(key, user)).block()
@@ -55,7 +55,7 @@ class RedisKeyValueTypedDomainTests(
     }
 
     @Test
-    fun `typedAll and typedByIds rebind domain objects`() {
+    fun `typedAll and typedByIds convert domain objects`() {
         val key = Key.funKey(UUID.randomUUID())
         val user = User.create(Key.funKey(UUID.randomUUID()), "bob", "bob", "http://img")
         keyValuePersistence.add(KeyValuePair.create(key, user)).block()

--- a/chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/TopicRestTestBase.kt
+++ b/chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/TopicRestTestBase.kt
@@ -126,7 +126,7 @@ open class TopicRestTestBase<T>(
                     SpringCloudContractRestDocs.dslContract()
                 )
             )
-            .jsonPath("\$.[0].topic.data").isNotEmpty
+            .jsonPath("\$.[0].keyValue.data").isNotEmpty
     }
 
     @Test
@@ -153,7 +153,7 @@ open class TopicRestTestBase<T>(
                     SpringCloudContractRestDocs.dslContract()
                 )
             )
-            .jsonPath("\$.topic.data").isNotEmpty
+            .jsonPath("\$.keyValue.data").isNotEmpty
     }
 
     @Test
@@ -180,7 +180,7 @@ open class TopicRestTestBase<T>(
                     SpringCloudContractRestDocs.dslContract()
                 )
             )
-            .jsonPath("\$.topic.data").isNotEmpty
+            .jsonPath("\$.keyValue.data").isNotEmpty
     }
 
     @Test

--- a/chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt
+++ b/chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt
@@ -106,7 +106,7 @@ open class UserRestTestBase<T>(
                     SpringCloudContractRestDocs.dslContract()
                 )
             )
-            .jsonPath("$.[0].user.name").isNotEmpty
+            .jsonPath("$.[0].name").isNotEmpty
     }
 
     @Test
@@ -132,6 +132,6 @@ open class UserRestTestBase<T>(
                     SpringCloudContractRestDocs.dslContract()
                 )
             )
-            .jsonPath("$.user.name").isNotEmpty
+            .jsonPath("$.name").isNotEmpty
     }
 }

--- a/docs/superpowers/plans/2026-08-25-domain-serialization.md
+++ b/docs/superpowers/plans/2026-08-25-domain-serialization.md
@@ -41,7 +41,7 @@ Observed post-change shapes (verified by spike):
 
 Note: `MessageTopic` extends `KeyValuePair`, which keeps its own `@JsonTypeInfo`. Once `MessageTopic` loses its annotation, Jackson annotation inheritance applies the `KeyValuePair` wrapper. So `MessageTopic` is NOT flat. It carries the `keyValue` wrapper. The test asserts this.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 Create `chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt`:
 
@@ -94,12 +94,12 @@ class DomainWireShapeTests : TestBase() {
 }
 ```
 
-- [ ] **Step 2: Run the test to verify it fails**
+- [x] **Step 2: Run the test to verify it fails**
 
 Run: `mvn -o -pl chat-core test -Dtest=DomainWireShapeTests`
 Expected: FAIL. The three tests fail because the current shapes carry the old wrappers (`user`, `topic`, `membership`).
 
-- [ ] **Step 3: Remove the annotations from User.kt**
+- [x] **Step 3: Remove the annotations from User.kt**
 
 In `chat-core/src/main/kotlin/com/demo/chat/domain/User.kt`, remove the two imports and the two annotations.
 
@@ -123,7 +123,7 @@ import java.util.*
 interface User<T> : KeyBearer<T> {
 ```
 
-- [ ] **Step 4: Remove the annotations from MessageTopic.kt**
+- [x] **Step 4: Remove the annotations from MessageTopic.kt**
 
 In `chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt`, remove the `JsonTypeInfo` import and the two annotations. KEEP the `JsonTypeName` import. The data classes `TopicMetaData`, `TopicMember`, `TopicMemberships` use it.
 
@@ -146,7 +146,7 @@ import java.util.*
 interface MessageTopic<T> : KeyValuePair<T, String> {
 ```
 
-- [ ] **Step 5: Remove the annotations from TopicMembership.kt**
+- [x] **Step 5: Remove the annotations from TopicMembership.kt**
 
 In `chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt`, remove the two imports and the two annotations.
 
@@ -175,17 +175,17 @@ After:
 interface TopicMembership<T> {
 ```
 
-- [ ] **Step 6: Run the wire-shape tests to verify they pass**
+- [x] **Step 6: Run the wire-shape tests to verify they pass**
 
 Run: `mvn -o -pl chat-core test -Dtest=DomainWireShapeTests`
 Expected: PASS. All three tests pass.
 
-- [ ] **Step 7: Run the full chat-core suite**
+- [x] **Step 7: Run the full chat-core suite**
 
 Run: `mvn -o -pl chat-core test`
 Expected: 43 tests pass. No new failures. The existing round-trip tests (`UserSerliazerTests`, `TopicSerializerTests`, `TopicMembershipSerializerTests`) still pass because the custom deserializers read the flat shape.
 
-- [ ] **Step 8: Commit**
+- [x] **Step 8: Commit**
 
 ```bash
 git add chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt \

--- a/docs/superpowers/plans/2026-08-25-domain-serialization.md
+++ b/docs/superpowers/plans/2026-08-25-domain-serialization.md
@@ -1,0 +1,365 @@
+# Domain Serialization: Drop the Dead Wrapper — Implementation Plan
+
+> **For agentic workers:** Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Project rule: no sub-agent driven development.
+
+**Goal:** Remove the dead `@JsonTypeInfo(WRAPPER_OBJECT)` wrapper from `User`, `MessageTopic`, and `TopicMembership`. Delete the redis `rebind` workaround. Update the REST contract test.
+
+**Architecture:** Drop the two annotations from the three no-subtype domain interfaces. The custom deserializers already read the flat shape, so they stay. Delete `rebind` in `KeyValuePersistenceRedis` and use plain `convertValue`. Update the REST test assertions and add wire-shape tests that pin the new format.
+
+**Tech Stack:** Kotlin, Jackson, Spring Boot, JUnit 5, AssertJ, Maven, Testcontainers (redis).
+
+**Spec:** `docs/superpowers/specs/2026-08-25-domain-serialization-design.md`
+
+## Global Constraints
+
+- Run `mvn -o -pl chat-core,<module> test`. Never `-pl <module>` alone.
+- Keep the annotations on `Key`, `Message`, `KeyValuePair`. They have subtypes.
+- Do not touch the six E2EE types in `EncryptedEnvelope.kt`.
+- Do not touch `RequestResponse`. It uses `As.PROPERTY`, a different mechanism.
+- Controlled English for new prose and comments.
+- Expected counts: chat-core 43, chat-client-rsocket 57, chat-persistence-redis 46. chat-webflux has 2 pre-existing failures. No new failures.
+- Drift discipline: check bindings before editing covered files. Update prose first, then `drift link`.
+
+---
+
+### Task 1: Drop the annotations from the three domain types
+
+**Files:**
+- Create: `chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt`
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/domain/User.kt`
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt`
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt`
+
+**Interfaces:**
+- Consumes: `TestBase.mapper`, `DefaultChatJacksonModules().allModules()`, `User.create`, `MessageTopic.create`, `TopicMembership.create`, `Key.funKey`.
+- Produces: flat wire shapes for the three types. Task 2 and Task 3 rely on the new shapes.
+
+Observed post-change shapes (verified by spike):
+- `User`: `{"name":"MOON","key":{"key":{"id":1,"empty":false}},"handle":"LUNA","timestamp":...,"imageUri":"http://"}`
+- `MessageTopic`: `{"keyValue":{"key":{"key":{"id":1,"empty":false}},"data":"MOON"}}`
+- `TopicMembership`: `{"key":1,"memberOf":3,"member":2}`
+
+Note: `MessageTopic` extends `KeyValuePair`, which keeps its own `@JsonTypeInfo`. Once `MessageTopic` loses its annotation, Jackson annotation inheritance applies the `KeyValuePair` wrapper. So `MessageTopic` is NOT flat. It carries the `keyValue` wrapper. The test asserts this.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt`:
+
+```kotlin
+package com.demo.chat.test.serializers
+
+import com.demo.chat.config.DefaultChatJacksonModules
+import com.demo.chat.domain.Key
+import com.demo.chat.domain.MessageTopic
+import com.demo.chat.domain.TopicMembership
+import com.demo.chat.domain.User
+import com.demo.chat.test.TestBase
+import com.fasterxml.jackson.databind.JsonNode
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class DomainWireShapeTests : TestBase() {
+
+    private fun shapeNode(obj: Any): JsonNode {
+        mapper.apply { registerModules(DefaultChatJacksonModules().allModules()) }
+        return mapper.readTree(mapper.writeValueAsString(obj))
+    }
+
+    @Test
+    fun `User serialises flat without the user wrapper`() {
+        val node = shapeNode(User.create(Key.funKey(1L), "MOON", "LUNA", "http://"))
+        Assertions.assertFalse(node.has("user"), "User must not carry the user wrapper")
+        Assertions.assertEquals("MOON", node.get("name").asText())
+        Assertions.assertEquals("LUNA", node.get("handle").asText())
+        Assertions.assertEquals("http://", node.get("imageUri").asText())
+        Assertions.assertTrue(node.get("key").has("key"), "Key must stay wrapped")
+    }
+
+    @Test
+    fun `TopicMembership serialises flat without the membership wrapper`() {
+        val node = shapeNode(TopicMembership.create(1L, 2L, 3L))
+        Assertions.assertFalse(node.has("membership"), "TopicMembership must not carry the membership wrapper")
+        Assertions.assertEquals(1L, node.get("key").asLong())
+        Assertions.assertEquals(2L, node.get("member").asLong())
+        Assertions.assertEquals(3L, node.get("memberOf").asLong())
+    }
+
+    @Test
+    fun `MessageTopic serialises with the inherited keyValue wrapper`() {
+        val node = shapeNode(MessageTopic.create(Key.funKey(1L), "MOON"))
+        Assertions.assertTrue(node.has("keyValue"), "MessageTopic inherits the keyValue wrapper")
+        Assertions.assertFalse(node.has("topic"), "MessageTopic must not carry the topic wrapper")
+        Assertions.assertEquals("MOON", node.get("keyValue").get("data").asText())
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `mvn -o -pl chat-core test -Dtest=DomainWireShapeTests`
+Expected: FAIL. The three tests fail because the current shapes carry the old wrappers (`user`, `topic`, `membership`).
+
+- [ ] **Step 3: Remove the annotations from User.kt**
+
+In `chat-core/src/main/kotlin/com/demo/chat/domain/User.kt`, remove the two imports and the two annotations.
+
+Before:
+```kotlin
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import java.time.Instant
+import java.util.*
+
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName("user")
+interface User<T> : KeyBearer<T> {
+```
+
+After:
+```kotlin
+import java.time.Instant
+import java.util.*
+
+interface User<T> : KeyBearer<T> {
+```
+
+- [ ] **Step 4: Remove the annotations from MessageTopic.kt**
+
+In `chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt`, remove the `JsonTypeInfo` import and the two annotations. KEEP the `JsonTypeName` import. The data classes `TopicMetaData`, `TopicMember`, `TopicMemberships` use it.
+
+Before:
+```kotlin
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+import java.util.*
+
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName("topic")
+interface MessageTopic<T> : KeyValuePair<T, String> {
+```
+
+After:
+```kotlin
+import com.fasterxml.jackson.annotation.JsonTypeName
+import java.util.*
+
+interface MessageTopic<T> : KeyValuePair<T, String> {
+```
+
+- [ ] **Step 5: Remove the annotations from TopicMembership.kt**
+
+In `chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt`, remove the two imports and the two annotations.
+
+Before:
+```kotlin
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+
+// I'd like to make memberships cross relational in the chat domain, thus
+// I've parameterized the types for Member, and Member-Of
+// Database Key = DK
+// Member Key = MK
+// topic Key = TK
+@JsonTypeInfo(include = JsonTypeInfo.As.WRAPPER_OBJECT, use = JsonTypeInfo.Id.NAME)
+@JsonTypeName("membership")
+interface TopicMembership<T> {
+```
+
+After:
+```kotlin
+// I'd like to make memberships cross relational in the chat domain, thus
+// I've parameterized the types for Member, and Member-Of
+// Database Key = DK
+// Member Key = MK
+// topic Key = TK
+interface TopicMembership<T> {
+```
+
+- [ ] **Step 6: Run the wire-shape tests to verify they pass**
+
+Run: `mvn -o -pl chat-core test -Dtest=DomainWireShapeTests`
+Expected: PASS. All three tests pass.
+
+- [ ] **Step 7: Run the full chat-core suite**
+
+Run: `mvn -o -pl chat-core test`
+Expected: 43 tests pass. No new failures. The existing round-trip tests (`UserSerliazerTests`, `TopicSerializerTests`, `TopicMembershipSerializerTests`) still pass because the custom deserializers read the flat shape.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add chat-core/src/test/kotlin/com/demo/chat/test/serializers/DomainWireShapeTests.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/User.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt
+git commit -m "drop dead json wrapper from user, topic, membership"
+```
+
+---
+
+### Task 2: Delete the redis rebind workaround
+
+**Files:**
+- Modify: `chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/KeyValuePersistenceRedis.kt`
+
+**Interfaces:**
+- Consumes: `objectMapper.convertValue` (already a field on the class).
+- Produces: plain `convertValue` in `typedGet`, `typedAll`, `typedByIds`. No `rebind`.
+
+- [ ] **Step 1: Replace the three call sites**
+
+In `KeyValuePersistenceRedis.kt`, replace `rebind(...)` with `objectMapper.convertValue(...)` in the three typed accessors.
+
+Before:
+```kotlin
+    override fun <E> typedGet(key: Key<T>, typeArgument: Class<E>): Mono<KeyValuePair<T, E>> =
+        get(key).map { kv -> KeyValuePair.create(kv.key, rebind(kv.data, typeArgument)) }
+
+    override fun <E> typedAll(typeArgument: Class<E>): Flux<KeyValuePair<T, E>> =
+        all().map { kv -> KeyValuePair.create(kv.key, rebind(kv.data, typeArgument)) }
+
+    override fun <E> typedByIds(ids: List<Key<T>>, typedArgument: Class<E>): Flux<KeyValuePair<T, E>> =
+        byIds(ids).map { kv -> KeyValuePair.create(kv.key, rebind(kv.data, typedArgument)) }
+```
+
+After:
+```kotlin
+    override fun <E> typedGet(key: Key<T>, typeArgument: Class<E>): Mono<KeyValuePair<T, E>> =
+        get(key).map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typeArgument)) }
+
+    override fun <E> typedAll(typeArgument: Class<E>): Flux<KeyValuePair<T, E>> =
+        all().map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typeArgument)) }
+
+    override fun <E> typedByIds(ids: List<Key<T>>, typedArgument: Class<E>): Flux<KeyValuePair<T, E>> =
+        byIds(ids).map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typedArgument)) }
+```
+
+- [ ] **Step 2: Delete the rebind method and its KDoc**
+
+Delete the `rebind` method and its KDoc block (the `/** ... */` comment and the `private fun <E> rebind(...)` function). The class body ends at the closing brace after `typedByIds`.
+
+- [ ] **Step 3: Remove the now-unused imports**
+
+Remove the two imports that only `rebind` used:
+```kotlin
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+import com.fasterxml.jackson.annotation.JsonTypeName
+```
+
+- [ ] **Step 4: Run the redis suite including the integration typed domain test**
+
+Run: `mvn -o -pl chat-core,chat-persistence-redis test -Pintegration`
+Expected: the redis suite passes. The `RedisKeyValueTypedDomainTests` (typed domain test) passes with plain `convertValue`. It needs Docker for the Testcontainers Redis.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/KeyValuePersistenceRedis.kt
+git commit -m "delete redis rebind workaround"
+```
+
+---
+
+### Task 3: Update the REST contract test
+
+**Files:**
+- Modify: `chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt`
+
+**Interfaces:**
+- Consumes: the flat `User` wire shape from Task 1.
+- Produces: REST test assertions that match the flat shape.
+
+- [ ] **Step 1: Update the two jsonPath assertions**
+
+In `UserRestTestBase.kt`, update the two assertions that pin the old wrapper.
+
+In `should find user by name`, before:
+```kotlin
+            .jsonPath("$.[0].user.name").isNotEmpty
+```
+After:
+```kotlin
+            .jsonPath("$.[0].name").isNotEmpty
+```
+
+In `should find user by id`, before:
+```kotlin
+            .jsonPath("$.user.name").isNotEmpty
+```
+After:
+```kotlin
+            .jsonPath("$.name").isNotEmpty
+```
+
+- [ ] **Step 2: Run the webflux suite**
+
+Run: `mvn -o -pl chat-core,chat-webflux test`
+Expected: the 2 pre-existing failures stay. No new failures. `LongUserRestTests` passes with the updated assertions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt
+git commit -m "update rest contract to flat user shape"
+```
+
+---
+
+### Task 4: Update docs, create the E2EE follow-up, check drift
+
+**Files:**
+- Modify: `forward-register.md`
+- Create: E2EE follow-up issue (via `fp`)
+
+**Interfaces:**
+- Consumes: the completed change from Tasks 1-3.
+- Produces: updated forward register, E2EE follow-up issue, verified drift.
+
+- [ ] **Step 1: Update forward-register.md**
+
+Move `CHAT-gjggodpa` out of the deferred table. Record the E2EE follow-up issue. Note the `MessageTopic` inheritance outcome: it carries the `keyValue` wrapper, not flat.
+
+- [ ] **Step 2: Create the E2EE follow-up issue**
+
+Run:
+```bash
+fp issue create --title "Drop the dead json wrapper from the six e2ee types" --parent CHAT-gjggodpa
+```
+
+The six types: `DeviceRegistration`, `PreKeyBundle`, `EncryptedEnvelope`, `ConversationEpoch`, `FrankingTag`, `Presence` in `chat-core/src/main/kotlin/com/demo/chat/domain/EncryptedEnvelope.kt`.
+
+- [ ] **Step 3: Check drift bindings on the edited files**
+
+Run:
+```bash
+drift refs chat-core/src/main/kotlin/com/demo/chat/domain/User.kt
+drift refs chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt
+drift refs chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt
+drift refs chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/KeyValuePersistenceRedis.kt
+drift refs chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt
+```
+
+If any file has a binding and the prose is stale, update the prose first. Then refresh provenance with `drift link`. Verify with `drift check`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add forward-register.md
+git commit -m "record e2ee follow-up, update forward register"
+```
+
+---
+
+## Final verification
+
+Run the full build health:
+```bash
+./shell-scripts/build-health.sh --integration
+```
+Expected: no new failures beyond the 2 pre-existing chat-webflux failures.
+
+Attach the commits to the issue and mark it done:
+```bash
+fp issue assign CHAT-gjggodpa --rev <commit-shas>
+fp issue update --status done CHAT-gjggodpa
+```

--- a/docs/superpowers/plans/2026-08-25-domain-serialization.md
+++ b/docs/superpowers/plans/2026-08-25-domain-serialization.md
@@ -319,11 +319,11 @@ git commit -m "update rest contract to flat user and keyValue topic shapes"
 - Consumes: the completed change from Tasks 1-3.
 - Produces: updated forward register, E2EE follow-up issue, verified drift.
 
-- [ ] **Step 1: Update forward-register.md**
+- [x] **Step 1: Update forward-register.md**
 
 Move `CHAT-gjggodpa` out of the deferred table. Record the E2EE follow-up issue. Note the `MessageTopic` inheritance outcome: it carries the `keyValue` wrapper, not flat.
 
-- [ ] **Step 2: Create the E2EE follow-up issue**
+- [x] **Step 2: Create the E2EE follow-up issue**
 
 Run:
 ```bash
@@ -332,7 +332,7 @@ fp issue create --title "Drop the dead json wrapper from the six e2ee types" --p
 
 The six types: `DeviceRegistration`, `PreKeyBundle`, `EncryptedEnvelope`, `ConversationEpoch`, `FrankingTag`, `Presence` in `chat-core/src/main/kotlin/com/demo/chat/domain/EncryptedEnvelope.kt`.
 
-- [ ] **Step 3: Check drift bindings on the edited files**
+- [x] **Step 3: Check drift bindings on the edited files**
 
 Run:
 ```bash
@@ -345,7 +345,7 @@ drift refs chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/co
 
 If any file has a binding and the prose is stale, update the prose first. Then refresh provenance with `drift link`. Verify with `drift check`.
 
-- [ ] **Step 4: Commit**
+- [x] **Step 4: Commit**
 
 ```bash
 git add forward-register.md

--- a/docs/superpowers/plans/2026-08-25-domain-serialization.md
+++ b/docs/superpowers/plans/2026-08-25-domain-serialization.md
@@ -17,7 +17,7 @@
 - Do not touch the six E2EE types in `EncryptedEnvelope.kt`.
 - Do not touch `RequestResponse`. It uses `As.PROPERTY`, a different mechanism.
 - Controlled English for new prose and comments.
-- Expected counts: chat-core 43, chat-client-rsocket 57, chat-persistence-redis 46. chat-webflux has 2 pre-existing failures. No new failures.
+- Expected counts: chat-core 43, chat-client-rsocket 57, chat-persistence-redis 46. chat-webflux 81 tests, all pass. No new failures.
 - Drift discipline: check bindings before editing covered files. Update prose first, then `drift link`.
 
 ---
@@ -206,7 +206,7 @@ git commit -m "drop dead json wrapper from user, topic, membership"
 - Consumes: `objectMapper.convertValue` (already a field on the class).
 - Produces: plain `convertValue` in `typedGet`, `typedAll`, `typedByIds`. No `rebind`.
 
-- [ ] **Step 1: Replace the three call sites**
+- [x] **Step 1: Replace the three call sites**
 
 In `KeyValuePersistenceRedis.kt`, replace `rebind(...)` with `objectMapper.convertValue(...)` in the three typed accessors.
 
@@ -234,11 +234,11 @@ After:
         byIds(ids).map { kv -> KeyValuePair.create(kv.key, objectMapper.convertValue(kv.data, typedArgument)) }
 ```
 
-- [ ] **Step 2: Delete the rebind method and its KDoc**
+- [x] **Step 2: Delete the rebind method and its KDoc**
 
 Delete the `rebind` method and its KDoc block (the `/** ... */` comment and the `private fun <E> rebind(...)` function). The class body ends at the closing brace after `typedByIds`.
 
-- [ ] **Step 3: Remove the now-unused imports**
+- [x] **Step 3: Remove the now-unused imports**
 
 Remove the two imports that only `rebind` used:
 ```kotlin
@@ -246,12 +246,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo
 import com.fasterxml.jackson.annotation.JsonTypeName
 ```
 
-- [ ] **Step 4: Run the redis suite including the integration typed domain test**
+- [x] **Step 4: Run the redis suite including the integration typed domain test**
 
 Run: `mvn -o -pl chat-core,chat-persistence-redis test -Pintegration`
 Expected: the redis suite passes. The `RedisKeyValueTypedDomainTests` (typed domain test) passes with plain `convertValue`. It needs Docker for the Testcontainers Redis.
 
-- [ ] **Step 5: Commit**
+- [x] **Step 5: Commit**
 
 ```bash
 git add chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/KeyValuePersistenceRedis.kt
@@ -264,12 +264,13 @@ git commit -m "delete redis rebind workaround"
 
 **Files:**
 - Modify: `chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt`
+- Modify: `chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/TopicRestTestBase.kt`
 
 **Interfaces:**
-- Consumes: the flat `User` wire shape from Task 1.
-- Produces: REST test assertions that match the flat shape.
+- Consumes: the flat `User` wire shape and the `keyValue`-wrapped `MessageTopic` shape from Task 1.
+- Produces: REST test assertions that match the new shapes.
 
-- [ ] **Step 1: Update the two jsonPath assertions**
+- [x] **Step 1: Update the jsonPath assertions**
 
 In `UserRestTestBase.kt`, update the two assertions that pin the old wrapper.
 
@@ -291,16 +292,19 @@ After:
             .jsonPath("$.name").isNotEmpty
 ```
 
-- [ ] **Step 2: Run the webflux suite**
+Also update the three `topic.data` jsonPaths in `TopicRestTestBase.kt` to `keyValue.data`. `MessageTopic` now carries the inherited `keyValue` wrapper. The plan originally named only `UserRestTestBase.kt`; the `TopicRestTestBase.kt` change was found during execution.
+
+- [x] **Step 2: Run the webflux suite**
 
 Run: `mvn -o -pl chat-core,chat-webflux test`
-Expected: the 2 pre-existing failures stay. No new failures. `LongUserRestTests` passes with the updated assertions.
+Expected: all 81 tests pass. No failures. The suite was green before the change. The 5 failures seen mid-Task-3 (3 in `LongTopicRestTests`, 2 in `LongUserRestTests`) were caused by the Task 1 wrapper removal, not pre-existing.
 
-- [ ] **Step 3: Commit**
+- [x] **Step 3: Commit**
 
 ```bash
-git add chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt
-git commit -m "update rest contract to flat user shape"
+git add chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/UserRestTestBase.kt \
+        chat-webflux/src/test/kotlin/com/demo/chat/test/controller/webflux/composite/TopicRestTestBase.kt
+git commit -m "update rest contract to flat user and keyValue topic shapes"
 ```
 
 ---
@@ -356,7 +360,7 @@ Run the full build health:
 ```bash
 ./shell-scripts/build-health.sh --integration
 ```
-Expected: no new failures beyond the 2 pre-existing chat-webflux failures.
+Expected: no new failures. The chat-webflux suite is fully green (81 tests).
 
 Attach the commits to the issue and mark it done:
 ```bash

--- a/docs/superpowers/specs/2026-08-25-domain-serialization-design.md
+++ b/docs/superpowers/specs/2026-08-25-domain-serialization-design.md
@@ -1,0 +1,132 @@
+# Domain Serialization: Drop the Dead Wrapper
+
+Remove `@JsonTypeInfo(WRAPPER_OBJECT)` from the three domain types that declare no
+subtype. Delete the redis rebind workaround. Update the REST contract tests.
+
+Status: design, approved 2026-08-25. Issue: CHAT-gjggodpa.
+
+## The problem
+
+The chat domain interfaces carry `@JsonTypeInfo(WRAPPER_OBJECT)` and
+`@JsonTypeName` uniformly. chat-core also registers a custom `JsonDeserializer`
+for the same types. The two mechanisms overlap.
+
+For `User`, `MessageTopic` and `TopicMembership` the wrapper carries no
+polymorphism. None of the three declares a subtype. The wrapper feeds only
+Jackson's own type machinery.
+
+The round trip is asymmetric. A `User` serialised at root writes
+`{"user":{...}}`. As the `data` of a `KeyValuePair` it goes through the erased
+type parameter `E` and is written flat. Reading the flat form back makes Jackson
+read the first property name as a type id and fail.
+
+`KeyValuePersistenceRedis.rebind` hides that failure. It re-applies the declared
+wrapper before `convertValue`. The REST path makes the asymmetry systematic.
+`KVRequest.data` is `Any`. Every domain object posted over REST is stored flat.
+In-process writes keep the wrapper. Two writers, two formats, one store.
+
+## Decisions
+
+| # | Decision |
+|---|----------|
+| 1 | Drop the annotation from the three types with no subtypes |
+| 2 | The store is disposable: flush it, no migration, no compat shim |
+| 3 | Hard cut: no compat period, update the in-repo tests |
+| 4 | CHAT-ejhtsarb stays a separate issue |
+| 5 | The six E2EE types defer to a follow-up issue |
+
+## Design
+
+### Keep the wrapper where it is load-bearing
+
+`Key`, `Message` and `KeyValuePair` declare subtypes. Their wrappers are
+load-bearing. `KeyDeserializer` unwraps `node.get("key").get("key")`. The
+subtype ids select the concrete class. Keep the annotations on these three.
+
+### Drop the wrapper where it is dead weight
+
+Remove `@JsonTypeInfo` and `@JsonTypeName` from:
+
+- `User` in `chat-core/src/main/kotlin/com/demo/chat/domain/User.kt`
+- `MessageTopic` in `chat-core/src/main/kotlin/com/demo/chat/domain/MessageTopic.kt`
+- `TopicMembership` in `chat-core/src/main/kotlin/com/demo/chat/domain/TopicMembership.kt`
+
+The custom deserializers stay. They already read the flat shape.
+`UserDeserializer` reads `name`, `handle` and `imageUri` flat and unwraps only
+the `Key`. `TopicDeserializer` and `MembershipDeserializer` do the same. The
+`Key` wrapper stays, so their `node.get("key").get("key")` unwraps still hold.
+
+### Delete the workaround
+
+`rebind` exists only for the asymmetry. Delete the method. Use plain
+`convertValue` in `typedGet`, `typedAll` and `typedByIds`. Update the class KDoc
+that describes the asymmetry.
+
+### Update the REST contract
+
+`LongUserRestTests` pins the wrapper at `$.user.name` and `$.[0].user.name`.
+Update both to `$.name` and `$.[0].name`.
+
+## Wire format change
+
+| type | before | after |
+|------|--------|-------|
+| `User` | `{"user":{...}}` | `{...}` |
+| `TopicMembership` | `{"membership":{...}}` | `{...}` |
+| `MessageTopic` | `{"topic":{...}}` | see note |
+
+The change applies to REST responses and to stored JSON in redis, cassandra and
+memory. The store is disposable. Flush it. No migration.
+
+Note on `MessageTopic`: it extends `KeyValuePair`, which keeps its own
+`@JsonTypeInfo`. Once `MessageTopic` loses its annotation, Jackson annotation
+inheritance may apply the `KeyValuePair` wrapper instead of the `topic` wrapper.
+The exact resulting shape is not fixed by this spec. The implementation must
+assert it in a test and record the outcome here.
+
+## Verification state
+
+The verified experiment removed the annotation from `User` only. It passed:
+chat-core 43, chat-client-rsocket 57, chat-persistence-redis 46, with plain
+`convertValue` and no rebind.
+
+The `MessageTopic` and `TopicMembership` removals are not yet test-verified.
+The implementation must run the full suite after all three removals and confirm
+no new failures. Watch the `MessageTopic` inheritance note above.
+
+## What does not change
+
+- The custom deserializers for the three types
+- The annotations on `Key`, `Message`, `KeyValuePair`
+- `RequestResponse` (uses `As.PROPERTY`, a different mechanism)
+- The six E2EE types in `EncryptedEnvelope.kt` (deferred)
+- The other persistence backends (no workaround there)
+- The rsocket client (verified clean, 57 pass)
+
+## Verification
+
+- chat-core: 43 tests pass
+- chat-client-rsocket: 57 tests pass
+- chat-persistence-redis: 46 tests pass, including the typed domain test with
+  plain `convertValue`
+- chat-webflux: the 2 pre-existing failures stay, no new failures.
+  `LongUserRestTests` passes with the updated assertions
+- Run `mvn -o -pl chat-core,<module> test`. Never `-pl <module>` alone.
+- Full build health per `docs/BUILD-HEALTH.md`
+
+## Follow-ups
+
+- Create a follow-up issue for the six E2EE types: `DeviceRegistration`,
+  `PreKeyBundle`, `EncryptedEnvelope`, `ConversationEpoch`, `FrankingTag`,
+  `Presence`
+- Update `forward-register.md`: move CHAT-gjggodpa out of the deferred table,
+  record the E2EE follow-up
+- Check drift bindings on the edited files. Update prose first, then
+  `drift link`
+
+## Out of scope
+
+- CHAT-ejhtsarb (KVRequest binds key as Integer) — same erasure class, separate
+  spec
+- The six E2EE types — follow-up issue
+- Stored JSON migration — the store is disposable

--- a/forward-register.md
+++ b/forward-register.md
@@ -69,9 +69,26 @@ rename with no alias period.
 
 | Issue | State | What |
 |-------|-------|------|
-| `CHAT-gjggodpa` | todo | Domain serialization: `@JsonTypeInfo` wrappers vs custom deserializers. **Blocked on a decision only the owner can make** — option 1 breaks the REST wire format and needs stored-JSON migration, option 2 changes the stored format across cassandra and memory, option 3 documents rather than fixes. |
 | `CHAT-koufkrsl` | todo | `nodeId` uniqueness unenforced, and the default derivation collides — by birthday across ~38 hosts, and deterministically for containers sharing an IP on different hosts. Registry-based detection is insufficient because a store outlives any one registry. |
 | `CHAT-cikgeefc` | todo | Build health verification. Standing tracker, deliberately left open — a cycle finding no drift is a clean reading, not a finished task. |
+
+## Domain serialization (2026-08-25/26)
+
+`CHAT-gjggodpa` is done. The dead `@JsonTypeInfo(WRAPPER_OBJECT)` wrapper was
+removed from `User`, `MessageTopic`, and `TopicMembership`. The redis `rebind`
+workaround was deleted; the typed accessors use plain `convertValue`. The REST
+contract test was updated to the new shapes. The webflux suite is fully green
+(81 tests).
+
+**`MessageTopic` inheritance outcome:** it extends `KeyValuePair`, which keeps
+its own `@JsonTypeInfo`. Once `MessageTopic` lost its annotation, Jackson
+annotation inheritance applied the `KeyValuePair` wrapper. So `MessageTopic` is
+NOT flat. It carries the `keyValue` wrapper. The wire-shape test pins this.
+
+**E2EE follow-up:** `CHAT-zbjzbcoy`. The six E2EE types in `EncryptedEnvelope.kt`
+(`DeviceRegistration`, `PreKeyBundle`, `EncryptedEnvelope`, `ConversationEpoch`,
+`FrankingTag`, `Presence`) still carry the dead wrapper. Same fix as
+`CHAT-gjggodpa`. Verify `EncryptedEnvelope` for subtypes before dropping.
 
 ## Housekeeping
 

--- a/forward-register.md
+++ b/forward-register.md
@@ -74,7 +74,7 @@ rename with no alias period.
 
 ## Domain serialization (2026-08-25/26)
 
-`CHAT-gjggodpa` is done. The dead `@JsonTypeInfo(WRAPPER_OBJECT)` wrapper was
+`CHAT-gjggodpa` implementation is complete. The dead `@JsonTypeInfo(WRAPPER_OBJECT)` wrapper was
 removed from `User`, `MessageTopic`, and `TopicMembership`. The redis `rebind`
 workaround was deleted; the typed accessors use plain `convertValue`. The REST
 contract test was updated to the new shapes. The webflux suite is fully green
@@ -85,8 +85,8 @@ its own `@JsonTypeInfo`. Once `MessageTopic` lost its annotation, Jackson
 annotation inheritance applied the `KeyValuePair` wrapper. So `MessageTopic` is
 NOT flat. It carries the `keyValue` wrapper. The wire-shape test pins this.
 
-**E2EE follow-up:** `CHAT-zbjzbcoy`. The six E2EE types in `EncryptedEnvelope.kt`
-(`DeviceRegistration`, `PreKeyBundle`, `EncryptedEnvelope`, `ConversationEpoch`,
+**E2EE follow-up:** `CHAT-zbjzbcoy`. The seven E2EE types in `EncryptedEnvelope.kt`
+(`DeviceRegistration`, `PreKeyBundle`, `EncryptedEnvelope`, `ConversationCursor`, `ConversationEpoch`,
 `FrankingTag`, `Presence`) still carry the dead wrapper. Same fix as
 `CHAT-gjggodpa`. Verify `EncryptedEnvelope` for subtypes before dropping.
 

--- a/forward-register.md
+++ b/forward-register.md
@@ -132,6 +132,12 @@ built on top of them inherits the risk.
   coverage.** `@Disabled` sits on the generic base classes, surefire counts them as
   test classes, and JUnit does not inherit `@Disabled`, so the concrete `Long*`
   subclasses run. Documented in `docs/BUILD-HEALTH.md`.
+- **A wire-format change makes the shell integration image stale.** The
+  chat-shell tests run the client against the
+  `chat-deploy-long-memory-integration-test` Docker image, not against the
+  reactor. After a serialization change, rebuild the image with
+  `mvn -Ptest-build install`, then run `-Pintegration`. A stale image caused 8
+  decode errors that looked like a code regression.
 - **A disabled boot test is how a backend rots unnoticed.** `RedisDeployBootTests`
   was `@Disabled` with an accurate comment explaining why, and the backend stayed
   broken behind it. Every composition gets a boot test in the plan, and they stay


### PR DESCRIPTION
Removes the JSON wrapper from the user, topic, and membership domain types.

## Change

- User, Topic, and Membership now serialize flat. No wrapper object.
- MessageTopic inherits type resolution from KeyValuePair.
- REST contract updated to flat user and keyValue topic shapes.
- Redis rebind workaround deleted.

## Wire format

This is a breaking wire-format change. A new client cannot read an old server. Pair client and server versions.

## Verification

- `mvn -o -pl chat-core,chat-shell test -Pintegration`: 36 run, 0 failures, 0 errors, 17 skipped.
- `./shell-scripts/build-health.sh --integration`: green.

The integration test uses the `chat-deploy-long-memory-integration-test` Docker image. Rebuild it after any serialization change before running `-Pintegration`.

## Follow-up

CHAT-zbjzbcoy: the seven E2EE types. Tracked separately.

Closes CHAT-gjggodpa.