### PR TITLE
Require explicit node ids for local key generation

### DIFF
--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeId.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeId.kt
@@ -1,0 +1,42 @@
+package com.demo.chat.domain
+
+/**
+ * A validated node id. Ten node bits in [SnowflakeGenerator] give 1024 values.
+ *
+ * There is no default and no derivation. A deployment states its node id, and
+ * two deployments that write to one store must not state the same one.
+ */
+class NodeId(val value: Int) {
+
+    init {
+        require(value in MIN..MAX) { message(value.toString()) }
+    }
+
+    override fun equals(other: Any?): Boolean = other is NodeId && other.value == value
+
+    override fun hashCode(): Int = value
+
+    override fun toString(): String = "NodeId($value)"
+
+    companion object {
+        const val MIN = 0
+        const val MAX = 1023
+
+        fun parse(raw: String?): NodeId {
+            val trimmed = raw?.trim()
+            require(!trimmed.isNullOrEmpty()) { message(raw) }
+            val parsed = trimmed.toIntOrNull()
+            require(parsed != null) { message(raw) }
+            return NodeId(parsed)
+        }
+
+        fun message(raw: String?): String =
+            "app.nodeid is required and has no default. " +
+                "Set it to an integer in $MIN..$MAX, unique across every deployment " +
+                "that writes to this store. Got: ${describe(raw)}"
+
+        // Only a null property is unset. An empty or blank value was supplied, so
+        // show it in quotes rather than hide it behind the word unset.
+        private fun describe(raw: String?): String = if (raw == null) "unset" else "'" + raw + "'"
+    }
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt
@@ -7,7 +7,7 @@ import org.springframework.core.env.Environment
 /**
  * Supplies the validated [NodeId].
  *
- * This class sits in `com.demo.chat.domain` on purpose. `com.demo.chat.config` is
+ * This class is in `com.demo.chat.domain` on purpose. `com.demo.chat.config` is
  * component-scanned by every deployment, so a copy placed there would supply the
  * bean in processes that generate no keys and would fail their startup.
  *

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt
@@ -1,0 +1,24 @@
+package com.demo.chat.domain
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+
+/**
+ * Supplies the validated [NodeId].
+ *
+ * This class sits in `com.demo.chat.domain` on purpose. `com.demo.chat.config` is
+ * component-scanned by every deployment, so a copy placed there would supply the
+ * bean in processes that generate no keys and would fail their startup.
+ *
+ * Read the raw value from [Environment]. Do not use `@Value("\${app.nodeid}")`.
+ * Spring resolves a placeholder before it injects a field, so an unset property
+ * fails placeholder resolution and [NodeId.parse] never reports the missing value.
+ */
+@Configuration
+open class NodeIdConfiguration {
+
+    @Bean
+    open fun nodeId(environment: Environment): NodeId =
+        NodeId.parse(environment.getProperty("app.nodeid"))
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt
@@ -1,8 +1,6 @@
 package com.demo.chat.domain
 
 import com.demo.chat.service.core.IKeyGenerator
-import java.net.NetworkInterface
-import java.security.SecureRandom
 import java.time.Instant
 
 /**
@@ -13,18 +11,15 @@ import java.time.Instant
  *
  * This class should be used as a Singleton.
  * Make sure that you create and reuse a Single instance of SequenceGenerator per node in your distributed system cluster.
+ *
+ * The node id is always supplied. There is no derivation, because a derived node id
+ * collided for certain across containers that share an IP. See [NodeId].
  */
 class SnowflakeGenerator : IKeyGenerator<Long> {
 
     constructor(nodeId: Int) {
         require(!(nodeId < 0 || nodeId > maxNodeId)) { String.format("NodeId must be between %d and %d", 0, maxNodeId) }
         this.nodeId = nodeId
-    }
-
-    // Let SequenceGenerator generate a nodeId
-    constructor() {
-        nodeId = createNodeId()
-
     }
 
     private val UNUSED_BITS = 1 // Sign bit, Unused (always set to 0)
@@ -81,27 +76,5 @@ class SnowflakeGenerator : IKeyGenerator<Long> {
             currentTimestamp = timestamp()
         }
         return currentTimestamp
-    }
-
-    private fun createNodeId(): Int {
-        var nodeId: Int
-        nodeId = try {
-            val sb = StringBuilder()
-            val networkInterfaces = NetworkInterface.getNetworkInterfaces()
-            while (networkInterfaces.hasMoreElements()) {
-                val networkInterface = networkInterfaces.nextElement()
-                val mac = networkInterface.hardwareAddress
-                if (mac != null) {
-                    for (i in mac.indices) {
-                        sb.append(String.format("%02X", mac[i]))
-                    }
-                }
-            }
-            sb.toString().hashCode()
-        } catch (ex: Exception) {
-            SecureRandom().nextInt()
-        }
-        nodeId = nodeId and maxNodeId
-        return nodeId
     }
 }

--- a/chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt
@@ -4,10 +4,7 @@ import com.demo.chat.domain.SnowflakeGenerator
 import com.demo.chat.service.core.IKeyGenerator
 
 class LongKeyGenerator(nodeId: Int) : IKeyGenerator<Long> {
-    private val idGenerator: IKeyGenerator<Long> = when (nodeId) {
-        0 -> SnowflakeGenerator()
-        else -> SnowflakeGenerator(nodeId)
-    }
+    private val idGenerator: IKeyGenerator<Long> = SnowflakeGenerator(nodeId)
 
     override fun nextId(): Long = idGenerator.nextId()
 }

--- a/chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt
@@ -5,10 +5,7 @@ import com.demo.chat.service.core.IKeyGenerator
 import java.util.*
 
 class UUIDKeyGenerator(nodeId: Int) : IKeyGenerator<UUID> {
-    private val idGenerator: IKeyGenerator<Long> = when (nodeId) {
-        0 -> SnowflakeGenerator()
-        else -> SnowflakeGenerator(nodeId)
-    }
+    private val idGenerator: IKeyGenerator<Long> = SnowflakeGenerator(nodeId)
 
     override fun nextId(): UUID =
         UUID.nameUUIDFromBytes(idGenerator.nextId().toString().encodeToByteArray())

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdConfigurationTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdConfigurationTests.kt
@@ -1,0 +1,54 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.mock.env.MockEnvironment
+
+class NodeIdConfigurationTests {
+
+    private fun contextWith(nodeId: String?): AnnotationConfigApplicationContext {
+        val context = AnnotationConfigApplicationContext()
+        val environment = MockEnvironment()
+        if (nodeId != null) {
+            environment.setProperty("app.nodeid", nodeId)
+        }
+        context.environment = environment
+        context.register(NodeIdConfiguration::class.java)
+        context.refresh()
+        return context
+    }
+
+    private fun allMessages(thrown: Throwable): String =
+        generateSequence(thrown) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
+
+    @Test
+    fun `a context without app nodeid fails and names the property`() {
+        val thrown = Assertions.assertThrows(Exception::class.java) { contextWith(null) }
+        val text = allMessages(thrown)
+        Assertions.assertTrue(text.contains("app.nodeid is required"), text)
+        Assertions.assertTrue(text.contains("unset"), text)
+    }
+
+    @Test
+    fun `a context with a value out of range fails and names the range`() {
+        val thrown = Assertions.assertThrows(Exception::class.java) { contextWith("1024") }
+        Assertions.assertTrue(allMessages(thrown).contains("0..1023"))
+    }
+
+    @Test
+    fun `a context with a valid app nodeid supplies the bean`() {
+        contextWith("5").use { context ->
+            Assertions.assertEquals(5, context.getBean(NodeId::class.java).value)
+        }
+    }
+
+    @Test
+    fun `a context accepts zero as an explicit value`() {
+        contextWith("0").use { context ->
+            Assertions.assertEquals(0, context.getBean(NodeId::class.java).value)
+        }
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdTests.kt
@@ -1,0 +1,92 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class NodeIdTests {
+
+    @Test
+    fun `parse accepts zero as an explicit value`() {
+        Assertions.assertEquals(0, NodeId.parse("0").value)
+    }
+
+    @Test
+    fun `parse accepts the maximum value`() {
+        Assertions.assertEquals(1023, NodeId.parse("1023").value)
+    }
+
+    @Test
+    fun `parse trims surrounding whitespace`() {
+        Assertions.assertEquals(7, NodeId.parse("  7  ").value)
+    }
+
+    @Test
+    fun `parse rejects an unset value`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse(null)
+        }
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid is required"))
+        Assertions.assertTrue(thrown.message!!.contains("unset"))
+    }
+
+    @Test
+    fun `parse rejects an empty value`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("")
+        }
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid is required"))
+    }
+
+    @Test
+    fun `parse rejects a whitespace only value`() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("   ")
+        }
+    }
+
+    @Test
+    fun `parse rejects a non numeric value`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("abc")
+        }
+        Assertions.assertTrue(thrown.message!!.contains("abc"))
+    }
+
+    @Test
+    fun `parse rejects a negative value`() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("-1")
+        }
+    }
+
+    @Test
+    fun `parse rejects a value above the maximum`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("1024")
+        }
+        Assertions.assertTrue(thrown.message!!.contains("0..1023"))
+    }
+
+    @Test
+    fun `the message names the property and the range`() {
+        val text = NodeId.message("99999")
+        Assertions.assertTrue(text.contains("app.nodeid"))
+        Assertions.assertTrue(text.contains("0..1023"))
+        Assertions.assertTrue(text.contains("no default"))
+        Assertions.assertTrue(text.contains("99999"))
+    }
+
+    @Test
+    fun `the message calls a null value unset`() {
+        val text = NodeId.message(null)
+        Assertions.assertTrue(text.contains("unset"))
+    }
+
+    @Test
+    fun `the message shows a blank value in quotes rather than as unset`() {
+        val text = NodeId.message("   ")
+        Assertions.assertTrue(text.contains("'   '"), text)
+        Assertions.assertFalse(text.contains("unset"), text)
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/SnowflakeGeneratorTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/SnowflakeGeneratorTests.kt
@@ -10,7 +10,7 @@ class SnowflakeGeneratorTests {
 
     @Test
     fun `should generate a few sequences`() {
-        val generator = SnowflakeGenerator()
+        val generator = SnowflakeGenerator(1)
 
         val publisher = Flux.create<Long> { sink ->
             sink.next(generator.nextId())

--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraDeployTest.kt
@@ -19,7 +19,7 @@ import org.springframework.test.context.TestPropertySource
     properties = [
         "spring.config.location=classpath:/application.yml",
         "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
-        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long", "app.nodeid=1",
         "app.service.core.key=cassandra",
         "app.service.core.pubsub=memory", "app.service.core.index=cassandra", "app.service.core.persistence=cassandra",
         "app.service.core.secrets=cassandra", "app.service.composite", "app.service.composite.auth",

--- a/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
+++ b/chat-deploy-kafka/src/test/kotlin/com/demo/chat/test/deploy/kafka/KafkaDeploymentTests.kt
@@ -28,7 +28,7 @@ import org.springframework.test.context.TestPropertySource
         "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
         "spring.application.name=test-deployment-kafka",
         "app.server.proto=rsocket",
-        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long", "app.nodeid=1",
         "spring.kafka.bootstrap-servers=\${spring.embedded.kafka.brokers}",
         "app.service.core.key=memory",
         "app.service.core.pubsub=kafka",

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt
@@ -17,7 +17,7 @@ import org.springframework.test.context.TestPropertySource
     properties = [
         "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
         "spring.application.name=test-deployment", "app.server.proto=rsocket",
-        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long", "app.nodeid=1",
         "app.service.core.key=memory",
         "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
         "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",

--- a/chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisDeployBootTests.kt
+++ b/chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisDeployBootTests.kt
@@ -62,7 +62,7 @@ import java.time.Duration
         "server.port=0",
         "spring.rsocket.server.port=0",
         "app.server.proto=rsocket",
-        "app.key.type=long",
+        "app.key.type=long", "app.nodeid=1",
         "app.service.core.key=redis",
         "app.service.core.pubsub=redis-pubsub",
         "app.service.core.index=lucene",

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt
@@ -1,12 +1,14 @@
 package com.demo.chat.config.persistence.cassandra
 
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
 import com.demo.chat.persistence.cassandra.domain.keygen.CassandraUUIDKeyGenerator
 import com.demo.chat.service.LongKeyGenerator
 import com.demo.chat.service.core.IKeyGenerator
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import java.util.*
 
 // One key generator per deployment. The selector that picks the key
@@ -16,18 +18,18 @@ import java.util.*
 // definition rather than on anything meaningful. Cassandra is the one that differs: its uuid generator is CassandraUUIDKeyGenerator.
 @Configuration("cassandraKeyGenConfiguration")
 @ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "cassandra")
+@Import(NodeIdConfiguration::class)
 class KeyGenConfiguration {
-
-    // enforce number on nodeid
-    @Value("\${app.nodeid:0}")
-    lateinit var nodeId: String
 
     @Bean("KeyGenerator")
     @ConditionalOnProperty("app.key.type", havingValue = "long")
-    fun longKeyGen(): IKeyGenerator<Long> = LongKeyGenerator(nodeId.toInt())
+    fun longKeyGen(nodeId: NodeId): IKeyGenerator<Long> = LongKeyGenerator(nodeId.value)
 
+    // CassandraUUIDKeyGenerator takes no node id. The NodeId parameter is here on
+    // purpose, so that app.nodeid is validated on this path too and one contract
+    // covers all three backends.
     @Bean("KeyGenerator")
     @ConditionalOnProperty("app.key.type", havingValue = "uuid")
-    fun uuidKeyGen(): IKeyGenerator<UUID> { return CassandraUUIDKeyGenerator() }
+    fun uuidKeyGen(nodeId: NodeId): IKeyGenerator<UUID> = CassandraUUIDKeyGenerator()
 
 }

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/LongKeyspaceAppTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/LongKeyspaceAppTests.kt
@@ -32,7 +32,7 @@ import reactor.test.StepVerifier
         CorePersistenceServices::class
     ]
 )
-@TestPropertySource(properties = ["app.service.core.key=cassandra","app.key.type=long"])
+@TestPropertySource(properties = ["app.service.core.key=cassandra","app.key.type=long","app.nodeid=1"])
 @Tag("integration")
 class LongKeyspaceAppTests : CassandraSchemaTest<Long>(TestLongKeyGenerator()) {
 

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/UUIDKeyspaceAppTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/UUIDKeyspaceAppTests.kt
@@ -33,7 +33,7 @@ import java.util.*
         CorePersistenceServices::class
     ]
 )
-@TestPropertySource(properties = ["app.service.core.key=cassandra","app.key.type=uuid"])
+@TestPropertySource(properties = ["app.service.core.key=cassandra","app.key.type=uuid","app.nodeid=1"])
 @Tag("integration")
 class UUIDKeyspaceAppTests : CassandraSchemaTest<UUID>(TestUUIDKeyGenerator()) {
 

--- a/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt
+++ b/chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt
@@ -1,12 +1,14 @@
 package com.demo.chat.config.persistence.memory
 
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
 import com.demo.chat.service.LongKeyGenerator
 import com.demo.chat.service.UUIDKeyGenerator
 import com.demo.chat.service.core.IKeyGenerator
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import java.util.*
 
 // One key generator per deployment. The selector that picks the key
@@ -16,16 +18,14 @@ import java.util.*
 // definition rather than on anything meaningful. Memory keeps matchIfMissing so an unset selector still boots.
 @Configuration("memoryKeyGenConfiguration")
 @ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "memory", matchIfMissing = true)
+@Import(NodeIdConfiguration::class)
 class KeyGenConfiguration {
-    // enforce number on nodeid
-    @Value("\${app.nodeid:0}")
-    lateinit var nodeId: String
 
     @ConditionalOnProperty("app.key.type", havingValue = "uuid")
     @Bean("KeyGenerator")
-    fun uuidGenerator(): IKeyGenerator<UUID> = UUIDKeyGenerator(nodeId.toInt())
+    fun uuidGenerator(nodeId: NodeId): IKeyGenerator<UUID> = UUIDKeyGenerator(nodeId.value)
 
     @ConditionalOnProperty("app.key.type", havingValue = "long")
     @Bean("KeyGenerator")
-    fun longGenerator(): IKeyGenerator<Long> = LongKeyGenerator(nodeId.toInt())
+    fun longGenerator(nodeId: NodeId): IKeyGenerator<Long> = LongKeyGenerator(nodeId.value)
 }

--- a/chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt
+++ b/chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt
@@ -1,12 +1,14 @@
 package com.demo.chat.config.persistence.redis
 
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
 import com.demo.chat.service.LongKeyGenerator
 import com.demo.chat.service.UUIDKeyGenerator
 import com.demo.chat.service.core.IKeyGenerator
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
 import java.util.*
 
 /**
@@ -20,16 +22,14 @@ import java.util.*
 // definition rather than on anything meaningful. Redis is selected explicitly or not at all.
 @Configuration("redisKeyGenConfiguration")
 @ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "redis")
+@Import(NodeIdConfiguration::class)
 class KeyGenConfiguration {
-    // enforce number on nodeid
-    @Value("\${app.nodeid:0}")
-    lateinit var nodeId: String
 
     @ConditionalOnProperty("app.key.type", havingValue = "uuid")
     @Bean("KeyGenerator")
-    fun uuidGenerator(): IKeyGenerator<UUID> = UUIDKeyGenerator(nodeId.toInt())
+    fun uuidGenerator(nodeId: NodeId): IKeyGenerator<UUID> = UUIDKeyGenerator(nodeId.value)
 
     @ConditionalOnProperty("app.key.type", havingValue = "long")
     @Bean("KeyGenerator")
-    fun longGenerator(): IKeyGenerator<Long> = LongKeyGenerator(nodeId.toInt())
+    fun longGenerator(nodeId: NodeId): IKeyGenerator<Long> = LongKeyGenerator(nodeId.value)
 }

--- a/docs/superpowers/plans/2026-08-27-nodeid-assignment.md
+++ b/docs/superpowers/plans/2026-08-27-nodeid-assignment.md
@@ -1,0 +1,759 @@
+# nodeId Assignment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: use superpowers:executing-plans to implement this plan task-by-task. Subagent-driven development is forbidden by AGENTS.md. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `app.nodeid` an explicit and validated deployment input, and delete every code path that derives a node id or supplies one by default.
+
+**Architecture:** One `NodeId` value type in `chat-core` owns the range rule and the error text. A `@Configuration` class reads the raw property from `Environment` and supplies one validated bean. The three `KeyGenConfiguration` classes import that class rather than each declaring `@Value`. The deriving constructor and the two `0 -> derive` sentinels are deleted. The launcher gains a required `--node-id` argument.
+
+**Tech Stack:** Kotlin 1.8, Spring Boot 3.3, JUnit 5, Maven, Python 3 for `shell-scripts/chat-build`.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-nodeid-assignment-design.md`
+
+## Global Constraints
+
+- Kotlin is the primary language.
+- Commit messages are lowercase imperative with no prefix. Match `drop dead json wrapper from the seven e2ee types`.
+- Run tests as `mvn -o -pl chat-core test`. Never run a dependent module alone. See the forward register, "Things worth not relearning".
+- Run `mvn -o -pl chat-core clean test` after a branch switch. A stale compiled test class outlives its source.
+- `app.nodeid` accepts an integer from 0 to 1023 inclusive. 0 is legal and explicit.
+- There is no default and no derivation, in the runtime or in the launcher.
+- Controlled English applies to comments, commit messages, and error text. Use plain words and active voice. Do not use semicolons.
+
+## Verified before planning
+
+- `ChatApp.kt` in `chat-deploy` and in `chat-authorization-server` sets `scanBasePackages = ["com.demo.chat.config"]`. That package is component-scanned in every deployment.
+- No component scan covers `com.demo.chat.domain`. The scans in use are `com.demo.chat.config`, `com.demo.chat.shell`, `com.demo.chat.controller.webflux`, and `com.demo.chat.config.deploy.cassandra.dse`.
+- `shell-scripts/chat-build` builds arguments in `add_common_args` at line 852, sets fields in `LaunchPlan.__init__` at line 472, and emits flags in `main_flags` at line 591.
+- `shell-scripts/test-flags.sh` holds a `CASES` array of `name|arguments` entries at line 46.
+- `app.nodeid` is set in no configuration file anywhere in the repository.
+
+## File Structure
+
+| File | Responsibility |
+|---|---|
+| `chat-core/src/main/kotlin/com/demo/chat/domain/NodeId.kt` | The value type. Owns the range rule, the parse function, and the error text. |
+| `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt` | Supplies one validated `NodeId` bean from `Environment`. Not component-scanned. |
+| `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdTests.kt` | Unit tests for `NodeId.parse`. No Spring context. |
+| `chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt` | Loses the no-argument constructor and `createNodeId`. |
+| `chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt` | Loses the `0 -> derive` sentinel. |
+| `chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt` | Loses the `0 -> derive` sentinel. |
+| Three `KeyGenConfiguration.kt` files | Inject `NodeId` instead of reading `@Value`. |
+| `shell-scripts/chat-build` | Gains a required `--node-id` argument and emits `-Dapp.nodeid`. |
+| `shell-scripts/test-flags.sh` | Passes `--node-id 0` in every case. |
+| `shell-scripts/golden/*.flags` | Regenerated, 15 files. |
+
+**Why `NodeIdConfiguration` lives in `com.demo.chat.domain`.** `com.demo.chat.config` is
+component-scanned by every deployment. A `@Configuration` class placed there would supply the
+bean in every process, including processes that generate no keys, and would fail their startup
+when `app.nodeid` is absent. `com.demo.chat.domain` is scanned by nothing, so the bean appears
+only where a `KeyGenConfiguration` imports it.
+
+---
+
+### Task 1: The NodeId value type and its bean
+
+**Files:**
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeId.kt`
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdTests.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdConfigurationTests.kt`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `com.demo.chat.domain.NodeId` with `val value: Int`, `NodeId.parse(raw: String?): NodeId`, `NodeId.message(raw: String?): String`, `NodeId.MIN = 0`, `NodeId.MAX = 1023`. Also `com.demo.chat.domain.NodeIdConfiguration`, a `@Configuration` exposing a `NodeId` bean.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdTests.kt`:
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class NodeIdTests {
+
+    @Test
+    fun `parse accepts zero as an explicit value`() {
+        Assertions.assertEquals(0, NodeId.parse("0").value)
+    }
+
+    @Test
+    fun `parse accepts the maximum value`() {
+        Assertions.assertEquals(1023, NodeId.parse("1023").value)
+    }
+
+    @Test
+    fun `parse trims surrounding whitespace`() {
+        Assertions.assertEquals(7, NodeId.parse("  7  ").value)
+    }
+
+    @Test
+    fun `parse rejects an unset value`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse(null)
+        }
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid is required"))
+        Assertions.assertTrue(thrown.message!!.contains("unset"))
+    }
+
+    @Test
+    fun `parse rejects an empty value`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("")
+        }
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid is required"))
+    }
+
+    @Test
+    fun `parse rejects a whitespace only value`() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("   ")
+        }
+    }
+
+    @Test
+    fun `parse rejects a non numeric value`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("abc")
+        }
+        Assertions.assertTrue(thrown.message!!.contains("abc"))
+    }
+
+    @Test
+    fun `parse rejects a negative value`() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("-1")
+        }
+    }
+
+    @Test
+    fun `parse rejects a value above the maximum`() {
+        val thrown = Assertions.assertThrows(IllegalArgumentException::class.java) {
+            NodeId.parse("1024")
+        }
+        Assertions.assertTrue(thrown.message!!.contains("0..1023"))
+    }
+
+    @Test
+    fun `the message names the property and the range`() {
+        val text = NodeId.message("99999")
+        Assertions.assertTrue(text.contains("app.nodeid"))
+        Assertions.assertTrue(text.contains("0..1023"))
+        Assertions.assertTrue(text.contains("no default"))
+        Assertions.assertTrue(text.contains("99999"))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-core test -Dtest=NodeIdTests`
+Expected: FAIL. Compilation fails because `com.demo.chat.domain.NodeId` does not exist.
+
+- [ ] **Step 3: Create the value type**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeId.kt`:
+
+```kotlin
+package com.demo.chat.domain
+
+/**
+ * A validated node id. Ten node bits in [SnowflakeGenerator] give 1024 values.
+ *
+ * There is no default and no derivation. A deployment states its node id, and
+ * two deployments that write to one store must not state the same one.
+ */
+class NodeId(val value: Int) {
+
+    init {
+        require(value in MIN..MAX) { message(value.toString()) }
+    }
+
+    override fun equals(other: Any?): Boolean = other is NodeId && other.value == value
+
+    override fun hashCode(): Int = value
+
+    override fun toString(): String = "NodeId($value)"
+
+    companion object {
+        const val MIN = 0
+        const val MAX = 1023
+
+        fun parse(raw: String?): NodeId {
+            val trimmed = raw?.trim()
+            require(!trimmed.isNullOrEmpty()) { message(raw) }
+            val parsed = trimmed.toIntOrNull()
+            require(parsed != null) { message(raw) }
+            return NodeId(parsed)
+        }
+
+        fun message(raw: String?): String =
+            "app.nodeid is required and has no default. " +
+                "Set it to an integer in $MIN..$MAX, unique across every deployment " +
+                "that writes to this store. Got: ${if (raw.isNullOrBlank()) "unset" else raw}"
+    }
+}
+```
+
+- [ ] **Step 4: Create the configuration class**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt`:
+
+```kotlin
+package com.demo.chat.domain
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.env.Environment
+
+/**
+ * Supplies the validated [NodeId].
+ *
+ * This class sits in `com.demo.chat.domain` on purpose. `com.demo.chat.config` is
+ * component-scanned by every deployment, so a copy placed there would supply the
+ * bean in processes that generate no keys and would fail their startup.
+ *
+ * Read the raw value from [Environment]. Do not use `@Value("\${app.nodeid}")`.
+ * Spring resolves a placeholder before it injects a field, so an unset property
+ * fails placeholder resolution and [NodeId.parse] never reports the missing value.
+ */
+@Configuration
+open class NodeIdConfiguration {
+
+    @Bean
+    open fun nodeId(environment: Environment): NodeId =
+        NodeId.parse(environment.getProperty("app.nodeid"))
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `mvn -o -pl chat-core test -Dtest=NodeIdTests`
+Expected: PASS. Ten tests, zero failures.
+
+- [ ] **Step 6: Write the configuration test**
+
+This test guards the `Environment.getProperty` choice. A change back to
+`@Value("\${app.nodeid}")` breaks it, because the failure text becomes a Spring
+placeholder error instead of the message from `NodeId`.
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdConfigurationTests.kt`:
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.mock.env.MockEnvironment
+
+class NodeIdConfigurationTests {
+
+    private fun contextWith(nodeId: String?): AnnotationConfigApplicationContext {
+        val context = AnnotationConfigApplicationContext()
+        val environment = MockEnvironment()
+        if (nodeId != null) {
+            environment.setProperty("app.nodeid", nodeId)
+        }
+        context.environment = environment
+        context.register(NodeIdConfiguration::class.java)
+        context.refresh()
+        return context
+    }
+
+    private fun allMessages(thrown: Throwable): String =
+        generateSequence(thrown) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
+
+    @Test
+    fun `a context without app nodeid fails and names the property`() {
+        val thrown = Assertions.assertThrows(Exception::class.java) { contextWith(null) }
+        val text = allMessages(thrown)
+        Assertions.assertTrue(text.contains("app.nodeid is required"), text)
+        Assertions.assertTrue(text.contains("unset"), text)
+    }
+
+    @Test
+    fun `a context with a value out of range fails and names the range`() {
+        val thrown = Assertions.assertThrows(Exception::class.java) { contextWith("1024") }
+        Assertions.assertTrue(allMessages(thrown).contains("0..1023"))
+    }
+
+    @Test
+    fun `a context with a valid app nodeid supplies the bean`() {
+        contextWith("5").use { context ->
+            Assertions.assertEquals(5, context.getBean(NodeId::class.java).value)
+        }
+    }
+
+    @Test
+    fun `a context accepts zero as an explicit value`() {
+        contextWith("0").use { context ->
+            Assertions.assertEquals(0, context.getBean(NodeId::class.java).value)
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Run the configuration test**
+
+Run: `mvn -o -pl chat-core test -Dtest=NodeIdConfigurationTests`
+Expected: PASS. Four tests, zero failures.
+
+If `MockEnvironment` does not resolve, `spring-test` is missing from `chat-core` test scope.
+Add it rather than weakening the test. `chat-core` already uses `spring-test` in
+`com.demo.chat.test.codec.ConversionTests`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add chat-core/src/main/kotlin/com/demo/chat/domain/NodeId.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdConfiguration.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdTests.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdConfigurationTests.kt
+git commit -m "add a validated nodeid type and its bean"
+```
+
+---
+
+### Task 2: Remove the derivation and require the node id
+
+Tasks 2, 3, and 4 land together. The tree is releasable at the end of Task 4, not between these tasks. After Task 2 a generated launch fails until Task 3 emits the flag.
+
+**Files:**
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt`
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt`
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt`
+- Modify: `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt`
+- Modify: `chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt`
+- Modify: `chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt`
+
+**Interfaces:**
+- Consumes: `NodeId` and `NodeIdConfiguration` from Task 1.
+- Produces: `SnowflakeGenerator(nodeId: Int)` as the only constructor. `LongKeyGenerator(nodeId: Int)` and `UUIDKeyGenerator(nodeId: Int)` keep their signatures and never derive.
+
+The generator change and the configuration change are one semantic change. Split them and the
+tree holds a worse state than today, because every deployment would resolve to node 0.
+
+- [ ] **Step 1: Delete the deriving constructor**
+
+In `chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt`, delete this
+constructor:
+
+```kotlin
+    // Let SequenceGenerator generate a nodeId
+    constructor() {
+        nodeId = createNodeId()
+
+    }
+```
+
+Delete the whole `createNodeId()` function. Delete these two imports:
+
+```kotlin
+import java.net.NetworkInterface
+import java.security.SecureRandom
+```
+
+Keep the `require` inside `constructor(nodeId: Int)`. It states the invariant of the class.
+
+- [ ] **Step 2: Delete the sentinel in LongKeyGenerator**
+
+Replace the body of `chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt`:
+
+```kotlin
+package com.demo.chat.service
+
+import com.demo.chat.domain.SnowflakeGenerator
+import com.demo.chat.service.core.IKeyGenerator
+
+class LongKeyGenerator(nodeId: Int) : IKeyGenerator<Long> {
+    private val idGenerator: IKeyGenerator<Long> = SnowflakeGenerator(nodeId)
+
+    override fun nextId(): Long = idGenerator.nextId()
+}
+```
+
+- [ ] **Step 3: Delete the sentinel in UUIDKeyGenerator**
+
+Replace the body of `chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt`:
+
+```kotlin
+package com.demo.chat.service
+
+import com.demo.chat.domain.SnowflakeGenerator
+import com.demo.chat.service.core.IKeyGenerator
+import java.util.*
+
+class UUIDKeyGenerator(nodeId: Int) : IKeyGenerator<UUID> {
+    private val idGenerator: IKeyGenerator<Long> = SnowflakeGenerator(nodeId)
+
+    override fun nextId(): UUID =
+        UUID.nameUUIDFromBytes(idGenerator.nextId().toString().encodeToByteArray())
+}
+```
+
+- [ ] **Step 4: Update the cassandra configuration**
+
+Replace `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt`:
+
+```kotlin
+package com.demo.chat.config.persistence.cassandra
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
+import com.demo.chat.persistence.cassandra.domain.keygen.CassandraUUIDKeyGenerator
+import com.demo.chat.service.LongKeyGenerator
+import com.demo.chat.service.core.IKeyGenerator
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import java.util.*
+
+// One key generator per deployment. The selector that picks the key
+// backend picks its generator too, so exactly one of these registers.
+// Ungated they all registered, and two of them share this simple class
+// name - a classpath carrying both failed to start on a conflicting bean
+// definition rather than on anything meaningful. Cassandra is the one that differs: its uuid generator is CassandraUUIDKeyGenerator.
+@Configuration("cassandraKeyGenConfiguration")
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "cassandra")
+@Import(NodeIdConfiguration::class)
+class KeyGenConfiguration {
+
+    @Bean("KeyGenerator")
+    @ConditionalOnProperty("app.key.type", havingValue = "long")
+    fun longKeyGen(nodeId: NodeId): IKeyGenerator<Long> = LongKeyGenerator(nodeId.value)
+
+    // CassandraUUIDKeyGenerator takes no node id. The NodeId parameter is here on
+    // purpose, so that app.nodeid is validated on this path too and one contract
+    // covers all three backends.
+    @Bean("KeyGenerator")
+    @ConditionalOnProperty("app.key.type", havingValue = "uuid")
+    fun uuidKeyGen(nodeId: NodeId): IKeyGenerator<UUID> = CassandraUUIDKeyGenerator()
+}
+```
+
+- [ ] **Step 5: Update the redis configuration**
+
+Replace `chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt`:
+
+```kotlin
+package com.demo.chat.config.persistence.redis
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
+import com.demo.chat.service.LongKeyGenerator
+import com.demo.chat.service.UUIDKeyGenerator
+import com.demo.chat.service.core.IKeyGenerator
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import java.util.*
+
+/**
+ * Provides the [IKeyGenerator] bean for Redis deployments, mirroring the
+ * memory/cassandra modules. Selected by `app.key.type` (uuid | long).
+ */
+// One key generator per deployment. The selector that picks the key
+// backend picks its generator too, so exactly one of these registers.
+// Ungated they all registered, and two of them share this simple class
+// name - a classpath carrying both failed to start on a conflicting bean
+// definition rather than on anything meaningful. Redis is selected explicitly or not at all.
+@Configuration("redisKeyGenConfiguration")
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "redis")
+@Import(NodeIdConfiguration::class)
+class KeyGenConfiguration {
+
+    @ConditionalOnProperty("app.key.type", havingValue = "uuid")
+    @Bean("KeyGenerator")
+    fun uuidGenerator(nodeId: NodeId): IKeyGenerator<UUID> = UUIDKeyGenerator(nodeId.value)
+
+    @ConditionalOnProperty("app.key.type", havingValue = "long")
+    @Bean("KeyGenerator")
+    fun longGenerator(nodeId: NodeId): IKeyGenerator<Long> = LongKeyGenerator(nodeId.value)
+}
+```
+
+- [ ] **Step 6: Update the memory configuration**
+
+Replace `chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt`:
+
+```kotlin
+package com.demo.chat.config.persistence.memory
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdConfiguration
+import com.demo.chat.service.LongKeyGenerator
+import com.demo.chat.service.UUIDKeyGenerator
+import com.demo.chat.service.core.IKeyGenerator
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import java.util.*
+
+// One key generator per deployment. The selector that picks the key
+// backend picks its generator too, so exactly one of these registers.
+// Ungated they all registered, and two of them share this simple class
+// name - a classpath carrying both failed to start on a conflicting bean
+// definition rather than on anything meaningful. Memory keeps matchIfMissing so an unset selector still boots.
+@Configuration("memoryKeyGenConfiguration")
+@ConditionalOnProperty(prefix = "app.service.core", name = ["key"], havingValue = "memory", matchIfMissing = true)
+@Import(NodeIdConfiguration::class)
+class KeyGenConfiguration {
+
+    @ConditionalOnProperty("app.key.type", havingValue = "uuid")
+    @Bean("KeyGenerator")
+    fun uuidGenerator(nodeId: NodeId): IKeyGenerator<UUID> = UUIDKeyGenerator(nodeId.value)
+
+    @ConditionalOnProperty("app.key.type", havingValue = "long")
+    @Bean("KeyGenerator")
+    fun longGenerator(nodeId: NodeId): IKeyGenerator<Long> = LongKeyGenerator(nodeId.value)
+}
+```
+
+- [ ] **Step 7: Build chat-core and read the failures**
+
+Run: `mvn -o -pl chat-core clean test`
+Expected: compilation succeeds. Some tests may fail where they build a generator directly.
+Fix each by passing an explicit node id, for example `LongKeyGenerator(1)`. Do not add a
+default anywhere.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt \
+        chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt \
+        chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt \
+        chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt \
+        chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt \
+        chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt
+git commit -m "require an explicit node id and delete the mac derivation"
+```
+
+---
+
+### Task 3: The launch surface
+
+**Files:**
+- Modify: `shell-scripts/chat-build`
+- Modify: `shell-scripts/test-flags.sh`
+- Modify: `shell-scripts/golden/*.flags`, 15 files, by regeneration only
+
+**Interfaces:**
+- Consumes: the runtime contract from Task 2.
+- Produces: a required `--node-id ID` argument on `chat-build`, and a `-Dapp.nodeid=ID` flag in every generated launch.
+
+- [ ] **Step 1: Add the argument**
+
+In `shell-scripts/chat-build`, inside `add_common_args` near line 852, add:
+
+```python
+    parser.add_argument("--node-id", metavar="ID", required=True, type=node_id_value,
+                        help="node id for key generation, an integer in 0..1023. "
+                             "It must be unique across every deployment that writes to one store.")
+```
+
+Add this helper above `add_common_args`:
+
+```python
+def node_id_value(raw: str) -> int:
+    """Parse --node-id. There is no default and no derivation."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"node id must be an integer in 0..1023, got {raw!r}")
+    if value < 0 or value > 1023:
+        raise argparse.ArgumentTypeError(
+            f"node id must be an integer in 0..1023, got {value}")
+    return value
+```
+
+- [ ] **Step 2: Carry the value onto the launch plan**
+
+In `LaunchPlan.__init__` near line 477, directly below the `self.key_type` line, add:
+
+```python
+        self.node_id = args.node_id
+```
+
+- [ ] **Step 3: Emit the flag**
+
+In `main_flags` near line 591, add the new flag directly below the key type flag:
+
+```python
+            f"-Dapp.key.type={self.key_type}",
+            f"-Dapp.nodeid={self.node_id}",
+```
+
+- [ ] **Step 4: Pass the argument in every golden case**
+
+In `shell-scripts/test-flags.sh`, append ` --node-id 0` to the arguments of all 15 entries in
+`CASES`. Use 0, which is a legal explicit value, so golden output stays the same on every
+machine. The result reads:
+
+```bash
+CASES=(
+  # core backends
+  "core-memory-init|core --memory --run --notls --long --init users,rootkeys --node-id 0"          # [parity]
+  "core-memory-consul|core --memory --consul --run --notls --long --init users,rootkeys --node-id 0" # [parity]
+  "core-memory-tls|core --memory --run --tls /etc/keys --long --init users,rootkeys --node-id 0"   # [parity]
+  "core-cassandra|core --cassandra --run --notls --long --init users,rootkeys --node-id 0"
+  "core-kafka|core --kafka --run --notls --long --node-id 0"
+  "core-redis|core --redis --run --notls --long --node-id 0"
+  "core-e2ee|core --memory --e2ee --run --notls --long --node-id 0"
+  # core variants
+  "core-uuid|core --memory --run --notls --uuid --node-id 0"
+  "core-websocket|core --memory --websocket --run --notls --long --node-id 0"
+  "core-debug|core --memory --debug --run --notls --long --node-id 0"
+  "core-build-image|core --memory --build --notls --long --node-id 0"
+  # other services
+  "rest-client|rest --run --notls --long --node-id 0"
+  "gateway-client|gateway --run --notls --long --node-id 0"
+  "authserv-client|authserv --run --notls --long --node-id 0"
+  "shell-client|shell --run --notls --long --node-id 0"                                            # [parity]
+)
+```
+
+- [ ] **Step 5: Confirm the goldens fail before regenerating**
+
+Run: `./shell-scripts/test-flags.sh`
+Expected: FAIL. Every case reports one added line, `-Dapp.nodeid=0`. Read the diff and confirm
+that this is the only change. A case that differs in any other flag is a bug in Steps 1 to 3.
+
+- [ ] **Step 6: Regenerate the goldens**
+
+Run: `./shell-scripts/test-flags.sh --update`
+Then run: `./shell-scripts/test-flags.sh`
+Expected: PASS, 15 cases.
+
+- [ ] **Step 7: Commit, and explain the regeneration**
+
+`shell-scripts/README-chat-build.md:243` says a diff from `--update` is a bug until you can say
+why it is not. The commit message must give that reason and must name the four cases that carry
+authority from the removed `test-parity.sh`.
+
+```bash
+git add shell-scripts/chat-build shell-scripts/test-flags.sh shell-scripts/golden
+git commit -m "emit app.nodeid from chat-build and regenerate the goldens" -m "chat-build gains a required --node-id argument and emits -Dapp.nodeid.
+All 15 goldens gain exactly one line, -Dapp.nodeid=0. No other flag moved.
+
+Four goldens carry authority from the removed test-parity.sh: core-memory-init,
+core-memory-consul, core-memory-tls, and shell-client. The case table marks them
+[parity]. Their regeneration is expected here, because every launch gains the
+same single flag."
+```
+
+---
+
+### Task 4: Sweep the remaining deployments and tests
+
+**Files:**
+- Modify: test sources and resources named by the build, across modules
+- Modify: `application*.yml` files for deployments that activate a key generator
+
+**Interfaces:**
+- Consumes: everything from Tasks 1 to 3.
+- Produces: a green build.
+
+- [ ] **Step 1: Run the whole build and collect the failures**
+
+Run: `mvn -o clean install -DskipTests`
+Then run: `./shell-scripts/build-health.sh`
+
+The set of tests that need `app.nodeid` cannot be read from the source, because
+`matchIfMissing = true` on the memory configuration makes it a classpath question. Let the
+build name them.
+
+- [ ] **Step 2: Add the property to each failing test**
+
+A failing test reports the message from `NodeId`. It contains `app.nodeid is required`.
+
+For a test that already declares properties, add the entry. For example, in
+`chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/repository/LongKeyspaceAppTests.kt`:
+
+```kotlin
+@TestPropertySource(properties = ["app.service.core.key=cassandra", "app.key.type=long", "app.nodeid=1"])
+```
+
+For a test that declares properties inside `@SpringBootTest`, add the entry to that list. For
+example, in `chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryDeploymentTests.kt`:
+
+```kotlin
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long", "app.nodeid=1",
+```
+
+Use `app.nodeid=1` in tests. Do not use 0, so that a test never passes by accident when a
+default creeps back.
+
+- [ ] **Step 3: Add the property to deployment configuration**
+
+For each `application*.yml` that belongs to a deployment activating a key generator, add:
+
+```yaml
+app:
+  nodeid: 1
+```
+
+Merge into the existing `app:` block when one is present. A deployment that runs more than one
+instance against one store must override this per instance. Record that in the commit message.
+
+- [ ] **Step 4: Run the whole build again**
+
+Run: `./shell-scripts/build-health.sh`
+Expected: green. Repeat Steps 2 and 3 until nothing reports `app.nodeid is required`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "set an explicit node id across tests and deployment configuration"
+```
+
+---
+
+### Task 5: Record the change
+
+**Files:**
+- Modify: `forward-register.md`
+
+- [ ] **Step 1: Add the entry**
+
+Add to "Things worth not relearning":
+
+```markdown
+- **`app.nodeid` is required and has no default.** It takes an integer in 0..1023, and
+  0 is a legal explicit value. The MAC derivation is gone, because it collided for
+  certain under containers that share an IP. `chat-build` requires `--node-id`.
+  Uniqueness across deployments is not enforced yet. That is `CHAT-wyssrokr`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add forward-register.md
+git commit -m "record the nodeid contract in the forward register"
+```
+
+## Self-review notes
+
+Spec coverage checked section by section. The contract, the components, the launch surface, the
+failure mode, the testing list, and the migration all map to a task. The "Verified facts" and
+"Correction carried into stage 2" sections carry no implementation work.
+
+Two spec items deserve care during execution:
+
+1. The context tests named in the spec are Task 1, Steps 6 and 7. They run against
+   `NodeIdConfiguration` directly with a `MockEnvironment`, so they need no deployment and no
+   scan configuration. Task 4 then proves the same contract from real deployments.
+2. The spec requires that `NodeIdConfiguration` never becomes global. Task 1 places it outside
+   every scanned package, and the comment in the file records why. If a later change moves it
+   into `com.demo.chat.config`, key-less processes start failing on a missing `app.nodeid`.

--- a/docs/superpowers/plans/2026-08-27-nodeid-assignment.md
+++ b/docs/superpowers/plans/2026-08-27-nodeid-assignment.md
@@ -24,7 +24,7 @@
 
 - `ChatApp.kt` in `chat-deploy` and in `chat-authorization-server` sets `scanBasePackages = ["com.demo.chat.config"]`. That package is component-scanned in every deployment.
 - No component scan covers `com.demo.chat.domain`. The scans in use are `com.demo.chat.config`, `com.demo.chat.shell`, `com.demo.chat.controller.webflux`, and `com.demo.chat.config.deploy.cassandra.dse`.
-- `shell-scripts/chat-build` builds arguments in `add_common_args` at line 852, sets fields in `LaunchPlan.__init__` at line 472, and emits flags in `main_flags` at line 591.
+- `shell-scripts/chat-build` builds arguments in `add_common_args` at line 852, sets fields in `BuildContext.__init__` at line 472, where `BuildContext` is declared at line 469, and emits flags in `main_flags` at line 591.
 - `shell-scripts/test-flags.sh` holds a `CASES` array of `name|arguments` entries at line 46.
 - `app.nodeid` is set in no configuration file anywhere in the repository.
 
@@ -146,6 +146,19 @@ class NodeIdTests {
         Assertions.assertTrue(text.contains("no default"))
         Assertions.assertTrue(text.contains("99999"))
     }
+
+    @Test
+    fun `the message calls a null value unset`() {
+        val text = NodeId.message(null)
+        Assertions.assertTrue(text.contains("unset"))
+    }
+
+    @Test
+    fun `the message shows a blank value in quotes rather than as unset`() {
+        val text = NodeId.message("   ")
+        Assertions.assertTrue(text.contains("'   '"), text)
+        Assertions.assertFalse(text.contains("unset"), text)
+    }
 }
 ```
 
@@ -194,7 +207,11 @@ class NodeId(val value: Int) {
         fun message(raw: String?): String =
             "app.nodeid is required and has no default. " +
                 "Set it to an integer in $MIN..$MAX, unique across every deployment " +
-                "that writes to this store. Got: ${if (raw.isNullOrBlank()) "unset" else raw}"
+                "that writes to this store. Got: ${describe(raw)}"
+
+        // Only a null property is unset. An empty or blank value was supplied, so
+        // show it in quotes rather than hide it behind the word unset.
+        private fun describe(raw: String?): String = if (raw == null) "unset" else "'" + raw + "'"
     }
 }
 ```
@@ -233,7 +250,7 @@ open class NodeIdConfiguration {
 - [ ] **Step 5: Run the tests to verify they pass**
 
 Run: `mvn -o -pl chat-core test -Dtest=NodeIdTests`
-Expected: PASS. Ten tests, zero failures.
+Expected: PASS. Twelve tests, zero failures.
 
 - [ ] **Step 6: Write the configuration test**
 
@@ -329,6 +346,7 @@ Tasks 2, 3, and 4 land together. The tree is releasable at the end of Task 4, no
 - Modify: `chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt`
 - Modify: `chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt`
 - Modify: `chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt`
+- Modify: `chat-core/src/test/kotlin/com/demo/chat/test/domain/SnowflakeGeneratorTests.kt`
 - Modify: `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt`
 - Modify: `chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt`
 - Modify: `chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt`
@@ -519,19 +537,43 @@ class KeyGenConfiguration {
 }
 ```
 
-- [ ] **Step 7: Build chat-core and read the failures**
+- [ ] **Step 7: Fix the test that calls the deleted constructor**
+
+`chat-core/src/test/kotlin/com/demo/chat/test/domain/SnowflakeGeneratorTests.kt` calls the
+no-argument constructor. Change this line:
+
+```kotlin
+        val generator = SnowflakeGenerator()
+```
+
+to:
+
+```kotlin
+        val generator = SnowflakeGenerator(1)
+```
+
+- [ ] **Step 8: Build chat-core and read the failures**
 
 Run: `mvn -o -pl chat-core clean test`
-Expected: compilation succeeds. Some tests may fail where they build a generator directly.
-Fix each by passing an explicit node id, for example `LongKeyGenerator(1)`. Do not add a
-default anywhere.
+Expected: PASS. Any other test that builds a generator directly fails to compile. Fix each by
+passing an explicit node id, for example `LongKeyGenerator(1)`. Do not add a default anywhere.
 
-- [ ] **Step 8: Commit**
+- [ ] **Step 9: Compile the three backend modules**
+
+This task changes three persistence modules. A `chat-core` run does not compile them, so a
+broken `KeyGenConfiguration` stays hidden until much later.
+
+Run: `mvn -o -pl chat-persistence-memory,chat-persistence-redis,chat-persistence-cassandra -am test-compile`
+Expected: BUILD SUCCESS. A failure here means a `KeyGenConfiguration` still reads `@Value`, or
+still passes a raw `String` where an `Int` is now required.
+
+- [ ] **Step 10: Commit**
 
 ```bash
 git add chat-core/src/main/kotlin/com/demo/chat/domain/SnowflakeGenerator.kt \
         chat-core/src/main/kotlin/com/demo/chat/service/LongKeyGenerator.kt \
         chat-core/src/main/kotlin/com/demo/chat/service/UUIDKeyGenerator.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/SnowflakeGeneratorTests.kt \
         chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt \
         chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt \
         chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt
@@ -579,7 +621,7 @@ def node_id_value(raw: str) -> int:
 
 - [ ] **Step 2: Carry the value onto the launch plan**
 
-In `LaunchPlan.__init__` near line 477, directly below the `self.key_type` line, add:
+In `BuildContext.__init__` near line 477, directly below the `self.key_type` line, add:
 
 ```python
         self.node_id = args.node_id
@@ -711,10 +753,20 @@ instance against one store must override this per instance. Record that in the c
 Run: `./shell-scripts/build-health.sh`
 Expected: green. Repeat Steps 2 and 3 until nothing reports `app.nodeid is required`.
 
-- [ ] **Step 5: Commit**
+- [ ] **Step 5: Review what changed, then stage only those files**
+
+Run: `git status --short`
+
+Read that list and stage each file by name. Do not use `git add -A`. This worktree can hold
+scratch files, and files from other work, and a broad stage sweeps them into the commit.
+
+The file set comes from the build in Steps 1 to 4, so it is known by the time you reach this
+step. Stage the test sources the build named, and the `application*.yml` files you edited, and
+nothing else.
 
 ```bash
-git add -A
+git status --short
+git add <each file named above>
 git commit -m "set an explicit node id across tests and deployment configuration"
 ```
 

--- a/docs/superpowers/specs/2026-08-27-nodeid-assignment-design.md
+++ b/docs/superpowers/specs/2026-08-27-nodeid-assignment-design.md
@@ -64,6 +64,7 @@ it uses `CassandraUUIDKeyGenerator`, which takes no argument.
 | Derivation | Delete it. | Any name for the derivation keeps the collision reachable. |
 | Value 0 | Legal and explicit. | 0 stops being a sentinel once the default is gone. |
 | Structure | One validated type in `chat-core`. | Three copies of one contract let the bad default sit unnoticed in all three. |
+| Launcher input | A required `--node-id` argument. | The launcher must not reintroduce a default that the runtime just removed. |
 
 ## The contract
 
@@ -89,7 +90,15 @@ text. A pure `parse(raw: String?)` function does the work, so tests need no Spri
 context.
 
 A `@Configuration` class in `chat-core` supplies one validated `NodeId` bean. That
-class reads `@Value("\${app.nodeid}")` with no default and calls `parse`.
+class reads the raw value with `Environment.getProperty("app.nodeid")` and passes the
+result to `parse`.
+
+Do not read the value with `@Value("\${app.nodeid}")`. Spring resolves a placeholder
+before it injects the field. An unset property then fails placeholder resolution, and
+the error comes from Spring rather than from `parse`. The unset case is the one every
+existing deployment meets first, so `parse` must own it.
+`Environment.getProperty` returns null for an absent property, which lets
+`parse(null)` produce the designed message.
 
 Do not put that class on a component-scanned path. A globally scanned bean would exist
 in every process, including processes that generate no keys, which contradicts the
@@ -131,12 +140,21 @@ Replace the `@Value("\${app.nodeid:0}")` field with the injected `NodeId`. Add t
 `shell-scripts/chat-build` builds the launch flags. Its `main_flags()` emits
 `-Dapp.key.type` today. It must also emit `-Dapp.nodeid`.
 
-`shell-scripts/golden` holds 15 `.flags` files. `shell-scripts/test-flags.sh` compares
-emitted flags against them. Every golden that gains the flag must be regenerated with
+**Input source.** `chat-build` takes the value from a required `--node-id ID`
+argument. A generated launch must name it. The launcher supplies no default and
+derives nothing, which matches the runtime contract. A missing `--node-id` fails the
+launcher with its own message, before any JVM starts.
+
+`shell-scripts/test-flags.sh` passes `--node-id 0` explicitly, so golden output stays
+deterministic across runs and machines. 0 is a legal explicit value under the new
+contract.
+
+`shell-scripts/golden` holds 15 `.flags` files. `test-flags.sh` compares emitted flags
+against them. Every golden that gains the flag must be regenerated with
 `./shell-scripts/test-flags.sh --update`.
 
-`README-chat-build.md` states that a regenerated golden needs an explanation. The
-commit message must give one.
+`shell-scripts/README-chat-build.md:243` states that a regenerated golden needs an
+explanation. The commit message must give one.
 
 **Emit the flag in all 15 goldens.** Twelve goldens name a key backend through
 `app.service.core.key`. Three do not: `gateway-client`, `rest-client`, and
@@ -165,7 +183,9 @@ Unit tests for `NodeId.parse` cover an unset value, an empty value, whitespace, 
 non-numeric value, a negative value, 0, 1023, and 1024.
 
 A context test asserts that a deployment without `app.nodeid` fails, and that the
-message names the property.
+message names the property. This test also guards the `Environment.getProperty`
+choice. A change back to `@Value` breaks it, because the failure text becomes a Spring
+placeholder error.
 
 A second context test asserts that a deployment with a valid value starts.
 
@@ -179,8 +199,18 @@ them.
 
 This is a breaking change with no grace period. `app.nodeid` is set nowhere today.
 It appears only in the three `@Value` declarations. No yml file, no properties file,
-no test, and no deploy config sets it. So every deployment currently derives its node
-id, and every one of them must gain the property before it starts.
+no test, and no deploy config sets it.
+
+So every deployment that activates a deriving key generator currently derives its node
+id. That set is:
+
+- memory, with either key type
+- redis, with either key type
+- Cassandra, with the Long key type
+
+Cassandra with the UUID key type does not derive, because `CassandraUUIDKeyGenerator`
+takes no node id. A process that activates no `KeyGenConfiguration` derives nothing.
+Every deployment in the deriving set must gain the property before it starts.
 
 The size of the test change is not knowable by reading. This matches the
 "Task 7 of the plan is unbounded" entry in the forward register. Run the full suite

--- a/docs/superpowers/specs/2026-08-27-nodeid-assignment-design.md
+++ b/docs/superpowers/specs/2026-08-27-nodeid-assignment-design.md
@@ -1,0 +1,215 @@
+# nodeId Assignment — Design
+
+Stage 1 of `CHAT-koufkrsl`. Stage 2 is `CHAT-wyssrokr`.
+
+## Goal
+
+Make `app.nodeid` an explicit and validated deployment input. Remove every code path
+that derives a node id or supplies one by default.
+
+## Scope
+
+In scope: the value of `app.nodeid`, its validation, and every launch surface that
+must now carry it.
+
+Out of scope: enforcement across deployments. Nothing in this design detects that two
+deployments chose the same node id. That work is `CHAT-wyssrokr`.
+
+## Background
+
+A `Long` key is a Snowflake value. `SnowflakeGenerator` uses 1 unused bit, 41 epoch
+bits, 10 node bits, and 12 sequence bits. Ten node bits give 1024 distinct values.
+
+Two generators that share a node id, emit in the same millisecond, and hold the same
+sequence value emit the same `Long`. Those values are entity keys. In a shared store
+the result is a silent overwrite, not an error.
+
+## Why UUID deployments carry the same risk
+
+`UUIDKeyGenerator` does not make random values. It hashes the Snowflake `Long`:
+
+```kotlin
+override fun nextId(): UUID =
+    UUID.nameUUIDFromBytes(idGenerator.nextId().toString().encodeToByteArray())
+```
+
+`UUID.nameUUIDFromBytes` is a name-based UUID. The UUID is a pure function of the
+`Long`. So a `Long` collision becomes a UUID collision. Redis and memory both pass
+the node id into `UUIDKeyGenerator`. Only the Cassandra UUID path ignores it, because
+it uses `CassandraUUIDKeyGenerator`, which takes no argument.
+
+## The three collision paths this design closes
+
+1. **The default is a derivation, not a value.** All three `KeyGenConfiguration`
+   classes read `@Value("\${app.nodeid:0}")`. `LongKeyGenerator` and `UUIDKeyGenerator`
+   both map `0` to `SnowflakeGenerator()`, which derives. So an unset property
+   silently switches to MAC-derived node ids. A node id of 0 also cannot be requested,
+   because 0 and "unset" look the same.
+
+2. **The derivation collides by birthday.** `createNodeId()` joins the MAC address of
+   every network interface, takes `String.hashCode()`, and masks to 10 bits. Across
+   1024 values a duplicate becomes more likely than not at about 38 hosts.
+
+3. **The derivation collides for certain under containers.** Docker derives a
+   container MAC from the container IP on the default bridge. Two containers that hold
+   the same IP on different hosts derive the same MAC and the same node id. The common
+   case is 172.17.0.2 on each host. This is the deployment topology in use.
+
+## Decisions
+
+| Decision | Choice | Reason |
+|---|---|---|
+| Staging | Assignment now. Store-side claim later. | Assignment closes the container collision at once. The claim needs its own design. |
+| Which deployments | Every deployment that generates keys locally. | The requirement follows the code that reads the value. |
+| Derivation | Delete it. | Any name for the derivation keeps the collision reachable. |
+| Value 0 | Legal and explicit. | 0 stops being a sentinel once the default is gone. |
+| Structure | One validated type in `chat-core`. | Three copies of one contract let the bad default sit unnoticed in all three. |
+
+## The contract
+
+`app.nodeid` is required for every deployment that activates a `KeyGenConfiguration`.
+
+- The value is an integer from 0 to 1023 inclusive.
+- 0 is legal and explicit.
+- An unset value fails at startup.
+- An empty or non-numeric value fails at startup.
+- A value out of range fails at startup.
+- There is no default and no derivation.
+
+The Cassandra UUID configuration also receives the validated value. It does not use
+it. The injection is deliberate and keeps one contract across all three backends. A
+comment must record that the validation is intentional.
+
+## Components
+
+### New: `NodeId` in `chat-core`
+
+A value type that holds one validated `Int`. It owns the range rule and the error
+text. A pure `parse(raw: String?)` function does the work, so tests need no Spring
+context.
+
+A `@Configuration` class in `chat-core` supplies one validated `NodeId` bean. That
+class reads `@Value("\${app.nodeid}")` with no default and calls `parse`.
+
+Do not put that class on a component-scanned path. A globally scanned bean would exist
+in every process, including processes that generate no keys, which contradicts the
+scope of this design. Each of the three `KeyGenConfiguration` classes pulls it in with
+`@Import` instead. The bean then exists exactly where a key generator is active, and
+the rule and the message still live in one place.
+
+### `SnowflakeGenerator`
+
+Delete the no-argument constructor. Delete `createNodeId()`. Remove the
+`java.net.NetworkInterface` and `java.security.SecureRandom` imports. Keep the
+existing range `require(...)`, because it states the invariant of the class.
+
+### `LongKeyGenerator` and `UUIDKeyGenerator`
+
+Both hold this sentinel:
+
+```kotlin
+private val idGenerator: IKeyGenerator<Long> = when (nodeId) {
+    0 -> SnowflakeGenerator()
+    else -> SnowflakeGenerator(nodeId)
+}
+```
+
+Delete the `when` in both classes. Pass the node id straight to
+`SnowflakeGenerator(nodeId)`.
+
+### The three `KeyGenConfiguration` classes
+
+Replace the `@Value("\${app.nodeid:0}")` field with the injected `NodeId`. Add the
+`@Import` described above. The files are:
+
+- `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/KeyGenConfiguration.kt`
+- `chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/KeyGenConfiguration.kt`
+- `chat-persistence-memory/src/main/kotlin/com/demo/chat/config/persistence/memory/KeyGenConfiguration.kt`
+
+## Launch surface
+
+`shell-scripts/chat-build` builds the launch flags. Its `main_flags()` emits
+`-Dapp.key.type` today. It must also emit `-Dapp.nodeid`.
+
+`shell-scripts/golden` holds 15 `.flags` files. `shell-scripts/test-flags.sh` compares
+emitted flags against them. Every golden that gains the flag must be regenerated with
+`./shell-scripts/test-flags.sh --update`.
+
+`README-chat-build.md` states that a regenerated golden needs an explanation. The
+commit message must give one.
+
+**Emit the flag in all 15 goldens.** Twelve goldens name a key backend through
+`app.service.core.key`. Three do not: `gateway-client`, `rest-client`, and
+`authserv-client`. Those three are not proof that no key generator starts, because the
+memory `KeyGenConfiguration` uses `matchIfMissing = true`. An absent selector still
+activates it when the memory module is on the classpath. Emitting the flag everywhere
+avoids a fragile classpath analysis. Where no `KeyGenConfiguration` is active, Spring
+ignores the property.
+
+## Failure mode
+
+Every existing deployment meets this error on its first boot, so the text must say
+what to do:
+
+```
+app.nodeid is required and has no default. Set it to an integer in 0..1023,
+unique across every deployment that writes to this store. Got: <raw|unset>
+```
+
+The message must name the property, give the range, state that no default exists, and
+show what it received.
+
+## Testing
+
+Unit tests for `NodeId.parse` cover an unset value, an empty value, whitespace, a
+non-numeric value, a negative value, 0, 1023, and 1024.
+
+A context test asserts that a deployment without `app.nodeid` fails, and that the
+message names the property.
+
+A second context test asserts that a deployment with a valid value starts.
+
+Existing Spring tests gain the property wherever they activate a
+`KeyGenConfiguration`. The repository holds 35 test classes that start a context. The
+exact set that needs the property cannot be read from the source, because
+`matchIfMissing = true` makes it a classpath question. Run the suite and let it name
+them.
+
+## Migration and risk
+
+This is a breaking change with no grace period. `app.nodeid` is set nowhere today.
+It appears only in the three `@Value` declarations. No yml file, no properties file,
+no test, and no deploy config sets it. So every deployment currently derives its node
+id, and every one of them must gain the property before it starts.
+
+The size of the test change is not knowable by reading. This matches the
+"Task 7 of the plan is unbounded" entry in the forward register. Run the full suite
+and let it name the failures rather than predict them.
+
+## Verified facts
+
+Each line below was read from current source, not assumed.
+
+- `SnowflakeGenerator()` derives a node id from network interfaces, and falls back to
+  `SecureRandom`.
+- `LongKeyGenerator(0)` means derive.
+- `UUIDKeyGenerator(0)` means derive.
+- `UUIDKeyGenerator` hashes the Snowflake `Long`, so a `Long` collision becomes a UUID
+  collision.
+- Redis and memory pass the node id into `UUIDKeyGenerator`.
+- The Cassandra UUID path uses `CassandraUUIDKeyGenerator` and ignores `app.nodeid`.
+- `app.nodeid` is set in no configuration file anywhere in the repository.
+- `shell-scripts/chat-build` emits `-Dapp.key.type` and does not emit `-Dapp.nodeid`.
+- 12 of the 15 goldens name a key backend.
+
+## Correction carried into stage 2
+
+An earlier note on `CHAT-koufkrsl` said a store-side claim fits an existing pattern,
+because root keys already live in the store and are read at startup. That is not
+correct. Root keys travel four ways. `app.rootkeys.create` makes them locally.
+`publish.scheme=kv` and `consume.scheme=kv` use consul KV. `consume.scheme=http` reads
+a peer actuator. All four are registry-scoped or peer-scoped. None is store-backed.
+
+A store-side claim is therefore a new mechanism, not an extension of one. This does
+not change the reasoning for stage 2, because only the shared store spans deployments.
+It does change the cost. The correction is recorded on `CHAT-wyssrokr`.

--- a/forward-register.md
+++ b/forward-register.md
@@ -150,6 +150,14 @@ built on top of them inherits the risk.
   on the branch. Run `mvn -o -pl chat-core clean test` after a branch switch. This
   is the same shape as the stale integration image trap above. The build artifact
   outlived the source.
+- **`app.nodeid` has no default and no derivation.** It takes an integer in
+  0..1023, and 0 is a legal explicit value. The MAC derivation is gone, because it
+  collided for certain across containers that share an IP. `chat-build --node-id`
+  is the normal launch path, and the argument is required. Do not add a shared
+  `app.nodeid` value to deployment yml. A committed default would make every
+  deployment the same node in silence, which is the failure this change removed.
+  Tests can use `app.nodeid=1`. Uniqueness across deployments is still not
+  enforced. That remains `CHAT-wyssrokr`.
 - **A disabled boot test is how a backend rots unnoticed.** `RedisDeployBootTests`
   was `@Disabled` with an accurate comment explaining why, and the backend stayed
   broken behind it. Every composition gets a boot test in the plan, and they stay

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -475,6 +475,7 @@ class BuildContext:
         self.selected = self._resolve_features()
         self.backend = self._resolve_backend()
         self.key_type = "uuid" if "uuid" in self.selected else "long"
+        self.node_id = args.node_id
         self.discovery = "consul" if "consul" in self.selected else "local"
         self.init_phases = [p.strip() for p in (args.init or "").split(",") if p.strip()]
         self.tls_dir: str | None = args.tls
@@ -589,6 +590,7 @@ class BuildContext:
         flags += self.endpoint_flags()
         flags += [
             f"-Dapp.key.type={self.key_type}",
+            f"-Dapp.nodeid={self.node_id}",
             f"-Dapp.primary={self.service.app_primary}",
             f"-Dspring.application.name={self.service.deployment_name}",
             "-Djava.security.egd=file:/dev/./urandom",
@@ -849,7 +851,24 @@ def find_consul_host() -> str:
 # CLI
 # --------------------------------------------------------------------------
 
+def node_id_value(raw: str) -> int:
+    """Parse --node-id. There is no default and no derivation."""
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"node id must be an integer in 0..1023, got {raw!r}")
+    if value < 0 or value > 1023:
+        raise argparse.ArgumentTypeError(
+            f"node id must be an integer in 0..1023, got {value}")
+    return value
+
+
 def add_common_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--node-id", metavar="ID", required=True, type=node_id_value,
+                        help="node id for key generation, an integer in 0..1023. "
+                             "It must be unique across every deployment that writes to one store.")
+
     tls = parser.add_mutually_exclusive_group()
     tls.add_argument("--tls", metavar="DIR",
                      help="enable TLS using certificates in DIR")

--- a/shell-scripts/golden/authserv-client.flags
+++ b/shell-scripts/golden/authserv-client.flags
@@ -8,6 +8,7 @@
 -Dapp.client.rsocket.core.secrets
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.oauth2.entrypoint-path=localhost:9090
 -Dapp.primary=authserv
 -Dapp.rootkeys.consume.scheme=http

--- a/shell-scripts/golden/core-build-image.flags
+++ b/shell-scripts/golden/core-build-image.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/core-cassandra.flags
+++ b/shell-scripts/golden/core-cassandra.flags
@@ -9,6 +9,7 @@
 -Dapp.controller.user
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.create=true
 -Dapp.server.proto=rsocket

--- a/shell-scripts/golden/core-debug.flags
+++ b/shell-scripts/golden/core-debug.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/core-e2ee.flags
+++ b/shell-scripts/golden/core-e2ee.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/core-kafka.flags
+++ b/shell-scripts/golden/core-kafka.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/core-memory-consul.flags
+++ b/shell-scripts/golden/core-memory-consul.flags
@@ -12,6 +12,7 @@
 -Dapp.kv.prefix=/chat
 -Dapp.kv.rootkeys=rootkeys
 -Dapp.kv.store=consul
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.create=true
 -Dapp.rootkeys.publish.scheme=kv

--- a/shell-scripts/golden/core-memory-init.flags
+++ b/shell-scripts/golden/core-memory-init.flags
@@ -9,6 +9,7 @@
 -Dapp.controller.user
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.create=true
 -Dapp.server.proto=rsocket

--- a/shell-scripts/golden/core-memory-tls.flags
+++ b/shell-scripts/golden/core-memory-tls.flags
@@ -9,6 +9,7 @@
 -Dapp.controller.user
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.create=true
 -Dapp.server.proto=rsocket

--- a/shell-scripts/golden/core-redis.flags
+++ b/shell-scripts/golden/core-redis.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/core-uuid.flags
+++ b/shell-scripts/golden/core-uuid.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=uuid
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/core-websocket.flags
+++ b/shell-scripts/golden/core-websocket.flags
@@ -10,6 +10,7 @@
 -Dapp.core.controllers=persistence,index,key,pubsub,secrets,user,topic,message
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=core-service
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/gateway-client.flags
+++ b/shell-scripts/golden/gateway-client.flags
@@ -1,6 +1,7 @@
 # profiles: client-backend,deploy,expose-gateway
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=gateway
 -Dapp.rest.port=6791
 -Dapp.rootkeys.consume.scheme=http

--- a/shell-scripts/golden/rest-client.flags
+++ b/shell-scripts/golden/rest-client.flags
@@ -9,6 +9,7 @@
 -Dapp.controller.user
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=REST
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/golden/shell-client.flags
+++ b/shell-scripts/golden/shell-client.flags
@@ -11,6 +11,7 @@
 -Dapp.client.rsocket.core.secrets
 -Dapp.key.type=long
 -Dapp.kv.store=none
+-Dapp.nodeid=0
 -Dapp.primary=shell
 -Dapp.rootkeys.consume.scheme=http
 -Dapp.rootkeys.consume.source=http://127.0.0.1:6791

--- a/shell-scripts/test-flags.sh
+++ b/shell-scripts/test-flags.sh
@@ -45,23 +45,23 @@ export DEBUG_PORT=5005
 # name | chat-build arguments
 CASES=(
   # core backends
-  "core-memory-init|core --memory --run --notls --long --init users,rootkeys"          # [parity]
-  "core-memory-consul|core --memory --consul --run --notls --long --init users,rootkeys" # [parity]
-  "core-memory-tls|core --memory --run --tls /etc/keys --long --init users,rootkeys"   # [parity]
-  "core-cassandra|core --cassandra --run --notls --long --init users,rootkeys"
-  "core-kafka|core --kafka --run --notls --long"
-  "core-redis|core --redis --run --notls --long"
-  "core-e2ee|core --memory --e2ee --run --notls --long"
+  "core-memory-init|core --memory --run --notls --long --init users,rootkeys --node-id 0"          # [parity]
+  "core-memory-consul|core --memory --consul --run --notls --long --init users,rootkeys --node-id 0" # [parity]
+  "core-memory-tls|core --memory --run --tls /etc/keys --long --init users,rootkeys --node-id 0"   # [parity]
+  "core-cassandra|core --cassandra --run --notls --long --init users,rootkeys --node-id 0"
+  "core-kafka|core --kafka --run --notls --long --node-id 0"
+  "core-redis|core --redis --run --notls --long --node-id 0"
+  "core-e2ee|core --memory --e2ee --run --notls --long --node-id 0"
   # core variants
-  "core-uuid|core --memory --run --notls --uuid"
-  "core-websocket|core --memory --websocket --run --notls --long"
-  "core-debug|core --memory --debug --run --notls --long"
-  "core-build-image|core --memory --build --notls --long"
+  "core-uuid|core --memory --run --notls --uuid --node-id 0"
+  "core-websocket|core --memory --websocket --run --notls --long --node-id 0"
+  "core-debug|core --memory --debug --run --notls --long --node-id 0"
+  "core-build-image|core --memory --build --notls --long --node-id 0"
   # other services
-  "rest-client|rest --run --notls --long"
-  "gateway-client|gateway --run --notls --long"
-  "authserv-client|authserv --run --notls --long"
-  "shell-client|shell --run --notls --long"                                            # [parity]
+  "rest-client|rest --run --notls --long --node-id 0"
+  "gateway-client|gateway --run --notls --long --node-id 0"
+  "authserv-client|authserv --run --notls --long --node-id 0"
+  "shell-client|shell --run --notls --long --node-id 0"                                            # [parity]
 )
 
 UPDATE=0


### PR DESCRIPTION
## Summary

- Add a `NodeId` value type and scoped configuration bean for `app.nodeid`.
- Remove MAC-derived Snowflake node ids and the `0 -> derive` sentinel.
- Require `--node-id` in `chat-build` and emit `-Dapp.nodeid`.
- Regenerate all 15 launch goldens with the explicit `-Dapp.nodeid=0` test value.
- Record the contract in `forward-register.md`.

## Review Notes

- No deployment YAML file sets `app.nodeid`.
- A shared YAML value would make every deployment use the same node id in silence.
- `chat-build --node-id` is now the normal launch path.
- Tests use `app.nodeid=1` so a default cannot hide in test coverage.
- Store-side uniqueness is still not enforced. That remains `CHAT-wyssrokr`.

## Test Plan

- [x] `./shell-scripts/test-flags.sh`
- [x] `./shell-scripts/build-health.sh`
- [x] `./shell-scripts/build-health.sh --integration`
- [x] `drift check`
- [x] `git diff --check`
