### PR TITLE
Record the sandboxed agent self-attach trap in the forward register

### DIFF
--- a/forward-register.md
+++ b/forward-register.md
@@ -158,6 +158,14 @@ built on top of them inherits the risk.
   deployment the same node in silence, which is the failure this change removed.
   Tests can use `app.nodeid=1`. Uniqueness across deployments is still not
   enforced. That remains `CHAT-wyssrokr`.
+- **A sandboxed build run can fail on agent self-attach, not on the code.**
+  Mockito loads the Byte Buddy agent into the running JVM. A sandbox can block that
+  self-attach on a GraalVM JVM, and `build-health.sh` then fails for a reason that
+  has nothing to do with the change under test. The same check passes unsandboxed.
+  Confirm a failure outside the sandbox before you treat it as a regression. The
+  build already prints the related warning on every run: "A Java agent has been
+  loaded dynamically" and "Dynamic loading of agents will be disallowed by default
+  in a future release".
 - **A disabled boot test is how a backend rots unnoticed.** `RedisDeployBootTests`
   was `@Disabled` with an accurate comment explaining why, and the backend stayed
   broken behind it. Every composition gets a boot test in the plan, and they stay


### PR DESCRIPTION
## What this changes

Adds one entry to `forward-register.md`, under "Things worth not relearning".

## The trap

Mockito loads the Byte Buddy agent into the running JVM. A sandbox can block that self-attach on a GraalVM JVM. `build-health.sh` then fails for a reason that has nothing to do with the change under test. The same check passes unsandboxed.

This came out of PR #51. The first sandboxed run failed this way. The unsandboxed run passed.

The build already prints the related warning on every run:

```
WARNING: A Java agent has been loaded dynamically (byte-buddy-agent-1.14.19.jar)
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```

## Why the register

This section already holds the stale integration image trap and the stale compiled test class trap. All three share one shape. A check goes red for a reason outside the change under test, and someone loses time to it. The entry says to confirm a failure outside the sandbox before treating it as a regression.

## Verification

`drift refs forward-register.md` returns no bindings. `drift check` returns ok before and after the edit. The diff is an insertion of 8 lines and changes nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015ehG4J7MXwdVrqEitSjqEM