### PR TITLE
Record E2EE completion and the stale test class trap in the forward register

### DIFF
--- a/forward-register.md
+++ b/forward-register.md
@@ -14,7 +14,7 @@ in this file is authoritative on its own — each row points at the artifact tha
 | Worktree | `.claude/worktrees/xstream-messaging-only` (locked) |
 | Branch | `capability-composition-spec`, merged into `master` on 2026-08-25 |
 | Commits | `25a93e57` spec, `0b609644` plan, on `master`, unpushed |
-| `origin/master` | `4d184528` — two commits behind local `master` |
+| `origin/master` | `b404d733` — PR #48 and PR #49 are merged |
 | Open PRs | dependabot only (#8, #10, #11); nothing of ours is in flight |
 
 The worktree is named for xstream messaging and has not held xstream work for
@@ -28,6 +28,8 @@ several tasks. The name is stale; the contents are current.
 | #45 | Build health re-verified against current master, all three verifier modes |
 | #46 | Why `chat-shell` reports 17 skipped under `-Pintegration` |
 | #47 | The redis backend made into a composition root that actually starts |
+| #48 | The dead JSON wrapper dropped from `User`, `MessageTopic`, and `TopicMembership` |
+| #49 | The dead JSON wrapper dropped from the seven E2EE types in `EncryptedEnvelope.kt` |
 
 ## Decisions carried forward
 
@@ -85,10 +87,15 @@ its own `@JsonTypeInfo`. Once `MessageTopic` lost its annotation, Jackson
 annotation inheritance applied the `KeyValuePair` wrapper. So `MessageTopic` is
 NOT flat. It carries the `keyValue` wrapper. The wire-shape test pins this.
 
-**E2EE follow-up:** `CHAT-zbjzbcoy`. The seven E2EE types in `EncryptedEnvelope.kt`
-(`DeviceRegistration`, `PreKeyBundle`, `EncryptedEnvelope`, `ConversationCursor`, `ConversationEpoch`,
-`FrankingTag`, `Presence`) still carry the dead wrapper. Same fix as
-`CHAT-gjggodpa`. Verify `EncryptedEnvelope` for subtypes before dropping.
+**E2EE follow-up is complete.** `CHAT-zbjzbcoy` is done and merged as PR #49. The
+seven E2EE types in `EncryptedEnvelope.kt` (`DeviceRegistration`, `PreKeyBundle`,
+`EncryptedEnvelope`, `ConversationCursor`, `ConversationEpoch`, `FrankingTag`,
+`Presence`) now serialize flat. The check for subtypes found none. No type had
+`@JsonSubTypes`. No type had a custom serializer or deserializer. So the wrapper
+was dead on all seven. `E2eeWireShapeTests` pins the flat shape, one test per type.
+
+`Key<T>` keeps its own wrapper inside these seven types. Only the outer wrapper
+went away.
 
 ## Housekeeping
 
@@ -138,6 +145,13 @@ built on top of them inherits the risk.
   reactor. After a serialization change, rebuild the image with
   `mvn -Ptest-build install`, then run `-Pintegration`. A stale image caused 8
   decode errors that looked like a code regression.
+- **A stale compiled test class outlives its source across a branch switch.**
+  `DomainWireShapeTests.class` stayed in `chat-core/target/test-classes` after a
+  checkout that removed its source. Surefire runs compiled classes, not sources.
+  So it ran the orphan class and reported 3 failures against source that was not
+  on the branch. Run `mvn -o -pl chat-core clean test` after a branch switch. This
+  is the same shape as the stale integration image trap above. The build artifact
+  outlived the source.
 - **A disabled boot test is how a backend rots unnoticed.** `RedisDeployBootTests`
   was `@Disabled` with an accurate comment explaining why, and the backend stayed
   broken behind it. Every composition gets a boot test in the plan, and they stay

--- a/forward-register.md
+++ b/forward-register.md
@@ -103,8 +103,6 @@ went away.
   #47 and the evidence is logged on the issue, but the status was never moved to
   `done`. It should be.
 - **`CHAT-uortzsbx` is `in-progress`** from earlier work, not touched this session.
-- **`b6-ste` still holds the B6 Simplified Technical English docs commit**
-  (`e2b1f99f`) awaiting its own PR. It was deliberately kept out of #44.
 - **Rebase done.** The branch was rebased onto `master` and merged on 2026-08-25.
   The spec and plan now wait for a PR from `master`.
 


### PR DESCRIPTION
## What this changes

PR #48 and PR #49 are merged. This updates the forward register to match.

Five changes:

1. The `origin/master` row now reads `b404d733`. The old row was two commits behind and no longer true.
2. The Landed table gains rows for PR #48 and PR #49.
3. The E2EE follow-up paragraph now records the outcome. It said the seven types still carried the dead wrapper. They do not. The subtype check found none, so the wrapper was dead on all seven.
4. Things worth not relearning gains the stale compiled test class trap.
5. The stale `b6-ste` item leaves Housekeeping. See below.

## The new trap entry

A stale `DomainWireShapeTests.class` stayed in `chat-core/target/test-classes` after a checkout that removed its source. Surefire runs compiled classes and not sources. So it ran the orphan class and reported 3 failures against source that was not on the branch. A clean rebuild cleared it.

This is the same shape as the stale integration image trap already in that section. The build artifact outlived the source. Both entries now sit together.

## The b6-ste item was false

Housekeeping said `b6-ste` still held commit `e2b1f99f` and awaited its own PR. That is not true. `git merge-base --is-ancestor e2b1f99f origin/master` succeeds, so the commit is already on master. No `b6-ste` branch exists locally or on the remote. The item needs no action, so it leaves Housekeeping.

## Still stale, and left alone

The Worktree, Branch, and Commits rows in "Where things stand" still describe the 2026-08-23/24 session. I did not rewrite them. AGENTS.md says not to rewrite unrelated legacy prose. Please say if you want them refreshed.

## Verification

`drift refs forward-register.md` returns no bindings. `drift check` returns ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ehG4J7MXwdVrqEitSjqEM