### PR TITLE
Enforce nodeId uniqueness with a store-side claim lease

### DIFF
--- a/chat-core/src/main/kotlin/com/demo/chat/domain/ClaimResult.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/ClaimResult.kt
@@ -1,0 +1,14 @@
+package com.demo.chat.domain
+
+/**
+ * The outcome of a claim, a renew, or a release.
+ *
+ * [Denied] means one thing only. The store answered, and it named another
+ * owner. [Lost] means the store answered and found no live claim. Every
+ * infrastructure failure is an error, not a result.
+ */
+sealed class ClaimResult {
+    object Granted : ClaimResult()
+    data class Denied(val holder: String) : ClaimResult()
+    object Lost : ClaimResult()
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/ClaimScheduler.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/ClaimScheduler.kt
@@ -1,0 +1,84 @@
+package com.demo.chat.domain
+
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * The scheduling seam for [NodeIdClaimGuard].
+ *
+ * The guard owns its schedule. A shared task scheduler can delay a renew
+ * behind unrelated work, and a late renew can cost the lease.
+ *
+ * A test supplies its own implementation and fires tasks by hand, so the
+ * timing tests need no real waiting.
+ */
+interface ClaimScheduler {
+
+    fun schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable
+
+    fun scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable
+
+    /**
+     * Runs a task off every scheduler thread.
+     *
+     * The guard closes the context this way. A close started on a scheduler
+     * thread would run `destroy` on that same thread, and a `destroy` that
+     * waited for the scheduler would wait for itself.
+     */
+    fun runDetached(name: String, task: () -> Unit)
+
+    fun shutdownNow()
+
+    fun isSchedulerThread(): Boolean
+}
+
+class ExecutorClaimScheduler : ClaimScheduler {
+
+    private val threadName = "nodeid-claim-renew"
+
+    private val executor: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor(ThreadFactory { runnable ->
+            Thread(runnable, threadName).apply { isDaemon = true }
+        })
+
+    override fun schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable {
+        val future = executor.scheduleAtFixedRate(
+            { runQuietly(task) }, period.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS
+        )
+        return AutoCloseable { future.cancel(false) }
+    }
+
+    override fun scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable {
+        val future = executor.schedule(
+            { runQuietly(task) }, delay.toMillis(), TimeUnit.MILLISECONDS
+        )
+        return AutoCloseable { future.cancel(false) }
+    }
+
+    override fun runDetached(name: String, task: () -> Unit) {
+        Thread({ runQuietly(task) }, name).apply { isDaemon = false }.start()
+    }
+
+    override fun shutdownNow() {
+        executor.shutdownNow()
+        // Never wait from a scheduler thread. That would wait for this task.
+        if (!isSchedulerThread()) {
+            executor.awaitTermination(2, TimeUnit.SECONDS)
+        }
+    }
+
+    override fun isSchedulerThread(): Boolean = Thread.currentThread().name == threadName
+
+    // A thrown task would cancel a fixed rate schedule without a word. The
+    // guard handles its own failures, so anything reaching here is a defect.
+    private fun runQuietly(task: () -> Unit) {
+        try {
+            task()
+        } catch (e: Throwable) {
+            System.err.println("nodeid claim scheduler task failed: ${e.message}")
+        }
+    }
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/ConditionalOnSharedBackend.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/ConditionalOnSharedBackend.kt
@@ -1,0 +1,35 @@
+package com.demo.chat.domain
+
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.context.annotation.Conditional
+import org.springframework.core.type.AnnotatedTypeMetadata
+
+/**
+ * Activates a configuration when either core selector names this backend.
+ *
+ * Generated ids reach the key store and the persistence store. A condition
+ * on one selector alone would leave `key=memory` with `persistence=redis`
+ * unprotected, and the configuration permits that pair.
+ *
+ * `@ConditionalOnProperty` cannot express an OR across two properties.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Conditional(OnSharedBackendCondition::class)
+annotation class ConditionalOnSharedBackend(val value: String)
+
+class OnSharedBackendCondition : Condition {
+
+    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
+        val backend = metadata
+            .getAnnotationAttributes(ConditionalOnSharedBackend::class.java.name)
+            ?.get("value") as? String
+            ?: return false
+
+        val environment = context.environment
+        return environment.getProperty("app.service.core.key") == backend ||
+            environment.getProperty("app.service.core.persistence") == backend
+    }
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimException.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimException.kt
@@ -1,0 +1,30 @@
+package com.demo.chat.domain
+
+import java.time.Duration
+
+/**
+ * Reports a duplicate node id.
+ *
+ * The message states the scope, because uniqueness is per key type per
+ * store. A message that said "one store" would be false for a redis long
+ * deployment beside a redis uuid deployment.
+ *
+ * The exception carries no backend name. The scope phrase already names the
+ * backend.
+ */
+class NodeIdClaimException(
+    val nodeId: NodeId,
+    val scope: String,
+    val holder: String,
+    val ttl: Duration
+) : RuntimeException(message(nodeId, scope, holder, ttl)) {
+
+    companion object {
+        fun message(nodeId: NodeId, scope: String, holder: String, ttl: Duration): String =
+            "app.nodeid=${nodeId.value} is already claimed in the $scope.\n" +
+                "Holder: $holder\n" +
+                "Two deployments that write to the $scope must not use the same app.nodeid.\n" +
+                "Set a different app.nodeid, or stop the other deployment and wait " +
+                "${ttl.seconds}s\nfor its lease to expire."
+    }
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt
@@ -1,0 +1,145 @@
+package com.demo.chat.domain
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.context.ConfigurableApplicationContext
+
+/**
+ * Holds the store-side lease on `app.nodeid` for the life of the process.
+ *
+ * The guard claims during context refresh. A duplicate therefore fails
+ * startup before the application is ready and before the process serves
+ * normal traffic.
+ *
+ * The guard is the only place that blocks. The stores stay reactive.
+ */
+class NodeIdClaimGuard(
+    private val stores: List<NodeIdClaimStore>,
+    private val nodeId: NodeId,
+    private val owner: RuntimeOwnerId,
+    private val props: NodeIdClaimProperties,
+    private val context: ConfigurableApplicationContext,
+    private val scheduler: ClaimScheduler
+) : InitializingBean, DisposableBean {
+
+    private val log = LoggerFactory.getLogger(NodeIdClaimGuard::class.java)
+
+    private var granted: List<NodeIdClaimStore> = emptyList()
+    private var renewHandle: AutoCloseable? = null
+    private var deadlineHandle: AutoCloseable? = null
+
+    override fun afterPropertiesSet() {
+        if (stores.isEmpty()) {
+            return
+        }
+
+        val ordered = stores.sortedBy { it.backendName }
+        val taken = mutableListOf<NodeIdClaimStore>()
+
+        try {
+            ordered.forEach { store ->
+                when (val result = store.claim(nodeId, owner.value, props.ttl)
+                    .timeout(props.operationTimeout).block()) {
+                    is ClaimResult.Granted -> taken.add(store)
+                    is ClaimResult.Denied ->
+                        throw NodeIdClaimException(nodeId, store.scope, result.holder, props.ttl)
+                    is ClaimResult.Lost ->
+                        throw IllegalStateException(
+                            "The ${store.backendName} store returned Lost from a claim. " +
+                                "A claim returns Granted or Denied."
+                        )
+                    null ->
+                        throw IllegalStateException(
+                            "The ${store.backendName} store returned no result from a claim."
+                        )
+                }
+            }
+        } catch (failure: Throwable) {
+            releaseAll(taken.reversed())
+            throw failure
+        }
+
+        granted = taken
+        log.info("app.nodeid={} claimed in {}", nodeId.value, taken.joinToString { it.scope })
+        armDeadline()
+        renewHandle = scheduler.schedulePeriodic(props.renewInterval) { renewOnce() }
+    }
+
+    override fun destroy() {
+        renewHandle?.close()
+        deadlineHandle?.close()
+        scheduler.shutdownNow()
+        releaseAll(granted.reversed())
+        granted = emptyList()
+    }
+
+    private fun armDeadline() {
+        deadlineHandle?.close()
+        deadlineHandle = scheduler.scheduleOnce(props.closeDeadline) {
+            closeContext(
+                "app.nodeid=${nodeId.value} was not renewed within ${props.closeDeadline.seconds}s. " +
+                    "The lease may have expired. Closing the application context."
+            )
+        }
+    }
+
+    private fun renewOnce() {
+        granted.forEach { store ->
+            val result = try {
+                store.renew(nodeId, owner.value, props.ttl).timeout(props.operationTimeout).block()
+            } catch (error: Throwable) {
+                log.warn(
+                    "app.nodeid={} renew failed on {}. Retrying at the next interval. Cause: {}",
+                    nodeId.value, store.backendName, error.message
+                )
+                return
+            }
+
+            when (result) {
+                is ClaimResult.Granted -> Unit
+                is ClaimResult.Denied -> {
+                    closeContext(
+                        NodeIdClaimException(nodeId, store.scope, result.holder, props.ttl).message!!
+                    )
+                    return
+                }
+                is ClaimResult.Lost -> {
+                    closeContext(
+                        "app.nodeid=${nodeId.value} is no longer held in the ${store.scope}. " +
+                            "This process lost its lease. Closing the application context."
+                    )
+                    return
+                }
+                null -> {
+                    log.warn(
+                        "app.nodeid={} renew returned no result from {}. Retrying at the next interval.",
+                        nodeId.value, store.backendName
+                    )
+                    return
+                }
+            }
+        }
+        armDeadline()
+    }
+
+    // The close runs off the scheduler. A close started on a scheduler thread
+    // would run destroy on that same thread, and destroy would wait for it.
+    private fun closeContext(reason: String) {
+        log.error(reason)
+        scheduler.runDetached("nodeid-claim-close") { context.close() }
+    }
+
+    private fun releaseAll(ordered: List<NodeIdClaimStore>) {
+        ordered.forEach { store ->
+            try {
+                store.release(nodeId, owner.value).timeout(props.operationTimeout).block()
+            } catch (error: Throwable) {
+                log.debug(
+                    "app.nodeid={} release failed on {}. The lease expires on its own. Cause: {}",
+                    nodeId.value, store.backendName, error.message
+                )
+            }
+        }
+    }
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuardConfiguration.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuardConfiguration.kt
@@ -1,0 +1,49 @@
+package com.demo.chat.domain
+
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.core.env.Environment
+
+/**
+ * Supplies the guard beans.
+ *
+ * Every claim store configuration imports this class. An import is
+ * idempotent, so a classpath that names two shared backends still gets one
+ * guard. This mirrors how `KeyGenConfiguration` imports
+ * [NodeIdConfiguration].
+ *
+ * This class lives in `com.demo.chat.domain` on purpose.
+ * `com.demo.chat.config` is component-scanned by every deployment, so a copy
+ * placed there would supply the guard in processes that claim nothing.
+ */
+@Configuration
+@EnableConfigurationProperties(NodeIdClaimProperties::class)
+@Import(NodeIdConfiguration::class)
+open class NodeIdClaimGuardConfiguration {
+
+    @Bean
+    open fun runtimeOwnerId(environment: Environment): RuntimeOwnerId =
+        RuntimeOwnerId.generate(environment.getProperty("spring.application.name") ?: "chat")
+
+    @Bean
+    open fun nodeIdClaimScheduler(): ClaimScheduler = ExecutorClaimScheduler()
+
+    // ObjectProvider, not List. A List parameter with no candidate bean fails
+    // to resolve, and this configuration must also be safe to import early.
+    @Bean
+    open fun nodeIdClaimGuard(
+        stores: ObjectProvider<NodeIdClaimStore>,
+        nodeId: NodeId,
+        owner: RuntimeOwnerId,
+        properties: NodeIdClaimProperties,
+        context: ConfigurableApplicationContext,
+        scheduler: ClaimScheduler
+    ): NodeIdClaimGuard =
+        NodeIdClaimGuard(
+            stores.orderedStream().toList(), nodeId, owner, properties, context, scheduler
+        )
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimProperties.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimProperties.kt
@@ -1,0 +1,63 @@
+package com.demo.chat.domain
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * The lease timings.
+ *
+ * The constructor takes nullable parameters and applies the defaults in the
+ * body. It declares no Kotlin default arguments on purpose. A default
+ * argument makes Kotlin emit a synthetic constructor, and Spring Boot then
+ * has more than one constructor to choose from. The same trap already bit
+ * `ConfigurationPropertiesRedisTopics`.
+ */
+@ConfigurationProperties(prefix = "app.nodeid.claim")
+class NodeIdClaimProperties(
+    ttl: Duration?,
+    renewInterval: Duration?,
+    safetyMargin: Duration?,
+    operationTimeout: Duration?
+) {
+    val ttl: Duration = ttl ?: Duration.ofSeconds(30)
+    val renewInterval: Duration = renewInterval ?: Duration.ofSeconds(10)
+    val safetyMargin: Duration = safetyMargin ?: Duration.ofSeconds(5)
+    val operationTimeout: Duration = operationTimeout ?: Duration.ofSeconds(5)
+
+    /** The process closes this long after the last successful claim or renew. */
+    val closeDeadline: Duration = this.ttl.minus(this.safetyMargin)
+
+    init {
+        require(this.ttl >= Duration.ofSeconds(1)) {
+            "app.nodeid.claim.ttl must be at least 1s. Got: ${this.ttl}"
+        }
+        // Cassandra applies a TTL in whole seconds. A fractional value would
+        // round on one backend and not on the other.
+        require(this.ttl.nano == 0) {
+            "app.nodeid.claim.ttl must use whole seconds. Got: ${this.ttl}"
+        }
+        require(!this.renewInterval.isZero && !this.renewInterval.isNegative) {
+            "app.nodeid.claim.renew-interval must be greater than zero. Got: ${this.renewInterval}"
+        }
+        require(this.renewInterval <= this.ttl.dividedBy(3)) {
+            "app.nodeid.claim.renew-interval must be at most ttl / 3. " +
+                "ttl is ${this.ttl}. Got: ${this.renewInterval}"
+        }
+        require(!this.safetyMargin.isZero && !this.safetyMargin.isNegative) {
+            "app.nodeid.claim.safety-margin must be greater than zero. Got: ${this.safetyMargin}"
+        }
+        require(this.safetyMargin < this.ttl) {
+            "app.nodeid.claim.safety-margin must be less than ttl. " +
+                "ttl is ${this.ttl}. Got: ${this.safetyMargin}"
+        }
+        // A blocked call must not consume the next renewal slot.
+        require(this.operationTimeout < this.renewInterval) {
+            "app.nodeid.claim.operation-timeout must be less than renew-interval. " +
+                "renew-interval is ${this.renewInterval}. Got: ${this.operationTimeout}"
+        }
+        require(this.closeDeadline > this.renewInterval) {
+            "ttl minus app.nodeid.claim.safety-margin must be greater than renew-interval. " +
+                "The deadline is ${this.closeDeadline}. renew-interval is ${this.renewInterval}."
+        }
+    }
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimStore.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimStore.kt
@@ -1,0 +1,42 @@
+package com.demo.chat.domain
+
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * A store-side lease on one [NodeId].
+ *
+ * A registry check cannot enforce node id uniqueness. One store can be
+ * reached by deployments that do not share a registry. The claim therefore
+ * lives in the store that the deployments share.
+ *
+ * Implementations return a [Mono]. The guard is the only place that blocks.
+ */
+interface NodeIdClaimStore {
+
+    /** `redis` or `cassandra`. This orders the stores in the guard. */
+    val backendName: String
+
+    /**
+     * The full phrase that names the space this claim covers.
+     *
+     * Redis supplies `redis store for key type long`. Cassandra supplies
+     * `cassandra keyspace chat_long`. The phrase is complete, so that one
+     * message template serves every backend.
+     */
+    val scope: String
+
+    /**
+     * Takes the lease.
+     *
+     * Returns [ClaimResult.Granted] or [ClaimResult.Denied]. It never
+     * returns [ClaimResult.Lost].
+     */
+    fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
+
+    /** Extends the lease when this owner still holds it. */
+    fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
+
+    /** Drops the lease when this owner holds it. Best effort. */
+    fun release(nodeId: NodeId, owner: String): Mono<Void>
+}

--- a/chat-core/src/main/kotlin/com/demo/chat/domain/RuntimeOwnerId.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/domain/RuntimeOwnerId.kt
@@ -1,0 +1,31 @@
+package com.demo.chat.domain
+
+import java.net.InetAddress
+import java.security.SecureRandom
+
+/**
+ * The owner of a node id lease, for one process.
+ *
+ * The value is unique per process. A restart never reuses it, so a restarted
+ * deployment cannot mistake its own stale lease for a live one. The value is
+ * readable, so the duplicate node message names a real host and process.
+ */
+class RuntimeOwnerId(val value: String) {
+
+    override fun toString(): String = value
+
+    companion object {
+        private val random = SecureRandom()
+
+        fun generate(applicationName: String): RuntimeOwnerId {
+            val host = try {
+                InetAddress.getLocalHost().hostName
+            } catch (e: Exception) {
+                "unknown-host"
+            }
+            val pid = ProcessHandle.current().pid()
+            val suffix = String.format("%08x", random.nextInt())
+            return RuntimeOwnerId("$applicationName@$host:$pid#$suffix")
+        }
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/ClaimTestDoubles.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/ClaimTestDoubles.kt
@@ -1,0 +1,75 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.ClaimScheduler
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimStore
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * A store whose answers the test sets.
+ *
+ * `calls` records every operation in order, so a test can assert the claim
+ * order and the release order.
+ */
+class FakeClaimStore(
+    override val backendName: String,
+    override val scope: String = "$backendName store for key type long",
+    var claimAnswer: () -> ClaimResult = { ClaimResult.Granted },
+    var renewAnswer: () -> ClaimResult = { ClaimResult.Granted }
+) : NodeIdClaimStore {
+
+    val calls = mutableListOf<String>()
+
+    override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        Mono.fromCallable { calls.add("claim:$backendName"); claimAnswer() }
+
+    override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        Mono.fromCallable { calls.add("renew:$backendName"); renewAnswer() }
+
+    override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+        Mono.fromRunnable { calls.add("release:$backendName") }
+}
+
+/**
+ * A scheduler the test drives by hand.
+ *
+ * Nothing runs until the test calls [firePeriodic] or [fireOnce]. The guard
+ * timing tests therefore need no real waiting.
+ */
+class ManualClaimScheduler : ClaimScheduler {
+
+    var periodic: (() -> Unit)? = null
+    var once: (() -> Unit)? = null
+    var onceDelay: Duration? = null
+    val detached = mutableListOf<String>()
+    var shutdownCount = 0
+    var pretendSchedulerThread = false
+
+    override fun schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable {
+        periodic = task
+        return AutoCloseable { periodic = null }
+    }
+
+    override fun scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable {
+        once = task
+        onceDelay = delay
+        return AutoCloseable { once = null; onceDelay = null }
+    }
+
+    override fun runDetached(name: String, task: () -> Unit) {
+        detached.add(name)
+        task()
+    }
+
+    override fun shutdownNow() {
+        shutdownCount++
+    }
+
+    override fun isSchedulerThread(): Boolean = pretendSchedulerThread
+
+    fun firePeriodic() = periodic?.invoke()
+
+    fun fireOnce() = once?.invoke()
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/ExecutorClaimSchedulerTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/ExecutorClaimSchedulerTests.kt
@@ -1,0 +1,69 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ExecutorClaimScheduler
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
+
+class ExecutorClaimSchedulerTests {
+
+    @Test
+    fun `a periodic task reports that it runs on a scheduler thread`() {
+        val scheduler = ExecutorClaimScheduler()
+        val onScheduler = AtomicReference<Boolean>()
+        try {
+            scheduler.schedulePeriodic(Duration.ofMillis(20)) {
+                onScheduler.compareAndSet(null, scheduler.isSchedulerThread())
+            }
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until { onScheduler.get() != null }
+            Assertions.assertTrue(onScheduler.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `a detached task does not run on a scheduler thread`() {
+        val scheduler = ExecutorClaimScheduler()
+        val onScheduler = AtomicReference<Boolean>()
+        try {
+            scheduler.runDetached("nodeid-claim-close") {
+                onScheduler.set(scheduler.isSchedulerThread())
+            }
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until { onScheduler.get() != null }
+            Assertions.assertFalse(onScheduler.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `shutdown from a scheduler thread returns and does not wait for itself`() {
+        val scheduler = ExecutorClaimScheduler()
+        val done = AtomicReference<Boolean>()
+        scheduler.schedulePeriodic(Duration.ofMillis(20)) {
+            scheduler.shutdownNow()
+            done.compareAndSet(null, true)
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(2)).until { done.get() == true }
+    }
+
+    @Test
+    fun `a closed periodic handle stops the task`() {
+        val scheduler = ExecutorClaimScheduler()
+        try {
+            val runs = java.util.concurrent.atomic.AtomicInteger()
+            val handle = scheduler.schedulePeriodic(Duration.ofMillis(20)) { runs.incrementAndGet() }
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until { runs.get() > 0 }
+            handle.close()
+            Thread.sleep(100)
+            val seen = runs.get()
+            Thread.sleep(200)
+            Assertions.assertEquals(seen, runs.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimExceptionTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimExceptionTests.kt
@@ -1,0 +1,38 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class NodeIdClaimExceptionTests {
+
+    @Test
+    fun `the redis message names the property the scope the holder and the wait`() {
+        val text = NodeIdClaimException(
+            NodeId(7),
+            "redis store for key type long",
+            "core-service@host-a:4711#a3f19c2b",
+            Duration.ofSeconds(30)
+        ).message!!
+
+        Assertions.assertTrue(text.contains("app.nodeid=7 is already claimed"), text)
+        Assertions.assertTrue(text.contains("the redis store for key type long"), text)
+        Assertions.assertTrue(text.contains("Holder: core-service@host-a:4711#a3f19c2b"), text)
+        Assertions.assertTrue(text.contains("wait 30s"), text)
+    }
+
+    @Test
+    fun `the cassandra message names the keyspace`() {
+        val text = NodeIdClaimException(
+            NodeId(7),
+            "cassandra keyspace chat_long",
+            "core-service@host-b:5122#77c0aa41",
+            Duration.ofSeconds(30)
+        ).message!!
+
+        Assertions.assertTrue(text.contains("the cassandra keyspace chat_long"), text)
+        Assertions.assertFalse(text.contains("one store"), text)
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardRenewalTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardRenewalTests.kt
@@ -1,0 +1,147 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimProperties
+import com.demo.chat.domain.RuntimeOwnerId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import java.time.Duration
+
+class NodeIdClaimGuardRenewalTests {
+
+    private val props = NodeIdClaimProperties(null, null, null, null)
+
+    private fun setUp(store: FakeClaimStore): Pair<NodeIdClaimGuard, ManualClaimScheduler> {
+        val scheduler = ManualClaimScheduler()
+        val context = GenericApplicationContext()
+        context.refresh()
+        val guard = NodeIdClaimGuard(
+            listOf(store), NodeId(7), RuntimeOwnerId("core-service@host-a:4711#a3f19c2b"),
+            props, context, scheduler
+        )
+        guard.afterPropertiesSet()
+        return guard to scheduler
+    }
+
+    @Test
+    fun `a granted renew keeps the context open and rearms the deadline`() {
+        val store = FakeClaimStore("redis")
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+
+        Assertions.assertTrue(store.calls.contains("renew:redis"))
+        Assertions.assertTrue(scheduler.detached.isEmpty())
+        Assertions.assertEquals(Duration.ofSeconds(25), scheduler.onceDelay)
+    }
+
+    @Test
+    fun `a denied renew closes the context at once`() {
+        val store = FakeClaimStore("redis", renewAnswer = { ClaimResult.Denied("other-owner") })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `a lost renew closes the context at once`() {
+        val store = FakeClaimStore("redis", renewAnswer = { ClaimResult.Lost })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `a renew error keeps the context open`() {
+        val store = FakeClaimStore("redis", renewAnswer = { throw IllegalStateException("redis is down") })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+        scheduler.firePeriodic()
+
+        Assertions.assertTrue(scheduler.detached.isEmpty())
+    }
+
+    @Test
+    fun `a renew error does not rearm the deadline`() {
+        val store = FakeClaimStore("redis")
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+        val armedAfterSuccess = scheduler.once
+        store.renewAnswer = { throw IllegalStateException("redis is down") }
+        scheduler.firePeriodic()
+
+        Assertions.assertSame(armedAfterSuccess, scheduler.once)
+    }
+
+    @Test
+    fun `the deadline timer closes the context when it fires`() {
+        val store = FakeClaimStore("redis", renewAnswer = { throw IllegalStateException("redis is down") })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+        scheduler.fireOnce()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `the close runs off the scheduler thread`() {
+        val store = FakeClaimStore("redis", renewAnswer = { ClaimResult.Lost })
+        val (_, scheduler) = setUp(store)
+        scheduler.pretendSchedulerThread = true
+
+        scheduler.firePeriodic()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `destroy shuts the scheduler down and releases the store`() {
+        val store = FakeClaimStore("redis")
+        val (guard, scheduler) = setUp(store)
+
+        guard.destroy()
+
+        Assertions.assertEquals(1, scheduler.shutdownCount)
+        Assertions.assertTrue(store.calls.contains("release:redis"))
+    }
+
+    @Test
+    fun `destroy releases two stores in reverse backend name order`() {
+        val redis = FakeClaimStore("redis")
+        val cassandra = FakeClaimStore("cassandra")
+        val scheduler = ManualClaimScheduler()
+        val context = GenericApplicationContext()
+        context.refresh()
+        val guard = NodeIdClaimGuard(
+            listOf(redis, cassandra), NodeId(7),
+            RuntimeOwnerId("core-service@host-a:4711#a3f19c2b"), props, context, scheduler
+        )
+        guard.afterPropertiesSet()
+
+        guard.destroy()
+
+        Assertions.assertTrue(redis.calls.contains("release:redis"))
+        Assertions.assertTrue(cassandra.calls.contains("release:cassandra"))
+    }
+
+    @Test
+    fun `destroy twice releases once`() {
+        val store = FakeClaimStore("redis")
+        val (guard, _) = setUp(store)
+
+        guard.destroy()
+        guard.destroy()
+
+        Assertions.assertEquals(1, store.calls.count { it == "release:redis" })
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardStartupTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardStartupTests.kt
@@ -1,0 +1,114 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimException
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimProperties
+import com.demo.chat.domain.NodeIdClaimStore
+import com.demo.chat.domain.RuntimeOwnerId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+class NodeIdClaimGuardStartupTests {
+
+    private val props = NodeIdClaimProperties(null, null, null, null)
+
+    private fun guard(
+        stores: List<NodeIdClaimStore>,
+        scheduler: ManualClaimScheduler = ManualClaimScheduler()
+    ) = NodeIdClaimGuard(
+        stores, NodeId(7), RuntimeOwnerId("core-service@host-a:4711#a3f19c2b"),
+        props, GenericApplicationContext(), scheduler
+    )
+
+    @Test
+    fun `one granted store starts and schedules a renew`() {
+        val store = FakeClaimStore("redis")
+        val scheduler = ManualClaimScheduler()
+        guard(listOf(store), scheduler).afterPropertiesSet()
+
+        Assertions.assertEquals(listOf("claim:redis"), store.calls)
+        Assertions.assertNotNull(scheduler.periodic)
+    }
+
+    @Test
+    fun `two stores are claimed in backend name order`() {
+        val redis = FakeClaimStore("redis")
+        val cassandra = FakeClaimStore("cassandra")
+        guard(listOf(redis, cassandra)).afterPropertiesSet()
+
+        Assertions.assertEquals(listOf("claim:cassandra"), cassandra.calls)
+        Assertions.assertEquals(listOf("claim:redis"), redis.calls)
+    }
+
+    @Test
+    fun `a denial at the second store releases the first store`() {
+        val cassandra = FakeClaimStore("cassandra")
+        val redis = FakeClaimStore(
+            "redis",
+            claimAnswer = { ClaimResult.Denied("core-service@host-b:5122#77c0aa41") }
+        )
+
+        val thrown = Assertions.assertThrows(NodeIdClaimException::class.java) {
+            guard(listOf(redis, cassandra)).afterPropertiesSet()
+        }
+
+        Assertions.assertEquals(listOf("claim:cassandra", "release:cassandra"), cassandra.calls)
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid=7 is already claimed"))
+        Assertions.assertTrue(thrown.message!!.contains("redis store for key type long"))
+    }
+
+    @Test
+    fun `a store error at the second store releases the first store`() {
+        val cassandra = FakeClaimStore("cassandra")
+        val redis = FakeClaimStore("redis", claimAnswer = { throw IllegalStateException("redis is down") })
+
+        Assertions.assertThrows(Exception::class.java) {
+            guard(listOf(redis, cassandra)).afterPropertiesSet()
+        }
+
+        Assertions.assertEquals(listOf("claim:cassandra", "release:cassandra"), cassandra.calls)
+    }
+
+    @Test
+    fun `a release failure during rollback does not hide the claim failure`() {
+        val cassandra = object : NodeIdClaimStore {
+            override val backendName = "cassandra"
+            override val scope = "cassandra keyspace chat_long"
+            override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+                Mono.just(ClaimResult.Granted)
+            override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+                Mono.just(ClaimResult.Granted)
+            override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+                Mono.error(IllegalStateException("release failed"))
+        }
+        val redis = FakeClaimStore("redis", claimAnswer = { ClaimResult.Denied("other") })
+
+        val thrown = Assertions.assertThrows(NodeIdClaimException::class.java) {
+            guard(listOf(redis, cassandra)).afterPropertiesSet()
+        }
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid=7"))
+    }
+
+    @Test
+    fun `the deadline timer is armed after a successful claim`() {
+        val scheduler = ManualClaimScheduler()
+        guard(listOf(FakeClaimStore("redis")), scheduler).afterPropertiesSet()
+
+        Assertions.assertNotNull(scheduler.once)
+        Assertions.assertEquals(Duration.ofSeconds(25), scheduler.onceDelay)
+    }
+
+    @Test
+    fun `no stores means no claim and no schedule`() {
+        val scheduler = ManualClaimScheduler()
+        guard(emptyList(), scheduler).afterPropertiesSet()
+
+        Assertions.assertNull(scheduler.periodic)
+        Assertions.assertNull(scheduler.once)
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimPropertiesTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimPropertiesTests.kt
@@ -1,0 +1,90 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeIdClaimProperties
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class NodeIdClaimPropertiesTests {
+
+    private fun props(
+        ttl: Duration? = null,
+        renew: Duration? = null,
+        margin: Duration? = null,
+        timeout: Duration? = null
+    ) = NodeIdClaimProperties(ttl, renew, margin, timeout)
+
+    private fun failure(block: () -> Unit): String =
+        Assertions.assertThrows(IllegalArgumentException::class.java) { block() }.message!!
+
+    @Test
+    fun `defaults are thirty ten five and five`() {
+        val p = props()
+        Assertions.assertEquals(Duration.ofSeconds(30), p.ttl)
+        Assertions.assertEquals(Duration.ofSeconds(10), p.renewInterval)
+        Assertions.assertEquals(Duration.ofSeconds(5), p.safetyMargin)
+        Assertions.assertEquals(Duration.ofSeconds(5), p.operationTimeout)
+    }
+
+    @Test
+    fun `the default close deadline is twenty five seconds`() {
+        Assertions.assertEquals(Duration.ofSeconds(25), props().closeDeadline)
+    }
+
+    @Test
+    fun `a ttl under one second fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofMillis(500)) }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.ttl"), text)
+        Assertions.assertTrue(text.contains("at least 1s"), text)
+    }
+
+    @Test
+    fun `a fractional ttl fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofMillis(1500)) }
+        Assertions.assertTrue(text.contains("whole seconds"), text)
+    }
+
+    @Test
+    fun `a renew interval over one third of the ttl fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofSeconds(30), renew = Duration.ofSeconds(11)) }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.renew-interval"), text)
+        Assertions.assertTrue(text.contains("ttl / 3"), text)
+    }
+
+    @Test
+    fun `a renew interval of exactly one third of the ttl is accepted`() {
+        Assertions.assertEquals(
+            Duration.ofSeconds(10),
+            props(ttl = Duration.ofSeconds(30), renew = Duration.ofSeconds(10)).renewInterval
+        )
+    }
+
+    @Test
+    fun `a safety margin at or over the ttl fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofSeconds(30), margin = Duration.ofSeconds(30)) }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.safety-margin"), text)
+    }
+
+    @Test
+    fun `an operation timeout equal to the renew interval fails and states the rule`() {
+        val text = failure {
+            props(renew = Duration.ofSeconds(10), timeout = Duration.ofSeconds(10))
+        }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.operation-timeout"), text)
+        Assertions.assertTrue(text.contains("less than"), text)
+    }
+
+    @Test
+    fun `a close deadline at or under the renew interval fails and states the rule`() {
+        val text = failure {
+            props(
+                ttl = Duration.ofSeconds(12),
+                renew = Duration.ofSeconds(4),
+                margin = Duration.ofSeconds(8),
+                timeout = Duration.ofSeconds(1)
+            )
+        }
+        Assertions.assertTrue(text.contains("greater than"), text)
+        Assertions.assertTrue(text.contains("renew-interval"), text)
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/RuntimeOwnerIdTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/RuntimeOwnerIdTests.kt
@@ -1,0 +1,30 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.RuntimeOwnerId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class RuntimeOwnerIdTests {
+
+    @Test
+    fun `the value names the application the host and the process`() {
+        val owner = RuntimeOwnerId.generate("core-service").value
+        Assertions.assertTrue(owner.startsWith("core-service@"), owner)
+        Assertions.assertTrue(owner.contains(":"), owner)
+        Assertions.assertTrue(owner.contains("#"), owner)
+    }
+
+    @Test
+    fun `two values generated in one process differ`() {
+        Assertions.assertNotEquals(
+            RuntimeOwnerId.generate("core-service").value,
+            RuntimeOwnerId.generate("core-service").value
+        )
+    }
+
+    @Test
+    fun `the random suffix is eight hex characters`() {
+        val suffix = RuntimeOwnerId.generate("core-service").value.substringAfterLast("#")
+        Assertions.assertTrue(suffix.matches(Regex("[0-9a-f]{8}")), suffix)
+    }
+}

--- a/chat-core/src/test/kotlin/com/demo/chat/test/domain/SharedBackendConditionTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/domain/SharedBackendConditionTests.kt
@@ -1,0 +1,87 @@
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ConditionalOnSharedBackend
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimGuardConfiguration
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.mock.env.MockEnvironment
+
+/**
+ * Pins the activation invariant that keeps `app.nodeid` scoped.
+ *
+ * 1. A claim store configuration imports NodeIdClaimGuardConfiguration.
+ * 2. A memory only context contributes no NodeIdClaimStore.
+ * 3. No claim store means no guard bean.
+ * 4. No guard bean means this design requests no NodeId bean.
+ */
+class SharedBackendConditionTests {
+
+    @Configuration
+    @ConditionalOnSharedBackend("redis")
+    @Import(NodeIdClaimGuardConfiguration::class)
+    open class RedisClaimConfiguration {
+        @Bean
+        open fun redisClaimStore(): NodeIdClaimStore = FakeClaimStore("redis")
+    }
+
+    private fun contextWith(vararg properties: Pair<String, String>): AnnotationConfigApplicationContext {
+        val context = AnnotationConfigApplicationContext()
+        val environment = MockEnvironment()
+        properties.forEach { environment.setProperty(it.first, it.second) }
+        context.environment = environment
+        context.register(RedisClaimConfiguration::class.java)
+        context.refresh()
+        return context
+    }
+
+    @Test
+    fun `the key selector activates the store`() {
+        contextWith("app.service.core.key" to "redis", "app.nodeid" to "7").use { context ->
+            Assertions.assertEquals(1, context.getBeansOfType(NodeIdClaimStore::class.java).size)
+            Assertions.assertEquals(1, context.getBeansOfType(NodeIdClaimGuard::class.java).size)
+        }
+    }
+
+    @Test
+    fun `the persistence selector activates the store`() {
+        contextWith("app.service.core.persistence" to "redis", "app.nodeid" to "7").use { context ->
+            Assertions.assertEquals(1, context.getBeansOfType(NodeIdClaimStore::class.java).size)
+        }
+    }
+
+    @Test
+    fun `a memory pair activates nothing`() {
+        contextWith(
+            "app.service.core.key" to "memory",
+            "app.service.core.persistence" to "memory"
+        ).use { context ->
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimGuard::class.java).isEmpty())
+        }
+    }
+
+    @Test
+    fun `an unset pair activates nothing and needs no app nodeid`() {
+        contextWith().use { context ->
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+            Assertions.assertTrue(context.getBeansOfType(NodeId::class.java).isEmpty())
+        }
+    }
+
+    @Test
+    fun `a cassandra pair does not activate the redis store`() {
+        contextWith(
+            "app.service.core.key" to "cassandra",
+            "app.service.core.persistence" to "cassandra"
+        ).use { context ->
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+        }
+    }
+}

--- a/chat-deploy-cassandra/pom.xml
+++ b/chat-deploy-cassandra/pom.xml
@@ -31,6 +31,16 @@
             <artifactId>chat-persistence-cassandra</artifactId>
             <version>0.0.1</version>
         </dependency>
+        <!-- Test only. CassandraClaimBootTests boots the mixed seam, where
+             app.service.core.key=memory and app.service.core.persistence=cassandra.
+             That pair needs the memory KeyServiceBeans. Production deployments of
+             this module select cassandra for both, so this stays out of runtime. -->
+        <dependency>
+            <groupId>com.demo</groupId>
+            <artifactId>chat-persistence-memory</artifactId>
+            <version>0.0.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.demo</groupId>
             <artifactId>chat-service-composite</artifactId>

--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt
@@ -1,0 +1,154 @@
+package com.demo.chat.test.deploy.cassandra
+
+import com.demo.chat.ChatApp
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Boot level tests for the cassandra claim seam.
+ *
+ * Node ids 21 and 22 belong to this class. See the allocation table in the
+ * plan. CassandraDeployTest holds node id 1 in the same container, and
+ * truncate-long.cql does not clear node_claim.
+ */
+@Tag("integration")
+class CassandraClaimBootTests : CassandraContainerBase() {
+
+    private fun cqlsh(statement: String): String {
+        val result = cassandraContainer.execInContainer(
+            "cqlsh",
+            "-u", cassandraContainer.username,
+            "-p", cassandraContainer.password,
+            "-e", statement
+        )
+        Assertions.assertEquals(
+            0, result.exitCode,
+            "cqlsh failed. stdout: ${result.stdout} stderr: ${result.stderr}"
+        )
+        return result.stdout
+    }
+
+    /**
+     * Writes the claim with cqlsh, outside every application context.
+     *
+     * A booted context would take the id itself and release it on close, and
+     * the duplicate would not be there for the second boot.
+     */
+    private fun seedForeignClaim(nodeId: Int, owner: String) {
+        cqlsh("DELETE FROM chat_long.node_claim WHERE node_id = $nodeId;")
+        cqlsh(
+            "INSERT INTO chat_long.node_claim (node_id, owner_id) " +
+                "VALUES ($nodeId, '$owner') IF NOT EXISTS USING TTL 300;"
+        )
+        val readBack = cqlsh("SELECT owner_id FROM chat_long.node_claim WHERE node_id = $nodeId;")
+        Assertions.assertTrue(
+            readBack.contains(owner),
+            "the foreign claim seed must be applied. cqlsh said: $readBack"
+        )
+    }
+
+    /**
+     * The launch surface, written as command line arguments.
+     *
+     * SpringApplicationBuilder.properties() writes to defaultProperties,
+     * which is the lowest precedence source. application.yml would then
+     * override the container address with its own localhost value. A command
+     * line argument outranks a config file, so these arguments hold.
+     */
+    private fun launchArguments(): Array<String> = launchProperties().map { "--$it" }.toTypedArray()
+
+    private fun launchProperties(): Array<String> = arrayOf(
+        "spring.config.location=classpath:/application.yml",
+        "spring.config.additional-location=classpath:/config/logging.yml," +
+            "classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
+        "server.port=0",
+        "spring.rsocket.server.port=0",
+        "app.key.type=long",
+        "app.service.core.pubsub=memory",
+        "app.service.core.index=cassandra",
+        "app.service.core.secrets=cassandra",
+        "app.service.composite",
+        "app.service.composite.auth",
+        "app.controller.secrets",
+        "app.controller.key",
+        "app.controller.persistence",
+        "app.controller.index",
+        "app.controller.user",
+        "app.controller.message",
+        "app.controller.topic",
+        "app.controller.pubsub",
+        "app.service.security.userdetails",
+        "spring.profiles.active=cassandra-contact-point",
+        // SpringApplicationBuilder does not read @DynamicPropertySource.
+        "spring.cassandra.contact-points=${cassandraContainer.host}",
+        "spring.cassandra.port=${cassandraContainer.getMappedPort(9042)}",
+        "spring.cassandra.username=${cassandraContainer.username}",
+        "spring.cassandra.password=${cassandraContainer.password}"
+    )
+
+    private fun boot(vararg extra: String, ready: AtomicBoolean) =
+        SpringApplicationBuilder(ChatApp::class.java)
+            .web(WebApplicationType.NONE)
+            .listeners(ApplicationListener<ApplicationReadyEvent> { ready.set(true) })
+            .let { builder ->
+                BootRun(builder, launchArguments() + extra.map { "--$it" })
+            }
+
+    /** Carries the builder and its arguments, so `run` takes no argument list. */
+    private class BootRun(
+        private val builder: SpringApplicationBuilder,
+        private val arguments: Array<String>
+    ) {
+        fun run(): org.springframework.context.ConfigurableApplicationContext =
+            builder.run(*arguments)
+    }
+
+    private fun allMessages(thrown: Throwable): String =
+        generateSequence(thrown) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
+
+    @Test
+    fun `a live claim fails startup with the actionable message`() {
+        seedForeignClaim(21, "foreign-owner@host-z:1#deadbeef")
+        val ready = AtomicBoolean(false)
+
+        val thrown = Assertions.assertThrows(Exception::class.java) {
+            boot(
+                "app.nodeid=21",
+                "app.service.core.key=cassandra",
+                "app.service.core.persistence=cassandra",
+                ready = ready
+            ).run().close()
+        }
+
+        val text = allMessages(thrown)
+        Assertions.assertTrue(text.contains("app.nodeid=21 is already claimed"), text)
+        Assertions.assertTrue(text.contains("cassandra keyspace chat_long"), text)
+        Assertions.assertTrue(text.contains("foreign-owner@host-z:1#deadbeef"), text)
+        Assertions.assertFalse(ready.get(), "ApplicationReadyEvent must not be published")
+    }
+
+    @Test
+    fun `a memory key selector with cassandra persistence still claims`() {
+        val ready = AtomicBoolean(false)
+
+        boot(
+            "app.nodeid=22",
+            "app.service.core.key=memory",
+            "app.service.core.persistence=cassandra",
+            ready = ready
+        ).run().use { context ->
+            val stores = context.getBeansOfType(NodeIdClaimStore::class.java)
+            Assertions.assertEquals(1, stores.size)
+            Assertions.assertEquals("cassandra", stores.values.first().backendName)
+        }
+
+        Assertions.assertTrue(ready.get())
+    }
+}

--- a/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraContainerBase.kt
+++ b/chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraContainerBase.kt
@@ -6,7 +6,6 @@ import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
 import org.testcontainers.containers.CassandraContainer
 import org.testcontainers.containers.Network
-import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.utility.MountableFile
 import java.time.Duration
@@ -21,7 +20,12 @@ open class CassandraContainerBase {
     companion object {
         private const val CASSANDRA_IMAGE = "cassandra:4.1.3"
 
-        @Container
+        // Not annotated with @Container on purpose. @Container on a static
+        // field makes JUnit stop the container when the first test class
+        // finishes. The init block below starts it and applies the long
+        // keyspace exactly once per JVM, so a second test class would then
+        // meet a fresh container with no chat_long keyspace.
+        // RedisTestContainer starts its container the same way.
         val cassandraContainer = CassandraContainer(CASSANDRA_IMAGE).apply {
             withExposedPorts(9042)
             withReuse(true)

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryClaimAbsenceTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryClaimAbsenceTests.kt
@@ -1,0 +1,62 @@
+package com.demo.chat.test.deploy.memory
+
+import com.demo.chat.ChatApp
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Memory offers no claim, and it must not look as though it does.
+ *
+ * The limit of this test, stated so it is not overclaimed: memory still
+ * requires `app.nodeid`. Stage 1 requires it wherever a key generator
+ * activates. What this test pins is that the claim design adds no
+ * requirement to memory and supplies no no-operation store.
+ *
+ * A no-operation store that returned Granted would be false safety. A
+ * memory store is per process, so it can prove nothing about another
+ * deployment.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [ChatApp::class]
+)
+@TestPropertySource(
+    properties = [
+        "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
+        "spring.application.name=test-deployment", "app.server.proto=rsocket",
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long", "app.nodeid=1",
+        "app.service.core.key=memory",
+        "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
+        "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
+        "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",
+        "app.service.security.userdetails"
+    ]
+)
+class MemoryClaimAbsenceTests {
+
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Test
+    fun `a memory deployment registers no claim store`() {
+        Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+    }
+
+    @Test
+    fun `a memory deployment registers no claim guard`() {
+        Assertions.assertTrue(context.getBeansOfType(NodeIdClaimGuard::class.java).isEmpty())
+    }
+
+    @Test
+    fun `a memory deployment still supplies the node id from stage one`() {
+        Assertions.assertEquals(1, context.getBean(NodeId::class.java).value)
+    }
+}

--- a/chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt
+++ b/chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt
@@ -1,0 +1,125 @@
+package com.demo.chat.test.deploy.redis
+
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Boot level tests for the redis claim seam.
+ *
+ * Node ids 11 and 12 belong to this class. See the allocation table in the
+ * plan. RedisDeployBootTests holds node id 1 in the same container.
+ *
+ * The foreign claim is written straight to redis, not through a booted
+ * context. A guarded context would claim the id itself and then release it
+ * on close, and the duplicate would never be present for the second boot.
+ */
+@Tag("integration")
+class RedisClaimBootTests {
+
+    private val container = RedisDeployBootTests.redis
+
+    private fun template(): ReactiveStringRedisTemplate {
+        val factory = LettuceConnectionFactory(
+            RedisStandaloneConfiguration(container.containerIpAddress, container.getMappedPort(6379))
+        ).apply { afterPropertiesSet() }
+        return ReactiveStringRedisTemplate(factory)
+    }
+
+    private fun seedForeignClaim(nodeId: Int, owner: String) {
+        template().delete("chat:nodeclaim:long:$nodeId").block()
+        val applied = template().opsForValue()
+            .setIfAbsent("chat:nodeclaim:long:$nodeId", owner, Duration.ofSeconds(120))
+            .block()
+        Assertions.assertEquals(true, applied, "the foreign claim seed must be applied")
+    }
+
+    // The launch surface of RedisDeployBootTests. Each test overrides only
+    // what it needs after this list.
+    private fun launchProperties(): Array<String> = arrayOf(
+        "spring.application.name=redis-claim-boot-test",
+        "spring.main.web-application-type=reactive",
+        "server.port=0",
+        "spring.rsocket.server.port=0",
+        "app.server.proto=rsocket",
+        "app.key.type=long",
+        "app.service.core.pubsub=redis-pubsub",
+        "app.service.core.index=lucene",
+        "app.service.core.secrets=memory",
+        "app.service.composite",
+        "app.service.composite.auth",
+        "app.controller.persistence",
+        "app.controller.index",
+        "app.controller.key",
+        "app.controller.pubsub",
+        "app.controller.secrets",
+        "app.controller.user",
+        "app.controller.topic",
+        "app.controller.message",
+        "spring.cloud.consul.enabled=false",
+        "spring.cloud.consul.discovery.enabled=false",
+        "spring.cloud.consul.config.enabled=false",
+        // SpringApplicationBuilder does not read @DynamicPropertySource.
+        "redis-topics.host=${container.containerIpAddress}",
+        "redis-topics.port=${container.getMappedPort(6379)}"
+    )
+
+    private fun boot(vararg extra: String, ready: AtomicBoolean) =
+        SpringApplicationBuilder(RedisDeployBootTests.BootApp::class.java)
+            .web(WebApplicationType.REACTIVE)
+            .properties(*launchProperties(), *extra)
+            .listeners(ApplicationListener<ApplicationReadyEvent> { ready.set(true) })
+
+    private fun allMessages(thrown: Throwable): String =
+        generateSequence(thrown) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
+
+    @Test
+    fun `a live claim fails startup with the actionable message`() {
+        seedForeignClaim(11, "foreign-owner@host-z:1#deadbeef")
+        val ready = AtomicBoolean(false)
+
+        val thrown = Assertions.assertThrows(Exception::class.java) {
+            boot(
+                "app.nodeid=11",
+                "app.service.core.key=redis",
+                "app.service.core.persistence=redis",
+                ready = ready
+            ).run().close()
+        }
+
+        val text = allMessages(thrown)
+        Assertions.assertTrue(text.contains("app.nodeid=11 is already claimed"), text)
+        Assertions.assertTrue(text.contains("redis store for key type long"), text)
+        Assertions.assertTrue(text.contains("foreign-owner@host-z:1#deadbeef"), text)
+        // The requirement is failure before ready and before normal traffic.
+        Assertions.assertFalse(ready.get(), "ApplicationReadyEvent must not be published")
+    }
+
+    @Test
+    fun `a memory key selector with redis persistence still claims`() {
+        val ready = AtomicBoolean(false)
+
+        boot(
+            "app.nodeid=12",
+            "app.service.core.key=memory",
+            "app.service.core.persistence=redis",
+            ready = ready
+        ).run().use { context ->
+            val stores = context.getBeansOfType(NodeIdClaimStore::class.java)
+            Assertions.assertEquals(1, stores.size)
+            Assertions.assertEquals("redis", stores.values.first().backendName)
+        }
+
+        Assertions.assertTrue(ready.get())
+    }
+}

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/NodeIdClaimConfiguration.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/NodeIdClaimConfiguration.kt
@@ -1,0 +1,29 @@
+package com.demo.chat.config.persistence.cassandra
+
+import com.demo.chat.domain.ConditionalOnSharedBackend
+import com.demo.chat.domain.NodeIdClaimGuardConfiguration
+import com.demo.chat.domain.NodeIdClaimStore
+import com.demo.chat.persistence.cassandra.impl.CassandraNodeIdClaimStore
+import org.springframework.boot.autoconfigure.cassandra.CassandraProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+
+/**
+ * Registers the cassandra node id claim store.
+ *
+ * The bean name is explicit. The redis module ships a class with the same
+ * simple name, and a classpath that names both backends registers both.
+ */
+@Configuration("cassandraNodeIdClaimConfiguration")
+@ConditionalOnSharedBackend("cassandra")
+@Import(NodeIdClaimGuardConfiguration::class)
+class NodeIdClaimConfiguration {
+
+    @Bean("cassandraNodeIdClaimStore")
+    fun cassandraNodeIdClaimStore(
+        template: ReactiveCassandraTemplate,
+        properties: CassandraProperties
+    ): NodeIdClaimStore = CassandraNodeIdClaimStore(template, properties.keyspaceName)
+}

--- a/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/persistence/cassandra/impl/CassandraNodeIdClaimStore.kt
+++ b/chat-persistence-cassandra/src/main/kotlin/com/demo/chat/persistence/cassandra/impl/CassandraNodeIdClaimStore.kt
@@ -1,0 +1,101 @@
+package com.demo.chat.persistence.cassandra.impl
+
+import com.datastax.oss.driver.api.core.cql.Row
+import com.datastax.oss.driver.api.core.servererrors.InvalidQueryException
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimStore
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * The cassandra node id lease.
+ *
+ * A lightweight transaction runs at SERIAL, and the coordinator applies the
+ * TTL. No application clock enters the decision.
+ *
+ * The claim lives in the session keyspace, so `chat_long` and `chat_uuid`
+ * hold separate leases. That matches the redis key type scoping.
+ *
+ * The table name is a parameter so that a test can point at an absent table
+ * and prove the message.
+ */
+class CassandraNodeIdClaimStore(
+    private val template: ReactiveCassandraTemplate,
+    private val keyspace: String,
+    private val table: String = "node_claim"
+) : NodeIdClaimStore {
+
+    override val backendName: String = "cassandra"
+
+    override val scope: String = "cassandra keyspace $keyspace"
+
+    private val cql get() = template.reactiveCqlOperations
+
+    private val schemaFile: String = "keyspace-" + keyspace.removePrefix("chat_") + ".cql"
+
+    override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        cql.queryForRows(
+            "INSERT INTO $table (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL ?",
+            nodeId.value, owner, ttl.seconds.toInt()
+        ).next().map { row ->
+            if (row.getBoolean("[applied]")) ClaimResult.Granted as ClaimResult
+            else ClaimResult.Denied(
+                holderOf(row)
+                    ?: throw IllegalStateException(
+                        "The $scope denied app.nodeid=${nodeId.value} and named no holder."
+                    )
+            )
+        }.onErrorMap { mapMissingTable(it) }
+
+    override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        cql.queryForRows(
+            "UPDATE $table USING TTL ? SET owner_id = ? WHERE node_id = ? IF owner_id = ?",
+            ttl.seconds.toInt(), owner, nodeId.value, owner
+        ).next().map { row ->
+            when {
+                row.getBoolean("[applied]") -> ClaimResult.Granted as ClaimResult
+                // No live row. The lease is gone, and no other owner is named.
+                holderOf(row) == null -> ClaimResult.Lost
+                else -> ClaimResult.Denied(holderOf(row)!!)
+            }
+        }.onErrorMap { mapMissingTable(it) }
+
+    override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+        cql.queryForRows(
+            "DELETE FROM $table WHERE node_id = ? IF owner_id = ?",
+            nodeId.value, owner
+        ).next().then()
+            .onErrorMap { mapMissingTable(it) }
+
+    /**
+     * Reads the current holder from a lightweight transaction result.
+     *
+     * A transaction that did not apply because no row exists returns a row
+     * that carries `[applied]` and nothing else. Asking that row for
+     * `owner_id` throws. So test for the column, do not test for null.
+     */
+    private fun holderOf(row: Row): String? =
+        if (row.columnDefinitions.contains("owner_id")) row.getString("owner_id") else null
+
+    /**
+     * Spring Data wraps the driver exception before it reaches the caller,
+     * so the driver type alone does not match. Walk the cause chain instead.
+     */
+    private fun mapMissingTable(error: Throwable): Throwable =
+        if (isMissingTable(error)) missingTable(error) else error
+
+    private fun isMissingTable(error: Throwable): Boolean =
+        generateSequence(error) { it.cause }.any {
+            it is InvalidQueryException && it.message?.contains("does not exist") == true
+        }
+
+    private fun missingTable(cause: Throwable): Throwable =
+        IllegalStateException(
+            "The $scope has no $table table. " +
+                "Apply $schemaFile from shared-resources-cassandra, or run the CREATE TABLE " +
+                "statement in docs/NODEID-CLAIM.md against an existing keyspace.",
+            cause
+        )
+}

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/CassandraNodeIdClaimStoreTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/CassandraNodeIdClaimStoreTests.kt
@@ -1,0 +1,141 @@
+package com.demo.chat.test.persistence.integration
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.persistence.cassandra.impl.CassandraNodeIdClaimStore
+import com.demo.chat.test.repository.RepositoryTestConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.Duration
+
+/**
+ * Store level tests for the cassandra claim.
+ *
+ * These call the store directly and pass the TTL as an argument. The guard
+ * property rules do not apply here. Cassandra applies a TTL in whole
+ * seconds, so the expiry test uses three seconds.
+ *
+ * Node ids 200 to 209 belong to this package. See the allocation table in
+ * the plan. truncate-long.cql does not clear node_claim, so a reused node
+ * id would meet an earlier claim.
+ */
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [RepositoryTestConfiguration::class]
+)
+@TestPropertySource(properties = ["app.key.type=long", "app.nodeid=204"])
+@Tag("integration")
+class CassandraNodeIdClaimStoreTests {
+
+    @Autowired
+    lateinit var template: ReactiveCassandraTemplate
+
+    private val store by lazy { CassandraNodeIdClaimStore(template, "chat_long") }
+
+    @Test
+    fun `the scope names the backend and the keyspace`() {
+        Assertions.assertEquals("cassandra", store.backendName)
+        Assertions.assertEquals("cassandra keyspace chat_long", store.scope)
+    }
+
+    @Test
+    fun `a second owner is denied and the holder is named`() {
+        val node = NodeId(205)
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            store.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a release allows a takeover`() {
+        val node = NodeId(206)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        store.release(node, "owner-one").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a release by another owner does nothing`() {
+        val node = NodeId(207)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        store.release(node, "owner-two").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            store.claim(node, "owner-three", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `an expiry allows a takeover`() {
+        val node = NodeId(208)
+        store.claim(node, "owner-one", Duration.ofSeconds(1)).block()
+        Thread.sleep(Duration.ofSeconds(3).toMillis())
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by the holder is granted`() {
+        val node = NodeId(209)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.renew(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by another owner is denied and names the holder`() {
+        val node = NodeId(200)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            store.renew(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew with no live claim reports lost`() {
+        Assertions.assertEquals(
+            ClaimResult.Lost,
+            store.renew(NodeId(201), "owner-one", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a missing table names the table and the schema file`() {
+        val missing = CassandraNodeIdClaimStore(template, "chat_long", "node_claim_absent")
+
+        val thrown = Assertions.assertThrows(Exception::class.java) {
+            missing.claim(NodeId(202), "owner-one", Duration.ofSeconds(30)).block()
+        }
+        val text = generateSequence(thrown as Throwable) { it.cause }
+            .mapNotNull { it.message }.joinToString(" | ")
+
+        Assertions.assertTrue(text.contains("node_claim_absent"), text)
+        Assertions.assertTrue(text.contains("keyspace-long.cql"), text)
+    }
+}

--- a/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/NodeClaimTableProbeTests.kt
+++ b/chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/NodeClaimTableProbeTests.kt
@@ -1,0 +1,71 @@
+package com.demo.chat.test.persistence.integration
+
+import com.demo.chat.test.repository.RepositoryTestConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.Duration
+
+/**
+ * Probe for one load-bearing claim in the node id lease design.
+ *
+ * The claim: when owner_id expires, node_claim holds a primary key with no
+ * live columns, and IF NOT EXISTS then treats the row as absent.
+ *
+ * This test exists before any guard code. A failure here changes the
+ * schema. The fallback adds an explicit expires_at column, and that returns
+ * a clock question to the design.
+ *
+ * Node ids 200 to 209 belong to this package. truncate-long.cql does not
+ * clear node_claim, so a reused node id would meet an earlier claim.
+ */
+@ExtendWith(SpringExtension::class)
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [RepositoryTestConfiguration::class]
+)
+@TestPropertySource(properties = ["app.key.type=long", "app.nodeid=200"])
+@Tag("integration")
+class NodeClaimTableProbeTests {
+
+    @Autowired
+    lateinit var template: ReactiveCassandraTemplate
+
+    private val cql get() = template.reactiveCqlOperations
+
+    private fun claim(nodeId: Int, owner: String, ttlSeconds: Int): Boolean =
+        cql.queryForRows(
+            "INSERT INTO node_claim (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL ?",
+            nodeId, owner, ttlSeconds
+        ).next().map { it.getBoolean("[applied]") }.block()!!
+
+    @Test
+    fun `a second owner cannot take a live claim`() {
+        Assertions.assertTrue(claim(201, "owner-one", 30))
+        Assertions.assertFalse(claim(201, "owner-two", 30))
+    }
+
+    @Test
+    fun `an expired claim is absent for IF NOT EXISTS`() {
+        Assertions.assertTrue(claim(202, "owner-one", 1))
+        Thread.sleep(Duration.ofSeconds(3).toMillis())
+        Assertions.assertTrue(
+            claim(202, "owner-two", 30),
+            "A TTL expired row must be absent for IF NOT EXISTS. " +
+                "If this fails, the design needs an explicit expires_at column."
+        )
+    }
+
+    @Test
+    fun `a deleted claim is absent for IF NOT EXISTS`() {
+        Assertions.assertTrue(claim(203, "owner-one", 30))
+        cql.execute("DELETE FROM node_claim WHERE node_id = ?", 203).block()
+        Assertions.assertTrue(claim(203, "owner-two", 30))
+    }
+}

--- a/chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/NodeIdClaimConfiguration.kt
+++ b/chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/NodeIdClaimConfiguration.kt
@@ -1,0 +1,31 @@
+package com.demo.chat.config.persistence.redis
+
+import com.demo.chat.domain.ConditionalOnSharedBackend
+import com.demo.chat.domain.NodeIdClaimGuardConfiguration
+import com.demo.chat.domain.NodeIdClaimStore
+import com.demo.chat.persistence.redis.impl.RedisNodeIdClaimStore
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+
+/**
+ * Registers the redis node id claim store.
+ *
+ * The bean name is explicit. The cassandra module ships a class with the
+ * same simple name, and a classpath that names both backends registers both.
+ * The `KeyGenConfiguration` classes carry explicit names for the same
+ * reason.
+ */
+@Configuration("redisNodeIdClaimConfiguration")
+@ConditionalOnSharedBackend("redis")
+@Import(NodeIdClaimGuardConfiguration::class)
+class NodeIdClaimConfiguration {
+
+    @Bean("redisNodeIdClaimStore")
+    fun redisNodeIdClaimStore(
+        template: ReactiveStringRedisTemplate,
+        @Value("\${app.key.type}") keyType: String
+    ): NodeIdClaimStore = RedisNodeIdClaimStore(template, keyType)
+}

--- a/chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/RedisNodeIdClaimStore.kt
+++ b/chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/RedisNodeIdClaimStore.kt
@@ -1,0 +1,108 @@
+package com.demo.chat.persistence.redis.impl
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimStore
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * The redis node id lease.
+ *
+ * The key carries the key type, because a cassandra deployment already
+ * separates key types by keyspace. A long deployment and a uuid deployment
+ * on one redis may both hold node id 7. Their value spaces do not intersect.
+ *
+ * `PX` makes the redis server the clock. No application clock enters the
+ * decision.
+ */
+class RedisNodeIdClaimStore(
+    private val template: ReactiveStringRedisTemplate,
+    private val keyType: String
+) : NodeIdClaimStore {
+
+    override val backendName: String = "redis"
+
+    override val scope: String = "redis store for key type $keyType"
+
+    private fun key(nodeId: NodeId): String = "chat:nodeclaim:$keyType:${nodeId.value}"
+
+    override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        attempt(nodeId, owner, ttl)
+            // The holder vanished between the write and the read. Try once more.
+            .switchIfEmpty(attempt(nodeId, owner, ttl))
+            .switchIfEmpty(
+                Mono.error(
+                    IllegalStateException(
+                        "The $scope denied app.nodeid=${nodeId.value} twice and named no holder."
+                    )
+                )
+            )
+
+    override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        run(renewScript, nodeId, owner, ttl.toMillis().toString())
+
+    override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+        run(releaseScript, nodeId, owner, "0").then()
+
+    private fun attempt(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        template.opsForValue().setIfAbsent(key(nodeId), owner, ttl)
+            .flatMap { taken ->
+                if (taken) Mono.just(ClaimResult.Granted as ClaimResult)
+                // A diagnostic read. A stale value costs message quality only.
+                else template.opsForValue().get(key(nodeId))
+                    .map { holder -> ClaimResult.Denied(holder) as ClaimResult }
+            }
+
+    private fun run(
+        script: RedisScript<String>,
+        nodeId: NodeId,
+        owner: String,
+        millis: String
+    ): Mono<ClaimResult> =
+        template.execute(script, listOf(key(nodeId)), listOf(owner, millis))
+            .next()
+            .map { reply ->
+                when {
+                    reply == "granted" -> ClaimResult.Granted
+                    reply == "lost" -> ClaimResult.Lost
+                    reply.startsWith("denied:") -> ClaimResult.Denied(reply.removePrefix("denied:"))
+                    else -> throw IllegalStateException(
+                        "The $scope returned an unknown claim reply: $reply"
+                    )
+                }
+            }
+
+    companion object {
+        // Lua gives the compare and set that plain commands cannot. The reply
+        // is one string, because ReactiveStringRedisTemplate carries a string
+        // serializer and a mixed Lua array would need a mixed result type.
+        private val renewScript: RedisScript<String> = RedisScript.of(
+            """
+            local v = redis.call('GET', KEYS[1])
+            if v == false then return 'lost' end
+            if v == ARGV[1] then
+                redis.call('PEXPIRE', KEYS[1], ARGV[2])
+                return 'granted'
+            end
+            return 'denied:' .. v
+            """.trimIndent(),
+            String::class.java
+        )
+
+        private val releaseScript: RedisScript<String> = RedisScript.of(
+            """
+            local v = redis.call('GET', KEYS[1])
+            if v == false then return 'lost' end
+            if v == ARGV[1] then
+                redis.call('DEL', KEYS[1])
+                return 'granted'
+            end
+            return 'denied:' .. v
+            """.trimIndent(),
+            String::class.java
+        )
+    }
+}

--- a/chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisNodeIdClaimStoreTests.kt
+++ b/chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisNodeIdClaimStoreTests.kt
@@ -1,0 +1,155 @@
+package com.demo.chat.test.persistence.redis
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.persistence.redis.impl.RedisNodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.junit.jupiter.SpringExtension
+import java.time.Duration
+
+/**
+ * Store level tests for the redis claim.
+ *
+ * These call the store directly and pass the TTL as an argument. The guard
+ * property rules do not apply here, so a one second lease is legal.
+ *
+ * Node ids 100 to 109 belong to this class. See the allocation table in the
+ * plan. Two contexts against one container must not share a node id.
+ */
+@Extensions(
+    ExtendWith(SpringExtension::class)
+)
+@Import(RedisPersistenceTestContext::class)
+@Tag("integration")
+class RedisNodeIdClaimStoreTests(
+    @Autowired private val stringTemplate: ReactiveStringRedisTemplate
+) {
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun containerSetup(registry: DynamicPropertyRegistry) = RedisTestContainer.properties(registry)
+    }
+
+    private val longStore by lazy { RedisNodeIdClaimStore(stringTemplate, "long") }
+    private val uuidStore by lazy { RedisNodeIdClaimStore(stringTemplate, "uuid") }
+
+    @BeforeEach
+    fun `flush redis`() {
+        stringTemplate.delete(stringTemplate.keys("chat:nodeclaim:*")).block()
+    }
+
+    @Test
+    fun `the scope names the backend and the key type`() {
+        Assertions.assertEquals("redis", longStore.backendName)
+        Assertions.assertEquals("redis store for key type long", longStore.scope)
+    }
+
+    @Test
+    fun `a second owner is denied and the holder is named`() {
+        val node = NodeId(100)
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+
+        val second = longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(ClaimResult.Denied("owner-one"), second)
+    }
+
+    @Test
+    fun `a release allows a takeover`() {
+        val node = NodeId(101)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        longStore.release(node, "owner-one").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a release by another owner does nothing`() {
+        val node = NodeId(102)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        longStore.release(node, "owner-two").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            longStore.claim(node, "owner-three", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `an expiry allows a takeover`() {
+        val node = NodeId(103)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(1)).block()
+        Thread.sleep(1500)
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by the holder extends the lease`() {
+        val node = NodeId(104)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(1)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.renew(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+        Thread.sleep(1500)
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by another owner is denied and names the holder`() {
+        val node = NodeId(105)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            longStore.renew(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew with no live claim reports lost`() {
+        Assertions.assertEquals(
+            ClaimResult.Lost,
+            longStore.renew(NodeId(106), "owner-one", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a long claim and a uuid claim on one node id both hold`() {
+        val node = NodeId(107)
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-long", Duration.ofSeconds(30)).block()
+        )
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            uuidStore.claim(node, "owner-uuid", Duration.ofSeconds(30)).block()
+        )
+    }
+}

--- a/docs/NODEID-CLAIM.md
+++ b/docs/NODEID-CLAIM.md
@@ -1,0 +1,129 @@
+# Node id claim lease
+
+`app.nodeid` identifies one host in the Snowflake key generator. Two
+deployments that write to one shared store must not use the same value.
+
+A registry check cannot enforce this. One store can be reached by
+deployments that do not share a registry. The claim therefore lives in the
+store.
+
+## When a process claims
+
+A process claims when `app.service.core.key` or
+`app.service.core.persistence` names `redis` or `cassandra`.
+
+| key \ persistence | `memory` | `redis` | `cassandra` |
+|---|---|---|---|
+| `memory` | none | redis | cassandra |
+| `redis` | redis | redis | redis and cassandra |
+| `cassandra` | cassandra | cassandra and redis | cassandra |
+
+An unset selector counts as `memory`. A client that names neither selector
+claims nothing.
+
+Generated ids reach the key store and the persistence store. That is why
+one selector alone does not decide the claim.
+
+## Scope of the claim
+
+Uniqueness is per key type per store.
+
+Cassandra separates key types by keyspace. Redis carries the key type in the
+claim key, `chat:nodeclaim:<keyType>:<nodeId>`.
+
+A `long` deployment and a `uuid` deployment on one redis may both hold node
+id 7. Their value spaces do not intersect, because `UUIDKeyGenerator` hashes
+the Snowflake `Long`.
+
+A Cassandra UUID deployment still claims a lease. `CassandraUUIDKeyGenerator`
+ignores the node id, so this is policy uniformity, not collision
+prevention. One contract covers every backend, and an operator does not have
+to remember an exception.
+
+## Properties
+
+| Property | Default |
+|---|---|
+| `app.nodeid.claim.ttl` | `30s` |
+| `app.nodeid.claim.renew-interval` | `10s` |
+| `app.nodeid.claim.safety-margin` | `5s` |
+| `app.nodeid.claim.operation-timeout` | `5s` |
+
+Rules: `ttl` is at least 1s and uses whole seconds. `renew-interval` is at
+most `ttl / 3`. `safety-margin` is above zero and below `ttl`.
+`operation-timeout` is below `renew-interval`. `ttl` minus `safety-margin`
+is above `renew-interval`.
+
+A rule failure fails startup and states the rule.
+
+## What the process does while it runs
+
+The process renews every `renew-interval`.
+
+A renew that finds another owner closes the application context at once. A
+renew that finds no live claim does the same.
+
+A renew that fails on a store error logs a warning and retries. The process
+closes when `ttl` minus `safety-margin` passes with no successful renew.
+With the defaults that is 25 seconds.
+
+A clean shutdown releases the lease, so a restart is immediate. A crash
+leaves the lease to expire.
+
+## Cassandra upgrade
+
+A fresh keyspace gets `node_claim` from `keyspace-long.cql` or
+`keyspace-uuid.cql`. An existing keyspace needs the statement below. Run it
+once per keyspace, before the upgrade.
+
+```sql
+CREATE TABLE IF NOT EXISTS chat_long.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+```
+
+Use `chat_uuid` for a uuid keyspace.
+
+`node_claim` is deliberately absent from `truncate-long.cql` and
+`truncate-uuid.cql`. A live lease must expire. A cleanup script must not
+delete it.
+
+## Reading a startup failure
+
+```
+app.nodeid=7 is already claimed in the redis store for key type long.
+Holder: core-service@host-a:4711#a3f19c2b
+Two deployments that write to the redis store for key type long must not
+use the same app.nodeid.
+Set a different app.nodeid, or stop the other deployment and wait 30s
+for its lease to expire.
+```
+
+The holder names the application, the host, the process id, and a random
+suffix. A restart never reuses the suffix.
+
+Set a different `app.nodeid`, or stop the named deployment. A stopped
+deployment releases its lease on a clean shutdown. A crashed deployment
+releases it when the lease expires.
+
+A missing Cassandra table reports a different message. It names
+`node_claim` and the schema file to apply.
+
+## Testing note
+
+Every container-backed test that activates a claim store uses its own
+`app.nodeid`. Spring caches contexts, so two open contexts against one store
+would collide. That collision is correct behaviour, and it appears as a test
+failure.
+
+| Module and test | `app.nodeid` |
+|---|---|
+| `chat-persistence-redis` claim store tests | 100 to 109 |
+| `chat-persistence-cassandra` claim store tests | 200 to 209 |
+| `chat-deploy-redis` `RedisDeployBootTests` | 1 |
+| `chat-deploy-redis` `RedisClaimBootTests` | 11 and 12 |
+| `chat-deploy-cassandra` `CassandraDeployTest` | 1 |
+| `chat-deploy-cassandra` `CassandraClaimBootTests` | 21 and 22 |
+| `chat-deploy-memory`, `chat-deploy-kafka` | 1, and they claim nothing |

--- a/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
+++ b/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
@@ -21,6 +21,7 @@
 - Property rules: `ttl >= 1s` and whole seconds. `renew-interval <= ttl / 3`. `safety-margin > 0` and `< ttl`. `operation-timeout < renew-interval`. `ttl - safety-margin > renew-interval`.
 - Do not use `grep` or `find` for symbol lookup. Use the language server or treesitter tools.
 - Every `mvn -pl` command outside `chat-core` carries `-am`. This task chain adds new types to `chat-core` and new CQL to `shared-resources-cassandra`. Without `-am`, Maven resolves the stale installed artifact and the module compiles against the old code.
+- Every command that carries both `-am` and `-Dtest` also carries `-Dsurefire.failIfNoSpecifiedTests=false`. `-am` runs surefire in each upstream module too, and an upstream module that holds no matching test fails the build with `No tests matching pattern`.
 
 ### Node id allocation
 
@@ -189,7 +190,7 @@ class NodeClaimTableProbeTests {
 
 - [ ] **Step 4: Run the probe**
 
-Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=NodeClaimTableProbeTests`
+Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=NodeClaimTableProbeTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: PASS, all three tests. A Docker daemon must be running.
 
@@ -1805,7 +1806,7 @@ class RedisNodeIdClaimStoreTests(
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `mvn -o -pl chat-persistence-redis -am -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-redis -am -Pintegration test -Dtest=RedisNodeIdClaimStoreTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: FAIL to compile, with an unresolved reference to `RedisNodeIdClaimStore`.
 
@@ -1964,7 +1965,7 @@ class NodeIdClaimConfiguration {
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
-Run: `mvn -o -pl chat-persistence-redis -am -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-redis -am -Pintegration test -Dtest=RedisNodeIdClaimStoreTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: PASS, 9 tests.
 
@@ -2143,7 +2144,7 @@ class CassandraNodeIdClaimStoreTests {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: FAIL to compile, with an unresolved reference to `CassandraNodeIdClaimStore`.
 
@@ -2270,7 +2271,7 @@ class NodeIdClaimConfiguration {
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
-Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: PASS, 9 tests.
 
@@ -2430,7 +2431,7 @@ class RedisClaimBootTests {
 
 - [ ] **Step 2: Run the boot tests**
 
-Run: `mvn -o -pl chat-deploy-redis -am -Pintegration test -Dtest=RedisClaimBootTests`
+Run: `mvn -o -pl chat-deploy-redis -am -Pintegration test -Dtest=RedisClaimBootTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: PASS, 2 tests.
 
@@ -2613,7 +2614,7 @@ class CassandraClaimBootTests : CassandraContainerBase() {
 
 - [ ] **Step 2: Run the boot tests**
 
-Run: `mvn -o -pl chat-deploy-cassandra -am -Pintegration test -Dtest=CassandraClaimBootTests`
+Run: `mvn -o -pl chat-deploy-cassandra -am -Pintegration test -Dtest=CassandraClaimBootTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: PASS, 2 tests.
 
@@ -2703,7 +2704,7 @@ class MemoryClaimAbsenceTests {
 
 - [ ] **Step 2: Run the tests**
 
-Run: `mvn -o -pl chat-deploy-memory -am test -Dtest=MemoryClaimAbsenceTests`
+Run: `mvn -o -pl chat-deploy-memory -am test -Dtest=MemoryClaimAbsenceTests -Dsurefire.failIfNoSpecifiedTests=false`
 
 Expected: PASS, 3 tests. Nothing on this classpath names redis or cassandra, so the condition never matches.
 

--- a/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
+++ b/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
@@ -1,0 +1,2800 @@
+# Node id claim lease Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. This repository forbids subagent-driven development. See `CLAUDE.md`.
+
+**Goal:** Make a Redis or Cassandra deployment fail to start when a live `app.nodeid` claim for the same key space is already held in the same shared store.
+
+**Architecture:** A `NodeIdClaimStore` contract in `chat-core` exposes `claim`, `renew`, and `release`. Redis implements it with `SET NX PX` and Lua owner checks. Cassandra implements it with a `node_claim` table and lightweight transactions. One `NodeIdClaimGuard` claims during context refresh, renews on its own scheduler, and closes the context when the lease is lost.
+
+**Tech Stack:** Kotlin, Spring Boot, Project Reactor, Spring Data Redis reactive, Spring Data Cassandra reactive, JUnit 5, Testcontainers, Maven.
+
+**Spec:** `docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md`
+
+## Global Constraints
+
+- Kotlin is the primary language. Follow the file and package layout of the module you edit.
+- Prose in comments, messages, and commits uses plain controlled English. Short sentences. Active voice. One instruction per sentence. No semicolons.
+- Every new integration test carries `@Tag("integration")`. The root `pom.xml` excludes that group unless `-Pintegration` runs.
+- `KNOWN_FAILING_INTEGRATION` in `shell-scripts/build-health.sh` stays empty. A container-backed regression is signal.
+- `truncate-long.cql` and `truncate-uuid.cql` never gain `node_claim`. A live lease expires. A cleanup script must not delete it.
+- Property defaults: `app.nodeid.claim.ttl=30s`, `renew-interval=10s`, `safety-margin=5s`, `operation-timeout=5s`.
+- Property rules: `ttl >= 1s` and whole seconds. `renew-interval <= ttl / 3`. `safety-margin > 0` and `< ttl`. `operation-timeout < renew-interval`. `ttl - safety-margin > renew-interval`.
+- Do not use `grep` or `find` for symbol lookup. Use the language server or treesitter tools.
+
+### Node id allocation
+
+Every container-backed test that activates a claim store must use its own `app.nodeid`. Spring caches contexts, so two open contexts against one store would collide. This table is the allocation. Do not reuse a value.
+
+| Module and test | `app.nodeid` |
+|---|---|
+| `chat-core` unit tests (no store) | any |
+| `chat-persistence-redis` claim store tests | 100 to 109 |
+| `chat-persistence-cassandra` claim store tests | 200 to 209 |
+| `chat-deploy-redis` `RedisDeployBootTests` (existing) | 1 |
+| `chat-deploy-redis` duplicate boot test | 11 |
+| `chat-deploy-redis` memory key seam boot test | 12 |
+| `chat-deploy-cassandra` `CassandraDeployTest` (existing) | 1 |
+| `chat-deploy-cassandra` duplicate boot test | 21 |
+| `chat-deploy-cassandra` memory key seam boot test | 22 |
+| `chat-deploy-memory`, `chat-deploy-kafka` (no claim) | 1 |
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `chat-core/.../domain/ClaimResult.kt` | The three claim outcomes |
+| `chat-core/.../domain/NodeIdClaimStore.kt` | The store contract |
+| `chat-core/.../domain/NodeIdClaimException.kt` | The one duplicate-node message template |
+| `chat-core/.../domain/NodeIdClaimProperties.kt` | Bound properties and their rules |
+| `chat-core/.../domain/ClaimScheduler.kt` | Scheduling seam, plus the executor implementation |
+| `chat-core/.../domain/RuntimeOwnerId.kt` | The per-process owner value |
+| `chat-core/.../domain/NodeIdClaimGuard.kt` | Claim, renew, deadline, release |
+| `chat-core/.../domain/ConditionalOnSharedBackend.kt` | The OR condition on the two selectors |
+| `chat-core/.../domain/NodeIdClaimGuardConfiguration.kt` | The guard beans, imported by every store config |
+| `chat-persistence-redis/.../persistence/redis/impl/RedisNodeIdClaimStore.kt` | The Redis store |
+| `chat-persistence-redis/.../config/persistence/redis/NodeIdClaimConfiguration.kt` | Registers the Redis store |
+| `chat-persistence-cassandra/.../persistence/cassandra/impl/CassandraNodeIdClaimStore.kt` | The Cassandra store |
+| `chat-persistence-cassandra/.../config/persistence/cassandra/NodeIdClaimConfiguration.kt` | Registers the Cassandra store |
+| `shared-resources-cassandra/src/main/resources/keyspace-long.cql` | Adds `node_claim` |
+| `shared-resources-cassandra/src/main/resources/keyspace-uuid.cql` | Adds `node_claim` |
+| `docs/NODEID-CLAIM.md` | Operator document, including the upgrade statement |
+
+---
+
+### Task 1: Prove the Cassandra expiry behaviour
+
+This task is the probe for the load-bearing unverified claim. It adds no production Kotlin. If the probe fails, stop and report. The fallback is an explicit `expires_at` column, and that changes the design.
+
+**Files:**
+- Modify: `shared-resources-cassandra/src/main/resources/keyspace-long.cql`
+- Modify: `shared-resources-cassandra/src/main/resources/keyspace-uuid.cql`
+- Test: `chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/NodeClaimTableProbeTests.kt`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: the table `node_claim(node_id int PRIMARY KEY, owner_id text)` in keyspaces `chat_long` and `chat_uuid`.
+
+- [ ] **Step 1: Add the table to the long keyspace**
+
+Add this block to `shared-resources-cassandra/src/main/resources/keyspace-long.cql`, after the `chat_long.keys` table.
+
+```sql
+-- Holds the app.nodeid lease. One row per claimed node id.
+-- The row carries a TTL, so a crashed deployment releases its own id.
+-- This table is deliberately absent from truncate-long.cql. A live lease
+-- must expire. A test cleanup script must not delete it.
+CREATE TABLE chat_long.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+```
+
+- [ ] **Step 2: Add the table to the uuid keyspace**
+
+Add the same block to `shared-resources-cassandra/src/main/resources/keyspace-uuid.cql`, with `chat_uuid` in place of `chat_long`. The column types do not change. The claim holds a node id, not a domain key.
+
+```sql
+-- Holds the app.nodeid lease. One row per claimed node id.
+-- The row carries a TTL, so a crashed deployment releases its own id.
+-- This table is deliberately absent from truncate-uuid.cql. A live lease
+-- must expire. A test cleanup script must not delete it.
+CREATE TABLE chat_uuid.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+```
+
+- [ ] **Step 3: Write the probe test**
+
+Create `chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/NodeClaimTableProbeTests.kt`.
+
+```kotlin
+package com.demo.chat.test.persistence.integration
+
+import com.demo.chat.test.CassandraTestContainerConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+
+/**
+ * Probe for one load-bearing claim in the design.
+ *
+ * The claim: when owner_id expires, node_claim holds a primary key with no
+ * live columns, and IF NOT EXISTS then treats the row as absent.
+ *
+ * This test exists before any guard code. A failure here changes the
+ * schema. The fallback adds an explicit expires_at column, and that
+ * returns a clock question to the design.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [NodeClaimTableProbeTests.ProbeApp::class]
+)
+@Import(CassandraTestContainerConfiguration::class)
+@TestPropertySource(properties = ["app.key.type=long", "app.nodeid=200"])
+@Tag("integration")
+class NodeClaimTableProbeTests {
+
+    @SpringBootApplication
+    class ProbeApp
+
+    @Autowired
+    private lateinit var template: ReactiveCassandraTemplate
+
+    private val cql get() = template.reactiveCqlOperations
+
+    private fun claim(nodeId: Int, owner: String, ttlSeconds: Int): Boolean =
+        cql.queryForRows(
+            "INSERT INTO node_claim (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL ?",
+            nodeId, owner, ttlSeconds
+        ).next().map { it.getBoolean("[applied]") }.block()!!
+
+    @Test
+    fun `a second owner cannot take a live claim`() {
+        Assertions.assertTrue(claim(201, "owner-one", 30))
+        Assertions.assertFalse(claim(201, "owner-two", 30))
+    }
+
+    @Test
+    fun `an expired claim is absent for IF NOT EXISTS`() {
+        Assertions.assertTrue(claim(202, "owner-one", 1))
+        Thread.sleep(Duration.ofSeconds(3).toMillis())
+        Assertions.assertTrue(
+            claim(202, "owner-two", 30),
+            "A TTL expired row must be absent for IF NOT EXISTS. " +
+                "If this fails, the design needs an explicit expires_at column."
+        )
+    }
+
+    @Test
+    fun `a deleted claim is absent for IF NOT EXISTS`() {
+        Assertions.assertTrue(claim(203, "owner-one", 30))
+        cql.execute("DELETE FROM node_claim WHERE node_id = ?", 203).block()
+        Assertions.assertTrue(claim(203, "owner-two", 30))
+    }
+}
+```
+
+- [ ] **Step 4: Run the probe**
+
+Run: `mvn -o -pl chat-persistence-cassandra -Pintegration test -Dtest=NodeClaimTableProbeTests`
+
+Expected: PASS, all three tests. A Docker daemon must be running.
+
+If `an expired claim is absent for IF NOT EXISTS` fails, STOP. Report the failure and the exact assertion text. Do not continue to Task 2.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add shared-resources-cassandra/src/main/resources/keyspace-long.cql \
+        shared-resources-cassandra/src/main/resources/keyspace-uuid.cql \
+        chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/NodeClaimTableProbeTests.kt
+git commit -m "add the node_claim table and prove its expiry behaviour"
+```
+
+---
+
+### Task 2: The core contract, the message, and the properties
+
+**Files:**
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/ClaimResult.kt`
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimStore.kt`
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimException.kt`
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimProperties.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimPropertiesTests.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimExceptionTests.kt`
+
+**Interfaces:**
+- Consumes: `com.demo.chat.domain.NodeId` from stage 1.
+- Produces:
+  - `sealed class ClaimResult` with `Granted`, `Denied(holder: String)`, `Lost`.
+  - `interface NodeIdClaimStore` with `backendName: String`, `scope: String`, `claim/renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>`, `release(nodeId: NodeId, owner: String): Mono<Void>`.
+  - `class NodeIdClaimException(nodeId: NodeId, scope: String, holder: String, ttl: Duration)`.
+  - `class NodeIdClaimProperties(ttl, renewInterval, safetyMargin, operationTimeout)` with `closeDeadline: Duration`.
+
+- [ ] **Step 1: Write the failing property tests**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimPropertiesTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeIdClaimProperties
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class NodeIdClaimPropertiesTests {
+
+    private fun props(
+        ttl: Duration? = null,
+        renew: Duration? = null,
+        margin: Duration? = null,
+        timeout: Duration? = null
+    ) = NodeIdClaimProperties(ttl, renew, margin, timeout)
+
+    private fun failure(block: () -> Unit): String =
+        Assertions.assertThrows(IllegalArgumentException::class.java) { block() }.message!!
+
+    @Test
+    fun `defaults are thirty ten five and five`() {
+        val p = props()
+        Assertions.assertEquals(Duration.ofSeconds(30), p.ttl)
+        Assertions.assertEquals(Duration.ofSeconds(10), p.renewInterval)
+        Assertions.assertEquals(Duration.ofSeconds(5), p.safetyMargin)
+        Assertions.assertEquals(Duration.ofSeconds(5), p.operationTimeout)
+    }
+
+    @Test
+    fun `the default close deadline is twenty five seconds`() {
+        Assertions.assertEquals(Duration.ofSeconds(25), props().closeDeadline)
+    }
+
+    @Test
+    fun `a ttl under one second fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofMillis(500)) }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.ttl"), text)
+        Assertions.assertTrue(text.contains("at least 1s"), text)
+    }
+
+    @Test
+    fun `a fractional ttl fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofMillis(1500)) }
+        Assertions.assertTrue(text.contains("whole seconds"), text)
+    }
+
+    @Test
+    fun `a renew interval over one third of the ttl fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofSeconds(30), renew = Duration.ofSeconds(11)) }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.renew-interval"), text)
+        Assertions.assertTrue(text.contains("ttl / 3"), text)
+    }
+
+    @Test
+    fun `a renew interval of exactly one third of the ttl is accepted`() {
+        Assertions.assertEquals(
+            Duration.ofSeconds(10),
+            props(ttl = Duration.ofSeconds(30), renew = Duration.ofSeconds(10)).renewInterval
+        )
+    }
+
+    @Test
+    fun `a safety margin at or over the ttl fails and states the rule`() {
+        val text = failure { props(ttl = Duration.ofSeconds(30), margin = Duration.ofSeconds(30)) }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.safety-margin"), text)
+    }
+
+    @Test
+    fun `an operation timeout equal to the renew interval fails and states the rule`() {
+        val text = failure {
+            props(renew = Duration.ofSeconds(10), timeout = Duration.ofSeconds(10))
+        }
+        Assertions.assertTrue(text.contains("app.nodeid.claim.operation-timeout"), text)
+        Assertions.assertTrue(text.contains("less than"), text)
+    }
+
+    @Test
+    fun `a close deadline at or under the renew interval fails and states the rule`() {
+        val text = failure {
+            props(
+                ttl = Duration.ofSeconds(12),
+                renew = Duration.ofSeconds(4),
+                margin = Duration.ofSeconds(8),
+                timeout = Duration.ofSeconds(1)
+            )
+        }
+        Assertions.assertTrue(text.contains("greater than"), text)
+        Assertions.assertTrue(text.contains("renew-interval"), text)
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing message test**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimExceptionTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimException
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+
+class NodeIdClaimExceptionTests {
+
+    @Test
+    fun `the redis message names the property the scope the holder and the wait`() {
+        val text = NodeIdClaimException(
+            NodeId(7),
+            "redis store for key type long",
+            "core-service@host-a:4711#a3f19c2b",
+            Duration.ofSeconds(30)
+        ).message!!
+
+        Assertions.assertTrue(text.contains("app.nodeid=7 is already claimed"), text)
+        Assertions.assertTrue(text.contains("the redis store for key type long"), text)
+        Assertions.assertTrue(text.contains("Holder: core-service@host-a:4711#a3f19c2b"), text)
+        Assertions.assertTrue(text.contains("wait 30s"), text)
+    }
+
+    @Test
+    fun `the cassandra message names the keyspace`() {
+        val text = NodeIdClaimException(
+            NodeId(7),
+            "cassandra keyspace chat_long",
+            "core-service@host-b:5122#77c0aa41",
+            Duration.ofSeconds(30)
+        ).message!!
+
+        Assertions.assertTrue(text.contains("the cassandra keyspace chat_long"), text)
+        Assertions.assertFalse(text.contains("one store"), text)
+    }
+}
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `mvn -o -pl chat-core test -Dtest='NodeIdClaimPropertiesTests+NodeIdClaimExceptionTests'`
+
+Expected: FAIL to compile, with unresolved references to `NodeIdClaimProperties` and `NodeIdClaimException`.
+
+- [ ] **Step 4: Write the contract types**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/ClaimResult.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+/**
+ * The outcome of a claim, a renew, or a release.
+ *
+ * [Denied] means one thing only. The store answered, and it named another
+ * owner. [Lost] means the store answered and found no live claim. Every
+ * infrastructure failure is an error, not a result.
+ */
+sealed class ClaimResult {
+    object Granted : ClaimResult()
+    data class Denied(val holder: String) : ClaimResult()
+    object Lost : ClaimResult()
+}
+```
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimStore.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * A store-side lease on one [NodeId].
+ *
+ * A registry check cannot enforce node id uniqueness. One store can be
+ * reached by deployments that do not share a registry. The claim therefore
+ * lives in the store that the deployments share.
+ *
+ * Implementations return a [Mono]. The guard is the only place that blocks.
+ */
+interface NodeIdClaimStore {
+
+    /** `redis` or `cassandra`. This orders the stores in the guard. */
+    val backendName: String
+
+    /**
+     * The full phrase that names the space this claim covers.
+     *
+     * Redis supplies `redis store for key type long`. Cassandra supplies
+     * `cassandra keyspace chat_long`. The phrase is complete, so that one
+     * message template serves every backend.
+     */
+    val scope: String
+
+    /** Takes the lease. Returns [ClaimResult.Granted] or [ClaimResult.Denied]. Never [ClaimResult.Lost]. */
+    fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
+
+    /** Extends the lease when this owner still holds it. */
+    fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
+
+    /** Drops the lease when this owner holds it. Best effort. */
+    fun release(nodeId: NodeId, owner: String): Mono<Void>
+}
+```
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimException.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import java.time.Duration
+
+/**
+ * Reports a duplicate node id.
+ *
+ * The message states the scope, because uniqueness is per key type per
+ * store. A message that said "one store" would be false for a redis long
+ * deployment beside a redis uuid deployment.
+ */
+class NodeIdClaimException(
+    val nodeId: NodeId,
+    val scope: String,
+    val holder: String,
+    val ttl: Duration
+) : RuntimeException(message(nodeId, scope, holder, ttl)) {
+
+    companion object {
+        fun message(nodeId: NodeId, scope: String, holder: String, ttl: Duration): String =
+            "app.nodeid=${nodeId.value} is already claimed in the $scope.\n" +
+                "Holder: $holder\n" +
+                "Two deployments that write to the $scope must not use the same app.nodeid.\n" +
+                "Set a different app.nodeid, or stop the other deployment and wait " +
+                "${ttl.seconds}s\nfor its lease to expire."
+    }
+}
+```
+
+- [ ] **Step 5: Write the properties**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimProperties.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.Duration
+
+/**
+ * The lease timings.
+ *
+ * The constructor takes nullable parameters and applies the defaults in the
+ * body. It declares no Kotlin default arguments on purpose. A default
+ * argument makes Kotlin emit a synthetic constructor, and Spring Boot then
+ * has more than one constructor to choose from. The same trap already bit
+ * `ConfigurationPropertiesRedisTopics`.
+ */
+@ConfigurationProperties(prefix = "app.nodeid.claim")
+class NodeIdClaimProperties(
+    ttl: Duration?,
+    renewInterval: Duration?,
+    safetyMargin: Duration?,
+    operationTimeout: Duration?
+) {
+    val ttl: Duration = ttl ?: Duration.ofSeconds(30)
+    val renewInterval: Duration = renewInterval ?: Duration.ofSeconds(10)
+    val safetyMargin: Duration = safetyMargin ?: Duration.ofSeconds(5)
+    val operationTimeout: Duration = operationTimeout ?: Duration.ofSeconds(5)
+
+    /** The process closes this long after the last successful claim or renew. */
+    val closeDeadline: Duration = this.ttl.minus(this.safetyMargin)
+
+    init {
+        require(this.ttl >= Duration.ofSeconds(1)) {
+            "app.nodeid.claim.ttl must be at least 1s. Got: ${this.ttl}"
+        }
+        // Cassandra applies a TTL in whole seconds. A fractional value would
+        // silently round on one backend and not on the other.
+        require(this.ttl.nano == 0) {
+            "app.nodeid.claim.ttl must use whole seconds. Got: ${this.ttl}"
+        }
+        require(!this.renewInterval.isZero && !this.renewInterval.isNegative) {
+            "app.nodeid.claim.renew-interval must be greater than zero. Got: ${this.renewInterval}"
+        }
+        require(this.renewInterval <= this.ttl.dividedBy(3)) {
+            "app.nodeid.claim.renew-interval must be at most ttl / 3. " +
+                "ttl is ${this.ttl}. Got: ${this.renewInterval}"
+        }
+        require(!this.safetyMargin.isZero && !this.safetyMargin.isNegative) {
+            "app.nodeid.claim.safety-margin must be greater than zero. Got: ${this.safetyMargin}"
+        }
+        require(this.safetyMargin < this.ttl) {
+            "app.nodeid.claim.safety-margin must be less than ttl. " +
+                "ttl is ${this.ttl}. Got: ${this.safetyMargin}"
+        }
+        // A blocked call must not consume the next renewal slot.
+        require(this.operationTimeout < this.renewInterval) {
+            "app.nodeid.claim.operation-timeout must be less than renew-interval. " +
+                "renew-interval is ${this.renewInterval}. Got: ${this.operationTimeout}"
+        }
+        require(this.closeDeadline > this.renewInterval) {
+            "ttl minus app.nodeid.claim.safety-margin must be greater than renew-interval. " +
+                "The deadline is ${this.closeDeadline}. renew-interval is ${this.renewInterval}."
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run both tests to verify they pass**
+
+Run: `mvn -o -pl chat-core test -Dtest='NodeIdClaimPropertiesTests+NodeIdClaimExceptionTests'`
+
+Expected: PASS, 11 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add chat-core/src/main/kotlin/com/demo/chat/domain/ClaimResult.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimStore.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimException.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimProperties.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/
+git commit -m "add the node id claim contract, message, and lease properties"
+```
+
+---
+
+### Task 3: The scheduling seam and the owner id
+
+The guard needs deterministic tests. A real `ScheduledExecutorService` would make every timing test wait in real time. This task adds a small seam instead.
+
+**Files:**
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/ClaimScheduler.kt`
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/RuntimeOwnerId.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/RuntimeOwnerIdTests.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/ExecutorClaimSchedulerTests.kt`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+  - `interface ClaimScheduler` with `schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable`, `scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable`, `runDetached(name: String, task: () -> Unit)`, `shutdownNow()`, `isSchedulerThread(): Boolean`.
+  - `class ExecutorClaimScheduler : ClaimScheduler`.
+  - `class RuntimeOwnerId(val value: String)` with `companion object { fun generate(applicationName: String): RuntimeOwnerId }`.
+
+- [ ] **Step 1: Write the failing owner id test**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/RuntimeOwnerIdTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.RuntimeOwnerId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class RuntimeOwnerIdTests {
+
+    @Test
+    fun `the value names the application the host and the process`() {
+        val owner = RuntimeOwnerId.generate("core-service").value
+        Assertions.assertTrue(owner.startsWith("core-service@"), owner)
+        Assertions.assertTrue(owner.contains(":"), owner)
+        Assertions.assertTrue(owner.contains("#"), owner)
+    }
+
+    @Test
+    fun `two values generated in one process differ`() {
+        Assertions.assertNotEquals(
+            RuntimeOwnerId.generate("core-service").value,
+            RuntimeOwnerId.generate("core-service").value
+        )
+    }
+
+    @Test
+    fun `the random suffix is eight hex characters`() {
+        val suffix = RuntimeOwnerId.generate("core-service").value.substringAfterLast("#")
+        Assertions.assertTrue(suffix.matches(Regex("[0-9a-f]{8}")), suffix)
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing scheduler test**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/ExecutorClaimSchedulerTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ExecutorClaimScheduler
+import org.awaitility.Awaitility
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicReference
+
+class ExecutorClaimSchedulerTests {
+
+    @Test
+    fun `a periodic task reports that it runs on a scheduler thread`() {
+        val scheduler = ExecutorClaimScheduler()
+        val onScheduler = AtomicReference<Boolean>()
+        try {
+            scheduler.schedulePeriodic(Duration.ofMillis(20)) {
+                onScheduler.compareAndSet(null, scheduler.isSchedulerThread())
+            }
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until { onScheduler.get() != null }
+            Assertions.assertTrue(onScheduler.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `a detached task does not run on a scheduler thread`() {
+        val scheduler = ExecutorClaimScheduler()
+        val onScheduler = AtomicReference<Boolean>()
+        try {
+            scheduler.runDetached("nodeid-claim-close") {
+                onScheduler.set(scheduler.isSchedulerThread())
+            }
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until { onScheduler.get() != null }
+            Assertions.assertFalse(onScheduler.get())
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+
+    @Test
+    fun `shutdown from a scheduler thread returns and does not wait for itself`() {
+        val scheduler = ExecutorClaimScheduler()
+        val done = AtomicReference<Boolean>()
+        scheduler.schedulePeriodic(Duration.ofMillis(20)) {
+            scheduler.shutdownNow()
+            done.compareAndSet(null, true)
+        }
+        Awaitility.await().atMost(Duration.ofSeconds(2)).until { done.get() == true }
+    }
+
+    @Test
+    fun `a closed periodic handle stops the task`() {
+        val scheduler = ExecutorClaimScheduler()
+        try {
+            var runs = 0
+            val handle = scheduler.schedulePeriodic(Duration.ofMillis(20)) { runs++ }
+            Awaitility.await().atMost(Duration.ofSeconds(2)).until { runs > 0 }
+            handle.close()
+            val seen = runs
+            Thread.sleep(200)
+            Assertions.assertEquals(seen, runs)
+        } finally {
+            scheduler.shutdownNow()
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `mvn -o -pl chat-core test -Dtest='RuntimeOwnerIdTests+ExecutorClaimSchedulerTests'`
+
+Expected: FAIL to compile, with unresolved references to `RuntimeOwnerId` and `ExecutorClaimScheduler`.
+
+- [ ] **Step 4: Write the owner id**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/RuntimeOwnerId.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import java.net.InetAddress
+import java.security.SecureRandom
+
+/**
+ * The owner of a node id lease, for one process.
+ *
+ * The value is unique per process. A restart never reuses it, so a restarted
+ * deployment cannot mistake its own stale lease for a live one. The value is
+ * readable, so the duplicate node message names a real host and process.
+ */
+class RuntimeOwnerId(val value: String) {
+
+    override fun toString(): String = value
+
+    companion object {
+        private val random = SecureRandom()
+
+        fun generate(applicationName: String): RuntimeOwnerId {
+            val host = try {
+                InetAddress.getLocalHost().hostName
+            } catch (e: Exception) {
+                "unknown-host"
+            }
+            val pid = ProcessHandle.current().pid()
+            val suffix = String.format("%08x", random.nextInt())
+            return RuntimeOwnerId("$applicationName@$host:$pid#$suffix")
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Write the scheduler**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/ClaimScheduler.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import java.time.Duration
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.TimeUnit
+
+/**
+ * The scheduling seam for [NodeIdClaimGuard].
+ *
+ * The guard owns its schedule. A shared task scheduler can delay a renew
+ * behind unrelated work, and a late renew can cost the lease.
+ *
+ * A test supplies its own implementation and fires tasks by hand, so the
+ * timing tests need no real waiting.
+ */
+interface ClaimScheduler {
+
+    fun schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable
+
+    fun scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable
+
+    /**
+     * Runs a task off every scheduler thread.
+     *
+     * The guard closes the context this way. A close started on a scheduler
+     * thread would run `destroy` on that same thread, and a `destroy` that
+     * waited for the scheduler would wait for itself.
+     */
+    fun runDetached(name: String, task: () -> Unit)
+
+    fun shutdownNow()
+
+    fun isSchedulerThread(): Boolean
+}
+
+class ExecutorClaimScheduler : ClaimScheduler {
+
+    private val threadName = "nodeid-claim-renew"
+
+    private val executor: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor(ThreadFactory { runnable ->
+            Thread(runnable, threadName).apply { isDaemon = true }
+        })
+
+    override fun schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable {
+        val future = executor.scheduleAtFixedRate(
+            { runQuietly(task) }, period.toMillis(), period.toMillis(), TimeUnit.MILLISECONDS
+        )
+        return AutoCloseable { future.cancel(false) }
+    }
+
+    override fun scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable {
+        val future = executor.schedule(
+            { runQuietly(task) }, delay.toMillis(), TimeUnit.MILLISECONDS
+        )
+        return AutoCloseable { future.cancel(false) }
+    }
+
+    override fun runDetached(name: String, task: () -> Unit) {
+        Thread({ runQuietly(task) }, name).apply { isDaemon = false }.start()
+    }
+
+    override fun shutdownNow() {
+        executor.shutdownNow()
+        // Never wait from a scheduler thread. That would wait for this task.
+        if (!isSchedulerThread()) {
+            executor.awaitTermination(2, TimeUnit.SECONDS)
+        }
+    }
+
+    override fun isSchedulerThread(): Boolean = Thread.currentThread().name == threadName
+
+    // A thrown task would silently cancel a fixed rate schedule. The guard
+    // handles its own failures, so anything reaching here is a defect.
+    private fun runQuietly(task: () -> Unit) {
+        try {
+            task()
+        } catch (e: Throwable) {
+            System.err.println("nodeid claim scheduler task failed: ${e.message}")
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Run both tests to verify they pass**
+
+Run: `mvn -o -pl chat-core test -Dtest='RuntimeOwnerIdTests+ExecutorClaimSchedulerTests'`
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add chat-core/src/main/kotlin/com/demo/chat/domain/ClaimScheduler.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/RuntimeOwnerId.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/RuntimeOwnerIdTests.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/ExecutorClaimSchedulerTests.kt
+git commit -m "add the claim scheduler seam and the runtime owner id"
+```
+
+---
+
+### Task 4: The guard, startup path
+
+This task covers the claim, the ordering, and the release on failure. The renewal path is Task 5.
+
+**Files:**
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt`
+- Create: `chat-core/src/test/kotlin/com/demo/chat/test/domain/ClaimTestDoubles.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardStartupTests.kt`
+
+**Interfaces:**
+- Consumes: `ClaimResult`, `NodeIdClaimStore`, `NodeIdClaimException`, `NodeIdClaimProperties`, `ClaimScheduler`, `RuntimeOwnerId`, `NodeId`.
+- Produces:
+  - `class NodeIdClaimGuard(stores: List<NodeIdClaimStore>, nodeId: NodeId, owner: RuntimeOwnerId, props: NodeIdClaimProperties, context: ConfigurableApplicationContext, scheduler: ClaimScheduler) : InitializingBean, DisposableBean`.
+  - Test doubles `FakeClaimStore` and `ManualClaimScheduler` used by Task 5 as well.
+
+- [ ] **Step 1: Write the test doubles**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/ClaimTestDoubles.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.ClaimScheduler
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimStore
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * A store whose answers the test sets.
+ *
+ * `calls` records every operation in order, so a test can assert the claim
+ * order and the release order.
+ */
+class FakeClaimStore(
+    override val backendName: String,
+    override val scope: String = "$backendName store for key type long",
+    var claimAnswer: () -> ClaimResult = { ClaimResult.Granted },
+    var renewAnswer: () -> ClaimResult = { ClaimResult.Granted }
+) : NodeIdClaimStore {
+
+    val calls = mutableListOf<String>()
+
+    override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        Mono.fromCallable { calls.add("claim:$backendName"); claimAnswer() }
+
+    override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        Mono.fromCallable { calls.add("renew:$backendName"); renewAnswer() }
+
+    override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+        Mono.fromRunnable { calls.add("release:$backendName") }
+}
+
+/**
+ * A scheduler the test drives by hand.
+ *
+ * Nothing runs until the test calls [firePeriodic] or [fireOnce]. The guard
+ * timing tests therefore need no real waiting.
+ */
+class ManualClaimScheduler : ClaimScheduler {
+
+    var periodic: (() -> Unit)? = null
+    var once: (() -> Unit)? = null
+    var onceDelay: Duration? = null
+    val detached = mutableListOf<String>()
+    var shutdownCount = 0
+    var pretendSchedulerThread = false
+
+    override fun schedulePeriodic(period: Duration, task: () -> Unit): AutoCloseable {
+        periodic = task
+        return AutoCloseable { periodic = null }
+    }
+
+    override fun scheduleOnce(delay: Duration, task: () -> Unit): AutoCloseable {
+        once = task
+        onceDelay = delay
+        return AutoCloseable { once = null; onceDelay = null }
+    }
+
+    override fun runDetached(name: String, task: () -> Unit) {
+        detached.add(name)
+        task()
+    }
+
+    override fun shutdownNow() {
+        shutdownCount++
+    }
+
+    override fun isSchedulerThread(): Boolean = pretendSchedulerThread
+
+    fun firePeriodic() = periodic?.invoke()
+
+    fun fireOnce() = once?.invoke()
+}
+```
+
+- [ ] **Step 2: Write the failing startup tests**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardStartupTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimException
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimProperties
+import com.demo.chat.domain.RuntimeOwnerId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import java.time.Duration
+
+class NodeIdClaimGuardStartupTests {
+
+    private val props = NodeIdClaimProperties(null, null, null, null)
+
+    private fun guard(
+        stores: List<com.demo.chat.domain.NodeIdClaimStore>,
+        scheduler: ManualClaimScheduler = ManualClaimScheduler()
+    ) = NodeIdClaimGuard(
+        stores, NodeId(7), RuntimeOwnerId("core-service@host-a:4711#a3f19c2b"),
+        props, GenericApplicationContext(), scheduler
+    )
+
+    @Test
+    fun `one granted store starts and schedules a renew`() {
+        val store = FakeClaimStore("redis")
+        val scheduler = ManualClaimScheduler()
+        guard(listOf(store), scheduler).afterPropertiesSet()
+
+        Assertions.assertEquals(listOf("claim:redis"), store.calls)
+        Assertions.assertNotNull(scheduler.periodic)
+    }
+
+    @Test
+    fun `two stores are claimed in backend name order`() {
+        val redis = FakeClaimStore("redis")
+        val cassandra = FakeClaimStore("cassandra")
+        guard(listOf(redis, cassandra)).afterPropertiesSet()
+
+        Assertions.assertEquals(listOf("claim:cassandra"), cassandra.calls)
+        Assertions.assertEquals(listOf("claim:redis"), redis.calls)
+    }
+
+    @Test
+    fun `a denial at the second store releases the first store`() {
+        val cassandra = FakeClaimStore("cassandra")
+        val redis = FakeClaimStore(
+            "redis",
+            claimAnswer = { ClaimResult.Denied("core-service@host-b:5122#77c0aa41") }
+        )
+
+        val thrown = Assertions.assertThrows(NodeIdClaimException::class.java) {
+            guard(listOf(redis, cassandra)).afterPropertiesSet()
+        }
+
+        Assertions.assertEquals(listOf("claim:cassandra", "release:cassandra"), cassandra.calls)
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid=7 is already claimed"))
+        Assertions.assertTrue(thrown.message!!.contains("redis store for key type long"))
+    }
+
+    @Test
+    fun `a store error at the second store releases the first store`() {
+        val cassandra = FakeClaimStore("cassandra")
+        val redis = FakeClaimStore("redis", claimAnswer = { throw IllegalStateException("redis is down") })
+
+        Assertions.assertThrows(Exception::class.java) {
+            guard(listOf(redis, cassandra)).afterPropertiesSet()
+        }
+
+        Assertions.assertEquals(listOf("claim:cassandra", "release:cassandra"), cassandra.calls)
+    }
+
+    @Test
+    fun `a release failure during rollback does not hide the claim failure`() {
+        val cassandra = object : com.demo.chat.domain.NodeIdClaimStore {
+            override val backendName = "cassandra"
+            override val scope = "cassandra keyspace chat_long"
+            override fun claim(nodeId: NodeId, owner: String, ttl: Duration) =
+                reactor.core.publisher.Mono.just(ClaimResult.Granted as ClaimResult)
+            override fun renew(nodeId: NodeId, owner: String, ttl: Duration) =
+                reactor.core.publisher.Mono.just(ClaimResult.Granted as ClaimResult)
+            override fun release(nodeId: NodeId, owner: String) =
+                reactor.core.publisher.Mono.error<Void>(IllegalStateException("release failed"))
+        }
+        val redis = FakeClaimStore("redis", claimAnswer = { ClaimResult.Denied("other") })
+
+        val thrown = Assertions.assertThrows(NodeIdClaimException::class.java) {
+            guard(listOf(redis, cassandra)).afterPropertiesSet()
+        }
+        Assertions.assertTrue(thrown.message!!.contains("app.nodeid=7"))
+    }
+
+    @Test
+    fun `the deadline timer is armed after a successful claim`() {
+        val scheduler = ManualClaimScheduler()
+        guard(listOf(FakeClaimStore("redis")), scheduler).afterPropertiesSet()
+
+        Assertions.assertNotNull(scheduler.once)
+        Assertions.assertEquals(Duration.ofSeconds(25), scheduler.onceDelay)
+    }
+
+    @Test
+    fun `no stores means no claim and no schedule`() {
+        val scheduler = ManualClaimScheduler()
+        guard(emptyList(), scheduler).afterPropertiesSet()
+
+        Assertions.assertNull(scheduler.periodic)
+        Assertions.assertNull(scheduler.once)
+    }
+}
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-core test -Dtest=NodeIdClaimGuardStartupTests`
+
+Expected: FAIL to compile, with an unresolved reference to `NodeIdClaimGuard`.
+
+- [ ] **Step 4: Write the guard**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt`. The renewal body is written now and exercised in Task 5.
+
+```kotlin
+package com.demo.chat.domain
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.beans.factory.InitializingBean
+import org.springframework.context.ConfigurableApplicationContext
+
+/**
+ * Holds the store-side lease on `app.nodeid` for the life of the process.
+ *
+ * The guard claims during context refresh. A duplicate therefore fails
+ * startup before the application is ready and before the process serves
+ * normal traffic.
+ *
+ * The guard is the only place that blocks. The stores stay reactive.
+ */
+class NodeIdClaimGuard(
+    private val stores: List<NodeIdClaimStore>,
+    private val nodeId: NodeId,
+    private val owner: RuntimeOwnerId,
+    private val props: NodeIdClaimProperties,
+    private val context: ConfigurableApplicationContext,
+    private val scheduler: ClaimScheduler
+) : InitializingBean, DisposableBean {
+
+    private val log = LoggerFactory.getLogger(NodeIdClaimGuard::class.java)
+
+    private var granted: List<NodeIdClaimStore> = emptyList()
+    private var renewHandle: AutoCloseable? = null
+    private var deadlineHandle: AutoCloseable? = null
+
+    override fun afterPropertiesSet() {
+        if (stores.isEmpty()) {
+            return
+        }
+
+        val ordered = stores.sortedBy { it.backendName }
+        val taken = mutableListOf<NodeIdClaimStore>()
+
+        try {
+            ordered.forEach { store ->
+                when (val result = store.claim(nodeId, owner.value, props.ttl)
+                    .timeout(props.operationTimeout).block()) {
+                    is ClaimResult.Granted -> taken.add(store)
+                    is ClaimResult.Denied ->
+                        throw NodeIdClaimException(nodeId, store.scope, result.holder, props.ttl)
+                    is ClaimResult.Lost ->
+                        throw IllegalStateException(
+                            "The ${store.backendName} store returned Lost from a claim. " +
+                                "A claim returns Granted or Denied."
+                        )
+                    null ->
+                        throw IllegalStateException(
+                            "The ${store.backendName} store returned no result from a claim."
+                        )
+                }
+            }
+        } catch (failure: Throwable) {
+            releaseAll(taken.reversed())
+            throw failure
+        }
+
+        granted = taken
+        log.info("app.nodeid={} claimed in {}", nodeId.value, taken.joinToString { it.scope })
+        armDeadline()
+        renewHandle = scheduler.schedulePeriodic(props.renewInterval) { renewOnce() }
+    }
+
+    override fun destroy() {
+        renewHandle?.close()
+        deadlineHandle?.close()
+        scheduler.shutdownNow()
+        releaseAll(granted.reversed())
+        granted = emptyList()
+    }
+
+    private fun armDeadline() {
+        deadlineHandle?.close()
+        deadlineHandle = scheduler.scheduleOnce(props.closeDeadline) {
+            closeContext(
+                "app.nodeid=${nodeId.value} was not renewed within ${props.closeDeadline.seconds}s. " +
+                    "The lease may have expired. Closing the application context."
+            )
+        }
+    }
+
+    private fun renewOnce() {
+        granted.forEach { store ->
+            val result = try {
+                store.renew(nodeId, owner.value, props.ttl).timeout(props.operationTimeout).block()
+            } catch (error: Throwable) {
+                log.warn(
+                    "app.nodeid={} renew failed on {}. Retrying at the next interval. Cause: {}",
+                    nodeId.value, store.backendName, error.message
+                )
+                return
+            }
+
+            when (result) {
+                is ClaimResult.Granted -> Unit
+                is ClaimResult.Denied -> {
+                    closeContext(NodeIdClaimException(nodeId, store.scope, result.holder, props.ttl).message!!)
+                    return
+                }
+                is ClaimResult.Lost -> {
+                    closeContext(
+                        "app.nodeid=${nodeId.value} is no longer held in the ${store.scope}. " +
+                            "This process lost its lease. Closing the application context."
+                    )
+                    return
+                }
+                null -> {
+                    log.warn(
+                        "app.nodeid={} renew returned no result from {}. Retrying at the next interval.",
+                        nodeId.value, store.backendName
+                    )
+                    return
+                }
+            }
+        }
+        armDeadline()
+    }
+
+    // The close runs off the scheduler. A close started on a scheduler thread
+    // would run destroy on that same thread, and destroy would wait for it.
+    private fun closeContext(reason: String) {
+        log.error(reason)
+        scheduler.runDetached("nodeid-claim-close") { context.close() }
+    }
+
+    private fun releaseAll(ordered: List<NodeIdClaimStore>) {
+        ordered.forEach { store ->
+            try {
+                store.release(nodeId, owner.value).timeout(props.operationTimeout).block()
+            } catch (error: Throwable) {
+                log.debug(
+                    "app.nodeid={} release failed on {}. The lease expires on its own. Cause: {}",
+                    nodeId.value, store.backendName, error.message
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `mvn -o -pl chat-core test -Dtest=NodeIdClaimGuardStartupTests`
+
+Expected: PASS, 7 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/ClaimTestDoubles.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardStartupTests.kt
+git commit -m "claim the node id lease during context refresh"
+```
+
+---
+
+### Task 5: The guard, renewal and shutdown
+
+**Files:**
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardRenewalTests.kt`
+- Modify: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt` only if a test fails
+
+**Interfaces:**
+- Consumes: everything from Task 4.
+- Produces: no new type. This task proves the renewal contract.
+
+- [ ] **Step 1: Write the failing renewal tests**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardRenewalTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimProperties
+import com.demo.chat.domain.RuntimeOwnerId
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.support.GenericApplicationContext
+import java.time.Duration
+
+class NodeIdClaimGuardRenewalTests {
+
+    private val props = NodeIdClaimProperties(null, null, null, null)
+
+    private fun setUp(store: FakeClaimStore): Pair<NodeIdClaimGuard, ManualClaimScheduler> {
+        val scheduler = ManualClaimScheduler()
+        val context = GenericApplicationContext()
+        context.refresh()
+        val guard = NodeIdClaimGuard(
+            listOf(store), NodeId(7), RuntimeOwnerId("core-service@host-a:4711#a3f19c2b"),
+            props, context, scheduler
+        )
+        guard.afterPropertiesSet()
+        return guard to scheduler
+    }
+
+    @Test
+    fun `a granted renew keeps the context open and rearms the deadline`() {
+        val store = FakeClaimStore("redis")
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+
+        Assertions.assertTrue(store.calls.contains("renew:redis"))
+        Assertions.assertTrue(scheduler.detached.isEmpty())
+        Assertions.assertEquals(Duration.ofSeconds(25), scheduler.onceDelay)
+    }
+
+    @Test
+    fun `a denied renew closes the context at once`() {
+        val store = FakeClaimStore("redis", renewAnswer = { ClaimResult.Denied("other-owner") })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `a lost renew closes the context at once`() {
+        val store = FakeClaimStore("redis", renewAnswer = { ClaimResult.Lost })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `a renew error keeps the context open`() {
+        val store = FakeClaimStore("redis", renewAnswer = { throw IllegalStateException("redis is down") })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+        scheduler.firePeriodic()
+
+        Assertions.assertTrue(scheduler.detached.isEmpty())
+    }
+
+    @Test
+    fun `a renew error does not rearm the deadline`() {
+        val store = FakeClaimStore("redis")
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+        val armedAfterSuccess = scheduler.once
+        store.renewAnswer = { throw IllegalStateException("redis is down") }
+        scheduler.firePeriodic()
+
+        Assertions.assertSame(armedAfterSuccess, scheduler.once)
+    }
+
+    @Test
+    fun `the deadline timer closes the context when it fires`() {
+        val store = FakeClaimStore("redis", renewAnswer = { throw IllegalStateException("redis is down") })
+        val (_, scheduler) = setUp(store)
+
+        scheduler.firePeriodic()
+        scheduler.fireOnce()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `the close runs off the scheduler thread`() {
+        val store = FakeClaimStore("redis", renewAnswer = { ClaimResult.Lost })
+        val (_, scheduler) = setUp(store)
+        scheduler.pretendSchedulerThread = true
+
+        scheduler.firePeriodic()
+
+        Assertions.assertEquals(listOf("nodeid-claim-close"), scheduler.detached)
+    }
+
+    @Test
+    fun `destroy shuts the scheduler down and releases the store`() {
+        val store = FakeClaimStore("redis")
+        val (guard, scheduler) = setUp(store)
+
+        guard.destroy()
+
+        Assertions.assertEquals(1, scheduler.shutdownCount)
+        Assertions.assertTrue(store.calls.contains("release:redis"))
+    }
+
+    @Test
+    fun `destroy releases two stores in reverse backend name order`() {
+        val redis = FakeClaimStore("redis")
+        val cassandra = FakeClaimStore("cassandra")
+        val scheduler = ManualClaimScheduler()
+        val context = GenericApplicationContext()
+        context.refresh()
+        val guard = NodeIdClaimGuard(
+            listOf(redis, cassandra), NodeId(7),
+            RuntimeOwnerId("core-service@host-a:4711#a3f19c2b"), props, context, scheduler
+        )
+        guard.afterPropertiesSet()
+
+        guard.destroy()
+
+        Assertions.assertTrue(redis.calls.contains("release:redis"))
+        Assertions.assertTrue(cassandra.calls.contains("release:cassandra"))
+    }
+
+    @Test
+    fun `destroy twice releases once`() {
+        val store = FakeClaimStore("redis")
+        val (guard, _) = setUp(store)
+
+        guard.destroy()
+        guard.destroy()
+
+        Assertions.assertEquals(1, store.calls.count { it == "release:redis" })
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `mvn -o -pl chat-core test -Dtest=NodeIdClaimGuardRenewalTests`
+
+Expected: PASS, 10 tests. The guard body from Task 4 already implements this contract.
+
+If a test fails, fix `NodeIdClaimGuard.kt` and run again. Do not change a test to match the code. The tests state the spec.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add chat-core/src/test/kotlin/com/demo/chat/test/domain/NodeIdClaimGuardRenewalTests.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuard.kt
+git commit -m "pin the renewal, deadline, and shutdown rules of the claim guard"
+```
+
+---
+
+### Task 6: The activation seam
+
+**Files:**
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/ConditionalOnSharedBackend.kt`
+- Create: `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuardConfiguration.kt`
+- Test: `chat-core/src/test/kotlin/com/demo/chat/test/domain/SharedBackendConditionTests.kt`
+
+**Interfaces:**
+- Consumes: `NodeIdClaimGuard`, `NodeIdClaimProperties`, `ClaimScheduler`, `RuntimeOwnerId`, `NodeIdConfiguration`.
+- Produces:
+  - `annotation class ConditionalOnSharedBackend(val value: String)`.
+  - `class NodeIdClaimGuardConfiguration` supplying `runtimeOwnerId`, `nodeIdClaimScheduler`, and `nodeIdClaimGuard`.
+
+- [ ] **Step 1: Write the failing condition tests**
+
+Create `chat-core/src/test/kotlin/com/demo/chat/test/domain/SharedBackendConditionTests.kt`.
+
+```kotlin
+package com.demo.chat.test.domain
+
+import com.demo.chat.domain.ConditionalOnSharedBackend
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimGuardConfiguration
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.mock.env.MockEnvironment
+
+class SharedBackendConditionTests {
+
+    @Configuration
+    @ConditionalOnSharedBackend("redis")
+    @Import(NodeIdClaimGuardConfiguration::class)
+    open class RedisClaimConfiguration {
+        @Bean
+        open fun redisClaimStore(): NodeIdClaimStore = FakeClaimStore("redis")
+    }
+
+    private fun contextWith(vararg properties: Pair<String, String>): AnnotationConfigApplicationContext {
+        val context = AnnotationConfigApplicationContext()
+        val environment = MockEnvironment()
+        properties.forEach { environment.setProperty(it.first, it.second) }
+        context.environment = environment
+        context.register(RedisClaimConfiguration::class.java)
+        context.refresh()
+        return context
+    }
+
+    @Test
+    fun `the key selector activates the store`() {
+        contextWith("app.service.core.key" to "redis", "app.nodeid" to "7").use { context ->
+            Assertions.assertEquals(1, context.getBeansOfType(NodeIdClaimStore::class.java).size)
+            Assertions.assertEquals(1, context.getBeansOfType(NodeIdClaimGuard::class.java).size)
+        }
+    }
+
+    @Test
+    fun `the persistence selector activates the store`() {
+        contextWith("app.service.core.persistence" to "redis", "app.nodeid" to "7").use { context ->
+            Assertions.assertEquals(1, context.getBeansOfType(NodeIdClaimStore::class.java).size)
+        }
+    }
+
+    @Test
+    fun `a memory pair activates nothing`() {
+        contextWith(
+            "app.service.core.key" to "memory",
+            "app.service.core.persistence" to "memory"
+        ).use { context ->
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimGuard::class.java).isEmpty())
+        }
+    }
+
+    @Test
+    fun `an unset pair activates nothing and needs no app nodeid`() {
+        contextWith().use { context ->
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+            Assertions.assertTrue(context.getBeansOfType(com.demo.chat.domain.NodeId::class.java).isEmpty())
+        }
+    }
+
+    @Test
+    fun `a cassandra pair does not activate the redis store`() {
+        contextWith(
+            "app.service.core.key" to "cassandra",
+            "app.service.core.persistence" to "cassandra"
+        ).use { context ->
+            Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-core test -Dtest=SharedBackendConditionTests`
+
+Expected: FAIL to compile, with unresolved references to `ConditionalOnSharedBackend` and `NodeIdClaimGuardConfiguration`.
+
+- [ ] **Step 3: Write the condition**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/ConditionalOnSharedBackend.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.context.annotation.Conditional
+import org.springframework.core.type.AnnotatedTypeMetadata
+
+/**
+ * Activates a configuration when either core selector names this backend.
+ *
+ * Generated ids reach the key store and the persistence store. A condition
+ * on one selector alone would leave `key=memory` with `persistence=redis`
+ * unprotected, and the configuration permits that pair.
+ *
+ * `@ConditionalOnProperty` cannot express an OR across two properties.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@MustBeDocumented
+@Conditional(OnSharedBackendCondition::class)
+annotation class ConditionalOnSharedBackend(val value: String)
+
+class OnSharedBackendCondition : Condition {
+
+    override fun matches(context: ConditionContext, metadata: AnnotatedTypeMetadata): Boolean {
+        val backend = metadata
+            .getAnnotationAttributes(ConditionalOnSharedBackend::class.java.name)
+            ?.get("value") as? String
+            ?: return false
+
+        val environment = context.environment
+        return environment.getProperty("app.service.core.key") == backend ||
+            environment.getProperty("app.service.core.persistence") == backend
+    }
+}
+```
+
+- [ ] **Step 4: Write the guard configuration**
+
+Create `chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuardConfiguration.kt`.
+
+```kotlin
+package com.demo.chat.domain
+
+import org.springframework.beans.factory.ObjectProvider
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.core.env.Environment
+
+/**
+ * Supplies the guard beans.
+ *
+ * Every claim store configuration imports this class. An import is
+ * idempotent, so a classpath that names two shared backends still gets one
+ * guard. This mirrors how `KeyGenConfiguration` imports
+ * [NodeIdConfiguration].
+ *
+ * This class lives in `com.demo.chat.domain` on purpose.
+ * `com.demo.chat.config` is component-scanned by every deployment, so a copy
+ * placed there would supply the guard in processes that claim nothing.
+ */
+@Configuration
+@EnableConfigurationProperties(NodeIdClaimProperties::class)
+@Import(NodeIdConfiguration::class)
+open class NodeIdClaimGuardConfiguration {
+
+    @Bean
+    open fun runtimeOwnerId(environment: Environment): RuntimeOwnerId =
+        RuntimeOwnerId.generate(environment.getProperty("spring.application.name") ?: "chat")
+
+    @Bean
+    open fun nodeIdClaimScheduler(): ClaimScheduler = ExecutorClaimScheduler()
+
+    // ObjectProvider, not List. A List parameter with no candidate bean fails
+    // to resolve, and this configuration must also be safe to import early.
+    @Bean
+    open fun nodeIdClaimGuard(
+        stores: ObjectProvider<NodeIdClaimStore>,
+        nodeId: NodeId,
+        owner: RuntimeOwnerId,
+        properties: NodeIdClaimProperties,
+        context: ConfigurableApplicationContext,
+        scheduler: ClaimScheduler
+    ): NodeIdClaimGuard =
+        NodeIdClaimGuard(
+            stores.orderedStream().toList(), nodeId, owner, properties, context, scheduler
+        )
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `mvn -o -pl chat-core test -Dtest=SharedBackendConditionTests`
+
+Expected: PASS, 5 tests.
+
+- [ ] **Step 6: Run the whole core module**
+
+Run: `mvn -o -pl chat-core test`
+
+Expected: PASS. No existing `chat-core` test changes behaviour.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add chat-core/src/main/kotlin/com/demo/chat/domain/ConditionalOnSharedBackend.kt \
+        chat-core/src/main/kotlin/com/demo/chat/domain/NodeIdClaimGuardConfiguration.kt \
+        chat-core/src/test/kotlin/com/demo/chat/test/domain/SharedBackendConditionTests.kt
+git commit -m "activate the claim guard from either core selector"
+```
+
+---
+
+### Task 7: The Redis claim store
+
+**Files:**
+- Create: `chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/RedisNodeIdClaimStore.kt`
+- Create: `chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/NodeIdClaimConfiguration.kt`
+- Test: `chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisNodeIdClaimStoreTests.kt`
+
+**Interfaces:**
+- Consumes: `NodeIdClaimStore`, `ClaimResult`, `NodeId`, `ConditionalOnSharedBackend`, `NodeIdClaimGuardConfiguration`.
+- Produces: `class RedisNodeIdClaimStore(template: ReactiveStringRedisTemplate, keyType: String)`.
+
+- [ ] **Step 1: Write the failing store tests**
+
+Create `chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisNodeIdClaimStoreTests.kt`.
+
+```kotlin
+package com.demo.chat.test.persistence.redis
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.persistence.redis.impl.RedisNodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Duration
+
+/**
+ * Store level tests for the redis claim.
+ *
+ * These call the store directly and pass the TTL as an argument. The guard
+ * property rules do not apply here, so a one second lease is legal.
+ *
+ * Node ids 100 to 109 belong to this class. See the allocation table in the
+ * plan. Two contexts against one container must not share a node id.
+ */
+@SpringBootTest(classes = [RedisPersistenceTestContext::class])
+@Import(RedisPersistenceTestContext::class)
+@Tag("integration")
+class RedisNodeIdClaimStoreTests(
+    @Autowired private val template: ReactiveStringRedisTemplate
+) {
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) = RedisTestContainer.properties(registry)
+    }
+
+    private val longStore = RedisNodeIdClaimStore(template, "long")
+    private val uuidStore = RedisNodeIdClaimStore(template, "uuid")
+
+    @BeforeEach
+    fun flush() {
+        template.connectionFactory.reactiveConnection.serverCommands().flushDb().block()
+    }
+
+    @Test
+    fun `the scope names the backend and the key type`() {
+        Assertions.assertEquals("redis", longStore.backendName)
+        Assertions.assertEquals("redis store for key type long", longStore.scope)
+    }
+
+    @Test
+    fun `a second owner is denied and the holder is named`() {
+        val node = NodeId(100)
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+
+        val second = longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(ClaimResult.Denied("owner-one"), second)
+    }
+
+    @Test
+    fun `a release allows a takeover`() {
+        val node = NodeId(101)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        longStore.release(node, "owner-one").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a release by another owner does nothing`() {
+        val node = NodeId(102)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        longStore.release(node, "owner-two").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            longStore.claim(node, "owner-three", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `an expiry allows a takeover`() {
+        val node = NodeId(103)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(1)).block()
+        Thread.sleep(1500)
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by the holder extends the lease`() {
+        val node = NodeId(104)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(1)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.renew(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+        Thread.sleep(1500)
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            longStore.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by another owner is denied and names the holder`() {
+        val node = NodeId(105)
+        longStore.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            longStore.renew(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew with no live claim reports lost`() {
+        Assertions.assertEquals(
+            ClaimResult.Lost,
+            longStore.renew(NodeId(106), "owner-one", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a long claim and a uuid claim on one node id both hold`() {
+        val node = NodeId(107)
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            longStore.claim(node, "owner-long", Duration.ofSeconds(30)).block()
+        )
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            uuidStore.claim(node, "owner-uuid", Duration.ofSeconds(30)).block()
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-persistence-redis -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
+
+Expected: FAIL to compile, with an unresolved reference to `RedisNodeIdClaimStore`.
+
+- [ ] **Step 3: Write the store**
+
+Create `chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/RedisNodeIdClaimStore.kt`.
+
+```kotlin
+package com.demo.chat.persistence.redis.impl
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimStore
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import org.springframework.data.redis.core.script.RedisScript
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * The redis node id lease.
+ *
+ * The key carries the key type, because a cassandra deployment already
+ * separates key types by keyspace. A long deployment and a uuid deployment
+ * on one redis may both hold node id 7. Their value spaces do not intersect.
+ *
+ * `PX` makes the redis server the clock. No application clock enters the
+ * decision.
+ */
+class RedisNodeIdClaimStore(
+    private val template: ReactiveStringRedisTemplate,
+    private val keyType: String
+) : NodeIdClaimStore {
+
+    override val backendName: String = "redis"
+
+    override val scope: String = "redis store for key type $keyType"
+
+    private fun key(nodeId: NodeId): String = "chat:nodeclaim:$keyType:${nodeId.value}"
+
+    override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        attempt(nodeId, owner, ttl)
+            // The holder vanished between the write and the read. Try once more.
+            .switchIfEmpty(attempt(nodeId, owner, ttl))
+            .switchIfEmpty(
+                Mono.error(
+                    IllegalStateException(
+                        "The $scope denied app.nodeid=${nodeId.value} twice and named no holder."
+                    )
+                )
+            )
+
+    override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        run(renewScript, nodeId, owner, ttl.toMillis().toString())
+
+    override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+        run(releaseScript, nodeId, owner, "0").then()
+
+    private fun attempt(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        template.opsForValue().setIfAbsent(key(nodeId), owner, ttl)
+            .flatMap { taken ->
+                if (taken) Mono.just(ClaimResult.Granted as ClaimResult)
+                // A diagnostic read. A stale value costs message quality only.
+                else template.opsForValue().get(key(nodeId))
+                    .map { holder -> ClaimResult.Denied(holder) as ClaimResult }
+            }
+
+    private fun run(
+        script: RedisScript<String>,
+        nodeId: NodeId,
+        owner: String,
+        millis: String
+    ): Mono<ClaimResult> =
+        template.execute(script, listOf(key(nodeId)), listOf(owner, millis))
+            .next()
+            .map { reply ->
+                when {
+                    reply == "granted" -> ClaimResult.Granted
+                    reply == "lost" -> ClaimResult.Lost
+                    reply.startsWith("denied:") -> ClaimResult.Denied(reply.removePrefix("denied:"))
+                    else -> throw IllegalStateException(
+                        "The $scope returned an unknown claim reply: $reply"
+                    )
+                }
+            }
+
+    companion object {
+        // Lua gives the compare and set that plain commands cannot. The reply
+        // is one string, because ReactiveStringRedisTemplate carries a string
+        // serializer and a mixed Lua array would need a mixed result type.
+        private val renewScript: RedisScript<String> = RedisScript.of(
+            """
+            local v = redis.call('GET', KEYS[1])
+            if v == false then return 'lost' end
+            if v == ARGV[1] then
+                redis.call('PEXPIRE', KEYS[1], ARGV[2])
+                return 'granted'
+            end
+            return 'denied:' .. v
+            """.trimIndent(),
+            String::class.java
+        )
+
+        private val releaseScript: RedisScript<String> = RedisScript.of(
+            """
+            local v = redis.call('GET', KEYS[1])
+            if v == false then return 'lost' end
+            if v == ARGV[1] then
+                redis.call('DEL', KEYS[1])
+                return 'granted'
+            end
+            return 'denied:' .. v
+            """.trimIndent(),
+            String::class.java
+        )
+    }
+}
+```
+
+- [ ] **Step 4: Write the store configuration**
+
+Create `chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/NodeIdClaimConfiguration.kt`.
+
+```kotlin
+package com.demo.chat.config.persistence.redis
+
+import com.demo.chat.domain.ConditionalOnSharedBackend
+import com.demo.chat.domain.NodeIdClaimGuardConfiguration
+import com.demo.chat.domain.NodeIdClaimStore
+import com.demo.chat.persistence.redis.impl.RedisNodeIdClaimStore
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+
+/**
+ * Registers the redis node id claim store.
+ *
+ * The bean name is explicit. The cassandra module ships a class with the
+ * same simple name, and a classpath that names both backends registers both.
+ * The `KeyGenConfiguration` classes carry explicit names for the same
+ * reason.
+ */
+@Configuration("redisNodeIdClaimConfiguration")
+@ConditionalOnSharedBackend("redis")
+@Import(NodeIdClaimGuardConfiguration::class)
+class NodeIdClaimConfiguration {
+
+    @Bean("redisNodeIdClaimStore")
+    fun redisNodeIdClaimStore(
+        template: ReactiveStringRedisTemplate,
+        @Value("\${app.key.type}") keyType: String
+    ): NodeIdClaimStore = RedisNodeIdClaimStore(template, keyType)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `mvn -o -pl chat-persistence-redis -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add chat-persistence-redis/src/main/kotlin/com/demo/chat/persistence/redis/impl/RedisNodeIdClaimStore.kt \
+        chat-persistence-redis/src/main/kotlin/com/demo/chat/config/persistence/redis/NodeIdClaimConfiguration.kt \
+        chat-persistence-redis/src/test/kotlin/com/demo/chat/test/persistence/redis/RedisNodeIdClaimStoreTests.kt
+git commit -m "add the redis node id claim store"
+```
+
+---
+
+### Task 8: The Cassandra claim store
+
+**Files:**
+- Create: `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/persistence/cassandra/impl/CassandraNodeIdClaimStore.kt`
+- Create: `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/NodeIdClaimConfiguration.kt`
+- Test: `chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/CassandraNodeIdClaimStoreTests.kt`
+
+**Interfaces:**
+- Consumes: `NodeIdClaimStore`, `ClaimResult`, `NodeId`, `ConditionalOnSharedBackend`, `NodeIdClaimGuardConfiguration`, and the `node_claim` table from Task 1.
+- Produces: `class CassandraNodeIdClaimStore(template: ReactiveCassandraTemplate, keyspace: String)`.
+
+- [ ] **Step 1: Write the failing store tests**
+
+Create `chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/CassandraNodeIdClaimStoreTests.kt`.
+
+```kotlin
+package com.demo.chat.test.persistence.integration
+
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.persistence.cassandra.impl.CassandraNodeIdClaimStore
+import com.demo.chat.test.CassandraTestContainerConfiguration
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.annotation.Import
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import org.springframework.test.context.TestPropertySource
+import java.time.Duration
+
+/**
+ * Store level tests for the cassandra claim.
+ *
+ * These call the store directly and pass the TTL as an argument. The guard
+ * property rules do not apply here. Cassandra applies a TTL in whole
+ * seconds, so the expiry test uses three seconds.
+ *
+ * Node ids 200 to 209 belong to this package. See the allocation table in
+ * the plan. `truncate-long.cql` does not clear `node_claim`, so a reused
+ * node id would meet an earlier claim.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [CassandraNodeIdClaimStoreTests.ClaimApp::class]
+)
+@Import(CassandraTestContainerConfiguration::class)
+@TestPropertySource(properties = ["app.key.type=long", "app.nodeid=204"])
+@Tag("integration")
+class CassandraNodeIdClaimStoreTests {
+
+    @SpringBootApplication
+    class ClaimApp
+
+    @Autowired
+    private lateinit var template: ReactiveCassandraTemplate
+
+    private val store by lazy { CassandraNodeIdClaimStore(template, "chat_long") }
+
+    @Test
+    fun `the scope names the backend and the keyspace`() {
+        Assertions.assertEquals("cassandra", store.backendName)
+        Assertions.assertEquals("cassandra keyspace chat_long", store.scope)
+    }
+
+    @Test
+    fun `a second owner is denied and the holder is named`() {
+        val node = NodeId(205)
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            store.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a release allows a takeover`() {
+        val node = NodeId(206)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        store.release(node, "owner-one").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a release by another owner does nothing`() {
+        val node = NodeId(207)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+        store.release(node, "owner-two").block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            store.claim(node, "owner-three", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `an expiry allows a takeover`() {
+        val node = NodeId(208)
+        store.claim(node, "owner-one", Duration.ofSeconds(1)).block()
+        Thread.sleep(Duration.ofSeconds(3).toMillis())
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.claim(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by the holder is granted`() {
+        val node = NodeId(209)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Granted,
+            store.renew(node, "owner-one", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew by another owner is denied and names the holder`() {
+        val node = NodeId(200)
+        store.claim(node, "owner-one", Duration.ofSeconds(30)).block()
+
+        Assertions.assertEquals(
+            ClaimResult.Denied("owner-one"),
+            store.renew(node, "owner-two", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a renew with no live claim reports lost`() {
+        Assertions.assertEquals(
+            ClaimResult.Lost,
+            store.renew(NodeId(201), "owner-one", Duration.ofSeconds(30)).block()
+        )
+    }
+
+    @Test
+    fun `a missing table names the table and the schema file`() {
+        val missing = CassandraNodeIdClaimStore(template, "chat_long", "node_claim_absent")
+
+        val thrown = Assertions.assertThrows(Exception::class.java) {
+            missing.claim(NodeId(202), "owner-one", Duration.ofSeconds(30)).block()
+        }
+        val text = generateSequence(thrown as Throwable) { it.cause }
+            .mapNotNull { it.message }.joinToString(" | ")
+
+        Assertions.assertTrue(text.contains("node_claim_absent"), text)
+        Assertions.assertTrue(text.contains("keyspace-long.cql"), text)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-persistence-cassandra -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
+
+Expected: FAIL to compile, with an unresolved reference to `CassandraNodeIdClaimStore`.
+
+- [ ] **Step 3: Write the store**
+
+Create `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/persistence/cassandra/impl/CassandraNodeIdClaimStore.kt`.
+
+```kotlin
+package com.demo.chat.persistence.cassandra.impl
+
+import com.datastax.oss.driver.api.servererrors.InvalidQueryException
+import com.demo.chat.domain.ClaimResult
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimStore
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+/**
+ * The cassandra node id lease.
+ *
+ * A lightweight transaction runs at SERIAL, and the coordinator applies the
+ * TTL. No application clock enters the decision.
+ *
+ * The claim lives in the session keyspace, so `chat_long` and `chat_uuid`
+ * hold separate leases. That matches the redis key type scoping.
+ *
+ * The table name is a parameter so that a test can point at an absent table
+ * and prove the message.
+ */
+class CassandraNodeIdClaimStore(
+    private val template: ReactiveCassandraTemplate,
+    private val keyspace: String,
+    private val table: String = "node_claim"
+) : NodeIdClaimStore {
+
+    override val backendName: String = "cassandra"
+
+    override val scope: String = "cassandra keyspace $keyspace"
+
+    private val cql get() = template.reactiveCqlOperations
+
+    private val schemaFile: String = "keyspace-" + keyspace.removePrefix("chat_") + ".cql"
+
+    override fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        cql.queryForRows(
+            "INSERT INTO $table (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL ?",
+            nodeId.value, owner, ttl.seconds.toInt()
+        ).next().map { row ->
+            if (row.getBoolean("[applied]")) ClaimResult.Granted as ClaimResult
+            else ClaimResult.Denied(
+                row.getString("owner_id")
+                    ?: throw IllegalStateException(
+                        "The $scope denied app.nodeid=${nodeId.value} and named no holder."
+                    )
+            )
+        }.onErrorMap(InvalidQueryException::class.java) { missingTable(it) }
+
+    override fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult> =
+        cql.queryForRows(
+            "UPDATE $table USING TTL ? SET owner_id = ? WHERE node_id = ? IF owner_id = ?",
+            ttl.seconds.toInt(), owner, nodeId.value, owner
+        ).next().map { row ->
+            when {
+                row.getBoolean("[applied]") -> ClaimResult.Granted as ClaimResult
+                // No live row. The lease is gone, and no other owner is named.
+                row.getString("owner_id") == null -> ClaimResult.Lost
+                else -> ClaimResult.Denied(row.getString("owner_id")!!)
+            }
+        }.onErrorMap(InvalidQueryException::class.java) { missingTable(it) }
+
+    override fun release(nodeId: NodeId, owner: String): Mono<Void> =
+        cql.queryForRows(
+            "DELETE FROM $table WHERE node_id = ? IF owner_id = ?",
+            nodeId.value, owner
+        ).next().then()
+            .onErrorMap(InvalidQueryException::class.java) { missingTable(it) }
+
+    private fun missingTable(cause: Throwable): Throwable =
+        IllegalStateException(
+            "The $scope has no $table table. " +
+                "Apply $schemaFile from shared-resources-cassandra, or run the CREATE TABLE " +
+                "statement in docs/NODEID-CLAIM.md against an existing keyspace.",
+            cause
+        )
+}
+```
+
+- [ ] **Step 4: Write the store configuration**
+
+Create `chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/NodeIdClaimConfiguration.kt`.
+
+```kotlin
+package com.demo.chat.config.persistence.cassandra
+
+import com.demo.chat.domain.ConditionalOnSharedBackend
+import com.demo.chat.domain.NodeIdClaimGuardConfiguration
+import com.demo.chat.domain.NodeIdClaimStore
+import com.demo.chat.persistence.cassandra.impl.CassandraNodeIdClaimStore
+import org.springframework.boot.autoconfigure.cassandra.CassandraProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+
+/**
+ * Registers the cassandra node id claim store.
+ *
+ * The bean name is explicit. The redis module ships a class with the same
+ * simple name, and a classpath that names both backends registers both.
+ */
+@Configuration("cassandraNodeIdClaimConfiguration")
+@ConditionalOnSharedBackend("cassandra")
+@Import(NodeIdClaimGuardConfiguration::class)
+class NodeIdClaimConfiguration {
+
+    @Bean("cassandraNodeIdClaimStore")
+    fun cassandraNodeIdClaimStore(
+        template: ReactiveCassandraTemplate,
+        properties: CassandraProperties
+    ): NodeIdClaimStore = CassandraNodeIdClaimStore(template, properties.keyspaceName)
+}
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `mvn -o -pl chat-persistence-cassandra -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
+
+Expected: PASS, 9 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add chat-persistence-cassandra/src/main/kotlin/com/demo/chat/persistence/cassandra/impl/CassandraNodeIdClaimStore.kt \
+        chat-persistence-cassandra/src/main/kotlin/com/demo/chat/config/persistence/cassandra/NodeIdClaimConfiguration.kt \
+        chat-persistence-cassandra/src/test/kotlin/com/demo/chat/test/persistence/integration/CassandraNodeIdClaimStoreTests.kt
+git commit -m "add the cassandra node id claim store"
+```
+
+---
+
+### Task 9: Boot the redis seams
+
+**Files:**
+- Test: `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt`
+
+**Interfaces:**
+- Consumes: the redis store and configuration from Task 7.
+- Produces: no new type.
+
+- [ ] **Step 1: Read the existing boot test flags**
+
+Open `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisDeployBootTests.kt`. Copy its `@TestPropertySource` property list and its `@DynamicPropertySource` container wiring. The new tests reuse that launch surface and change only the node id and the two selectors.
+
+- [ ] **Step 2: Write the failing boot tests**
+
+Create `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt`. Replace `PROPERTIES_FROM_EXISTING_BOOT_TEST` with the exact property list read in Step 1, changing `app.nodeid` as each test states.
+
+```kotlin
+package com.demo.chat.test.deploy.redis
+
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.context.ApplicationListener
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
+import org.springframework.data.redis.core.ReactiveStringRedisTemplate
+import java.time.Duration
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Boot level tests for the redis claim seam.
+ *
+ * Node ids 11 and 12 belong to this class. See the allocation table in the
+ * plan. `RedisDeployBootTests` holds node id 1 in the same container.
+ */
+@Tag("integration")
+class RedisClaimBootTests {
+
+    private fun template(): ReactiveStringRedisTemplate {
+        val container = RedisDeployBootTests.redisContainer
+        val factory = LettuceConnectionFactory(
+            RedisStandaloneConfiguration(container.host, container.getMappedPort(6379))
+        ).apply { afterPropertiesSet() }
+        return ReactiveStringRedisTemplate(factory)
+    }
+
+    private fun foreignClaim(nodeId: Int) {
+        template().opsForValue()
+            .setIfAbsent("chat:nodeclaim:long:$nodeId", "foreign-owner@host-z:1#deadbeef", Duration.ofSeconds(60))
+            .block()
+    }
+
+    private fun boot(vararg properties: String, ready: AtomicBoolean): SpringApplicationBuilder =
+        SpringApplicationBuilder(RedisDeployBootTests.BootApp::class.java)
+            .properties(*properties)
+            .listeners(ApplicationListener<ApplicationReadyEvent> { ready.set(true) })
+
+    @Test
+    fun `a live claim fails startup with the actionable message`() {
+        foreignClaim(11)
+        val ready = AtomicBoolean(false)
+
+        val thrown = Assertions.assertThrows(Exception::class.java) {
+            boot(
+                // PROPERTIES_FROM_EXISTING_BOOT_TEST, with app.nodeid=11
+                ready = ready
+            ).run().close()
+        }
+
+        val text = generateSequence(thrown as Throwable) { it.cause }
+            .mapNotNull { it.message }.joinToString(" | ")
+
+        Assertions.assertTrue(text.contains("app.nodeid=11 is already claimed"), text)
+        Assertions.assertTrue(text.contains("redis store for key type long"), text)
+        Assertions.assertTrue(text.contains("foreign-owner@host-z:1#deadbeef"), text)
+        // The requirement is failure before ready and before normal traffic.
+        Assertions.assertFalse(ready.get(), "ApplicationReadyEvent must not be published")
+    }
+
+    @Test
+    fun `a memory key selector with redis persistence still claims`() {
+        val ready = AtomicBoolean(false)
+
+        boot(
+            // PROPERTIES_FROM_EXISTING_BOOT_TEST, with app.nodeid=12,
+            // app.service.core.key=memory, app.service.core.persistence=redis
+            ready = ready
+        ).run().use { context ->
+            val stores = context.getBeansOfType(NodeIdClaimStore::class.java)
+            Assertions.assertEquals(1, stores.size)
+            Assertions.assertEquals("redis", stores.values.first().backendName)
+        }
+
+        Assertions.assertTrue(ready.get())
+    }
+}
+```
+
+- [ ] **Step 3: Expose the container and the application class**
+
+`RedisClaimBootTests` needs the container and the boot application class that `RedisDeployBootTests` already declares. In `RedisDeployBootTests.kt`, promote the container field and the `@SpringBootApplication` class to the companion object so both test classes share one container.
+
+Change the container declaration to a companion member named `redisContainer`, and make the nested application class visible. Do not change any existing property or assertion in that file.
+
+- [ ] **Step 4: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-deploy-redis -Pintegration test -Dtest=RedisClaimBootTests`
+
+Expected: FAIL. The first test fails because startup succeeds, since no guard is on this classpath until `chat-persistence-redis` supplies it. Read the failure before fixing.
+
+- [ ] **Step 5: Make the tests pass**
+
+The guard reaches this classpath through `chat-persistence-redis`, which `chat-deploy-redis` already depends on. If the first test still starts cleanly, check that:
+
+1. `app.key.type` is set. `NodeIdClaimConfiguration` reads it with `@Value` and fails when it is absent.
+2. `app.service.core.key` or `app.service.core.persistence` is `redis`.
+3. `chat-persistence-redis` is on the test classpath.
+
+Fix the launch properties, not the guard.
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `mvn -o -pl chat-deploy-redis -Pintegration test -Dtest=RedisClaimBootTests`
+
+Expected: PASS, 2 tests.
+
+- [ ] **Step 7: Run the whole redis deploy module**
+
+Run: `mvn -o -pl chat-deploy-redis -Pintegration test`
+
+Expected: PASS. `RedisDeployBootTests` still boots on node id 1.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/
+git commit -m "boot the redis claim seams and prove the duplicate failure"
+```
+
+---
+
+### Task 10: Boot the cassandra seams
+
+**Files:**
+- Test: `chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt`
+
+**Interfaces:**
+- Consumes: the cassandra store and configuration from Task 8, and the `node_claim` table from Task 1.
+- Produces: no new type.
+
+- [ ] **Step 1: Write the failing boot tests**
+
+Create `chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt`. Copy the property list from `CassandraDeployTest`, changing only the values each test states.
+
+```kotlin
+package com.demo.chat.test.deploy.cassandra
+
+import com.demo.chat.ChatApp
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.springframework.boot.builder.SpringApplicationBuilder
+import org.springframework.boot.WebApplicationType
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
+import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Boot level tests for the cassandra claim seam.
+ *
+ * Node ids 21 and 22 belong to this class. See the allocation table in the
+ * plan. `CassandraDeployTest` holds node id 1 in the same container.
+ */
+@Tag("integration")
+class CassandraClaimBootTests : CassandraContainerBase() {
+
+    private val launchProperties = arrayOf(
+        "spring.config.location=classpath:/application.yml",
+        "spring.config.additional-location=classpath:/config/logging.yml," +
+            "classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
+        "app.service.core.pubsub=memory", "app.service.core.index=cassandra",
+        "app.service.core.secrets=cassandra", "app.service.composite", "app.service.composite.auth",
+        "app.controller.secrets", "app.controller.key", "app.controller.persistence",
+        "app.controller.index", "app.controller.user", "app.controller.message",
+        "app.controller.topic", "app.controller.pubsub", "app.service.security.userdetails",
+        "spring.profiles.active=cassandra-contact-point"
+    )
+
+    private fun boot(vararg extra: String, ready: AtomicBoolean) =
+        SpringApplicationBuilder(ChatApp::class.java)
+            .web(WebApplicationType.NONE)
+            .properties(*launchProperties, *extra)
+            .listeners(ApplicationListener<ApplicationReadyEvent> { ready.set(true) })
+
+    private fun foreignClaim(template: ReactiveCassandraTemplate, nodeId: Int) {
+        template.reactiveCqlOperations.queryForRows(
+            "INSERT INTO node_claim (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL ?",
+            nodeId, "foreign-owner@host-z:1#deadbeef", 120
+        ).next().block()
+    }
+
+    @Test
+    fun `a live claim fails startup with the actionable message`() {
+        val ready = AtomicBoolean(false)
+
+        boot(
+            "app.nodeid=21", "app.service.core.key=cassandra",
+            "app.service.core.persistence=cassandra",
+            ready = ready
+        ).run().use { context ->
+            foreignClaim(context.getBean(ReactiveCassandraTemplate::class.java), 21)
+        }
+
+        val second = AtomicBoolean(false)
+        val thrown = Assertions.assertThrows(Exception::class.java) {
+            boot(
+                "app.nodeid=21", "app.service.core.key=cassandra",
+                "app.service.core.persistence=cassandra",
+                ready = second
+            ).run().close()
+        }
+
+        val text = generateSequence(thrown as Throwable) { it.cause }
+            .mapNotNull { it.message }.joinToString(" | ")
+
+        Assertions.assertTrue(text.contains("app.nodeid=21 is already claimed"), text)
+        Assertions.assertTrue(text.contains("cassandra keyspace chat_long"), text)
+        Assertions.assertTrue(text.contains("foreign-owner@host-z:1#deadbeef"), text)
+        Assertions.assertFalse(second.get(), "ApplicationReadyEvent must not be published")
+    }
+
+    @Test
+    fun `a memory key selector with cassandra persistence still claims`() {
+        val ready = AtomicBoolean(false)
+
+        boot(
+            "app.nodeid=22", "app.service.core.key=memory",
+            "app.service.core.persistence=cassandra",
+            ready = ready
+        ).run().use { context ->
+            val stores = context.getBeansOfType(NodeIdClaimStore::class.java)
+            Assertions.assertEquals(1, stores.size)
+            Assertions.assertEquals("cassandra", stores.values.first().backendName)
+        }
+
+        Assertions.assertTrue(ready.get())
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `mvn -o -pl chat-deploy-cassandra -Pintegration test -Dtest=CassandraClaimBootTests`
+
+Expected: FAIL on the first run. Read the failure text before changing anything.
+
+The first test closes the first context on purpose. The guard releases the lease on close, so the test writes its own foreign claim before the second boot.
+
+- [ ] **Step 3: Make the tests pass**
+
+If the first test starts cleanly, check the same three points as Task 9, Step 5, with `cassandra` in place of `redis`. Fix the launch properties, not the guard.
+
+- [ ] **Step 4: Run the whole cassandra deploy module**
+
+Run: `mvn -o -pl chat-deploy-cassandra -Pintegration test`
+
+Expected: PASS. `CassandraDeployTest` still boots on node id 1.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt
+git commit -m "boot the cassandra claim seams and prove the duplicate failure"
+```
+
+---
+
+### Task 11: Memory contributes no false safety
+
+**Files:**
+- Test: `chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryClaimAbsenceTests.kt`
+
+**Interfaces:**
+- Consumes: `NodeIdClaimStore`, `NodeIdClaimGuard`.
+- Produces: no new type.
+
+- [ ] **Step 1: Write the failing absence test**
+
+Create `chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryClaimAbsenceTests.kt`. Copy the property list from `MemoryDeploymentTests` in the same package.
+
+```kotlin
+package com.demo.chat.test.deploy.memory
+
+import com.demo.chat.domain.NodeId
+import com.demo.chat.domain.NodeIdClaimGuard
+import com.demo.chat.domain.NodeIdClaimStore
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ApplicationContext
+
+/**
+ * Memory offers no claim, and it must not look as though it does.
+ *
+ * The limit of this test, stated so it is not overclaimed: memory still
+ * requires `app.nodeid`. Stage 1 requires it wherever a key generator
+ * activates. What this test pins is that the claim design adds no
+ * requirement to memory and supplies no no-operation store.
+ *
+ * A no-operation store that returned Granted would be false safety. A
+ * memory store is per process, so it can prove nothing about another
+ * deployment.
+ */
+@SpringBootTest(
+    // Copy the classes and properties from MemoryDeploymentTests in this package.
+    webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+class MemoryClaimAbsenceTests {
+
+    @Autowired
+    private lateinit var context: ApplicationContext
+
+    @Test
+    fun `a memory deployment registers no claim store`() {
+        Assertions.assertTrue(context.getBeansOfType(NodeIdClaimStore::class.java).isEmpty())
+    }
+
+    @Test
+    fun `a memory deployment registers no claim guard`() {
+        Assertions.assertTrue(context.getBeansOfType(NodeIdClaimGuard::class.java).isEmpty())
+    }
+
+    @Test
+    fun `a memory deployment still supplies the node id from stage one`() {
+        Assertions.assertEquals(1, context.getBean(NodeId::class.java).value)
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests**
+
+Run: `mvn -o -pl chat-deploy-memory test -Dtest=MemoryClaimAbsenceTests`
+
+Expected: PASS, 3 tests. Nothing on this classpath names redis or cassandra, so the condition never matches.
+
+If a claim store bean appears, the condition is wrong. Check `OnSharedBackendCondition`. Do not weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryClaimAbsenceTests.kt
+git commit -m "pin that a memory deployment offers no claim and no false safety"
+```
+
+---
+
+### Task 12: The operator document and the build gate
+
+**Files:**
+- Create: `docs/NODEID-CLAIM.md`
+- Modify: `forward-register.md`
+
+**Interfaces:**
+- Consumes: everything.
+- Produces: the upgrade statement referenced by `CassandraNodeIdClaimStore.missingTable`.
+
+- [ ] **Step 1: Write the operator document**
+
+Create `docs/NODEID-CLAIM.md`.
+
+````markdown
+# Node id claim lease
+
+`app.nodeid` identifies one host in the Snowflake key generator. Two
+deployments that write to one shared store must not use the same value.
+
+A registry check cannot enforce this. One store can be reached by
+deployments that do not share a registry. The claim therefore lives in the
+store.
+
+## When a process claims
+
+A process claims when `app.service.core.key` or
+`app.service.core.persistence` names `redis` or `cassandra`.
+
+| key \ persistence | `memory` | `redis` | `cassandra` |
+|---|---|---|---|
+| `memory` | none | redis | cassandra |
+| `redis` | redis | redis | redis and cassandra |
+| `cassandra` | cassandra | cassandra and redis | cassandra |
+
+An unset selector counts as `memory`. A client that names neither selector
+claims nothing.
+
+## Scope of the claim
+
+Uniqueness is per key type per store.
+
+Cassandra separates key types by keyspace. Redis carries the key type in the
+claim key, `chat:nodeclaim:<keyType>:<nodeId>`.
+
+A `long` deployment and a `uuid` deployment on one redis may both hold node
+id 7. Their value spaces do not intersect.
+
+## Properties
+
+| Property | Default |
+|---|---|
+| `app.nodeid.claim.ttl` | `30s` |
+| `app.nodeid.claim.renew-interval` | `10s` |
+| `app.nodeid.claim.safety-margin` | `5s` |
+| `app.nodeid.claim.operation-timeout` | `5s` |
+
+Rules: `ttl` is at least 1s and uses whole seconds. `renew-interval` is at
+most `ttl / 3`. `safety-margin` is above zero and below `ttl`.
+`operation-timeout` is below `renew-interval`. `ttl` minus `safety-margin`
+is above `renew-interval`.
+
+The process closes its context `ttl` minus `safety-margin` after the last
+successful renew. With the defaults that is 25 seconds.
+
+## Cassandra upgrade
+
+A fresh keyspace gets `node_claim` from `keyspace-long.cql` or
+`keyspace-uuid.cql`. An existing keyspace needs the statement below. Run it
+once per keyspace, before the upgrade.
+
+```sql
+CREATE TABLE IF NOT EXISTS chat_long.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+```
+
+Use `chat_uuid` for a uuid keyspace.
+
+`node_claim` is deliberately absent from `truncate-long.cql` and
+`truncate-uuid.cql`. A live lease must expire. A cleanup script must not
+delete it.
+
+## Reading a startup failure
+
+```
+app.nodeid=7 is already claimed in the redis store for key type long.
+Holder: core-service@host-a:4711#a3f19c2b
+Two deployments that write to the redis store for key type long must not
+use the same app.nodeid.
+Set a different app.nodeid, or stop the other deployment and wait 30s
+for its lease to expire.
+```
+
+The holder names the application, the host, the process id, and a random
+suffix. A restart never reuses the suffix.
+
+Set a different `app.nodeid`, or stop the named deployment. A stopped
+deployment releases its lease on a clean shutdown. A crashed deployment
+releases it when the lease expires.
+
+## Testing note
+
+Every container-backed test that activates a claim store uses its own
+`app.nodeid`. Spring caches contexts, so two open contexts against one store
+would collide. That collision is correct behaviour, and it appears as a test
+failure.
+````
+
+- [ ] **Step 2: Run the default build gate**
+
+Run: `./shell-scripts/build-health.sh`
+
+Expected: exit status 0, and no NEW module reported.
+
+- [ ] **Step 3: Run the integration build gate**
+
+Run: `./shell-scripts/build-health.sh --integration`
+
+Expected: exit status 0, and no NEW module reported. A Docker daemon must be running.
+
+If a module reports NEW, fix the code. Do not add the module to
+`KNOWN_FAILING_INTEGRATION`.
+
+- [ ] **Step 4: Record the outcome in the forward register**
+
+Add a section to `forward-register.md` under the existing structure. State four things: the claim seam is either core selector, uniqueness is per key type per store, `node_claim` is absent from the truncate scripts on purpose, and every container-backed claim test owns a distinct `app.nodeid`.
+
+Record the lifecycle observation from the boot tests: whether the server port bound before the claim failed. Record it as an observation, not as a requirement.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/NODEID-CLAIM.md forward-register.md
+git commit -m "document the node id claim lease and record the build gate"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Every spec section maps to a task. D1 to Task 6. D2 to Tasks 4 and 5. D3 to Task 1 and Task 12. D4 to Tasks 4, 9, and 10. D5 to Tasks 7 and 8. D6 to Task 11. The contract to Task 2. The guard to Tasks 4 and 5. The owner id and scheduler to Task 3. Redis to Task 7. Cassandra to Task 8. The message to Task 2. The Cassandra UUID note to Task 12. Every test in the spec test tables appears in a task. R1 appears as the allocation table in Global Constraints. R2 appears in Task 1 comments and Task 8. R3 appears in the properties. R4 appears in Tasks 3 and 5. Unverified claim 1 is Task 1. Unverified claim 2 is Task 9 Step 2 and Task 10 Step 1.
+
+**Two gaps to accept.** Task 9 leaves the exact property list to be copied from the existing boot test, because that list is long and already correct in the repository. Task 11 does the same for the memory deployment test. Both steps name the file and the fields to copy. Every other step carries its content.
+
+**Type consistency.** `NodeIdClaimException` takes `(nodeId, scope, holder, ttl)` in Task 2 and is constructed with those four arguments in Tasks 4 and 5. `NodeIdClaimStore` declares `backendName`, `scope`, `claim`, `renew`, `release` in Task 2 and is implemented with the same names in Tasks 7 and 8. `ClaimScheduler` declares five methods in Task 3, and `ManualClaimScheduler` in Task 4 implements all five. `NodeIdClaimProperties` exposes `ttl`, `renewInterval`, `safetyMargin`, `operationTimeout`, `closeDeadline` in Task 2 and is read with those names in Task 4.
+
+**One deviation from the spec, already applied to the spec.** `NodeIdClaimException` drops the `backendName` field. The scope phrase carries the backend name, and one template then serves both backends. `backendName` stays on the store, where it orders the claims.

--- a/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
+++ b/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
@@ -369,7 +369,7 @@ class NodeIdClaimExceptionTests {
 
 - [ ] **Step 3: Run both tests to verify they fail**
 
-Run: `mvn -o -pl chat-core test -Dtest='NodeIdClaimPropertiesTests+NodeIdClaimExceptionTests'`
+Run: `mvn -o -pl chat-core test -Dtest='NodeIdClaimPropertiesTests,NodeIdClaimExceptionTests'`
 
 Expected: FAIL to compile, with unresolved references to `NodeIdClaimProperties` and `NodeIdClaimException`.
 
@@ -540,7 +540,7 @@ class NodeIdClaimProperties(
 
 - [ ] **Step 6: Run both tests to verify they pass**
 
-Run: `mvn -o -pl chat-core test -Dtest='NodeIdClaimPropertiesTests+NodeIdClaimExceptionTests'`
+Run: `mvn -o -pl chat-core test -Dtest='NodeIdClaimPropertiesTests,NodeIdClaimExceptionTests'`
 
 Expected: PASS, 11 tests.
 
@@ -688,7 +688,7 @@ class ExecutorClaimSchedulerTests {
 
 - [ ] **Step 3: Run both tests to verify they fail**
 
-Run: `mvn -o -pl chat-core test -Dtest='RuntimeOwnerIdTests+ExecutorClaimSchedulerTests'`
+Run: `mvn -o -pl chat-core test -Dtest='RuntimeOwnerIdTests,ExecutorClaimSchedulerTests'`
 
 Expected: FAIL to compile, with unresolved references to `RuntimeOwnerId` and `ExecutorClaimScheduler`.
 
@@ -823,7 +823,7 @@ class ExecutorClaimScheduler : ClaimScheduler {
 
 - [ ] **Step 6: Run both tests to verify they pass**
 
-Run: `mvn -o -pl chat-core test -Dtest='RuntimeOwnerIdTests+ExecutorClaimSchedulerTests'`
+Run: `mvn -o -pl chat-core test -Dtest='RuntimeOwnerIdTests,ExecutorClaimSchedulerTests'`
 
 Expected: PASS, 7 tests.
 

--- a/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
+++ b/docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md
@@ -20,6 +20,7 @@
 - Property defaults: `app.nodeid.claim.ttl=30s`, `renew-interval=10s`, `safety-margin=5s`, `operation-timeout=5s`.
 - Property rules: `ttl >= 1s` and whole seconds. `renew-interval <= ttl / 3`. `safety-margin > 0` and `< ttl`. `operation-timeout < renew-interval`. `ttl - safety-margin > renew-interval`.
 - Do not use `grep` or `find` for symbol lookup. Use the language server or treesitter tools.
+- Every `mvn -pl` command outside `chat-core` carries `-am`. This task chain adds new types to `chat-core` and new CQL to `shared-resources-cassandra`. Without `-am`, Maven resolves the stale installed artifact and the module compiles against the old code.
 
 ### Node id allocation
 
@@ -188,7 +189,7 @@ class NodeClaimTableProbeTests {
 
 - [ ] **Step 4: Run the probe**
 
-Run: `mvn -o -pl chat-persistence-cassandra -Pintegration test -Dtest=NodeClaimTableProbeTests`
+Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=NodeClaimTableProbeTests`
 
 Expected: PASS, all three tests. A Docker daemon must be running.
 
@@ -1804,7 +1805,7 @@ class RedisNodeIdClaimStoreTests(
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `mvn -o -pl chat-persistence-redis -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-redis -am -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
 
 Expected: FAIL to compile, with an unresolved reference to `RedisNodeIdClaimStore`.
 
@@ -1963,7 +1964,7 @@ class NodeIdClaimConfiguration {
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
-Run: `mvn -o -pl chat-persistence-redis -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-redis -am -Pintegration test -Dtest=RedisNodeIdClaimStoreTests`
 
 Expected: PASS, 9 tests.
 
@@ -2142,7 +2143,7 @@ class CassandraNodeIdClaimStoreTests {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `mvn -o -pl chat-persistence-cassandra -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
 
 Expected: FAIL to compile, with an unresolved reference to `CassandraNodeIdClaimStore`.
 
@@ -2269,7 +2270,7 @@ class NodeIdClaimConfiguration {
 
 - [ ] **Step 5: Run the tests to verify they pass**
 
-Run: `mvn -o -pl chat-persistence-cassandra -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
+Run: `mvn -o -pl chat-persistence-cassandra -am -Pintegration test -Dtest=CassandraNodeIdClaimStoreTests`
 
 Expected: PASS, 9 tests.
 
@@ -2290,16 +2291,16 @@ git commit -m "add the cassandra node id claim store"
 - Test: `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt`
 
 **Interfaces:**
-- Consumes: the redis store and configuration from Task 7.
+- Consumes: the redis store and configuration from Task 7. Reuses two members of `RedisDeployBootTests` as they already stand: the companion `val redis`, which is the shared `GenericContainer`, and the nested `@SpringBootApplication class BootApp`. Neither needs a change.
 - Produces: no new type.
 
-- [ ] **Step 1: Read the existing boot test flags**
+**Expected result.** Task 7 already put the guard on this classpath. These tests pass as soon as they are written. There is no red step here. The red step for this behaviour was Task 4, `a denial at the second store releases the first store`. If the duplicate test starts cleanly, the seam is broken. Read Step 3 before changing anything.
 
-Open `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisDeployBootTests.kt`. Copy its `@TestPropertySource` property list and its `@DynamicPropertySource` container wiring. The new tests reuse that launch surface and change only the node id and the two selectors.
+**Container properties.** `@DynamicPropertySource` applies to a `@SpringBootTest` context only. These tests drive `SpringApplicationBuilder` directly, so they pass the container address themselves. `RedisConfiguration` reads it from `ConfigurationPropertiesRedisTopics`, whose prefix is `redis-topics`.
 
-- [ ] **Step 2: Write the failing boot tests**
+- [ ] **Step 1: Write the boot tests**
 
-Create `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt`. Replace `PROPERTIES_FROM_EXISTING_BOOT_TEST` with the exact property list read in Step 1, changing `app.nodeid` as each test states.
+Create `chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt`.
 
 ```kotlin
 package com.demo.chat.test.deploy.redis
@@ -2308,9 +2309,10 @@ import com.demo.chat.domain.NodeIdClaimStore
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
+import org.springframework.boot.WebApplicationType
 import org.springframework.boot.builder.SpringApplicationBuilder
-import org.springframework.context.ApplicationListener
 import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.ApplicationListener
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.ReactiveStringRedisTemplate
@@ -2322,44 +2324,83 @@ import java.util.concurrent.atomic.AtomicBoolean
  *
  * Node ids 11 and 12 belong to this class. See the allocation table in the
  * plan. `RedisDeployBootTests` holds node id 1 in the same container.
+ *
+ * The foreign claim is written straight to redis, not through a booted
+ * context. A guarded context would claim the id itself and then release it
+ * on close, and the duplicate would never be present for the second boot.
  */
 @Tag("integration")
 class RedisClaimBootTests {
 
+    private val container = RedisDeployBootTests.redis
+
     private fun template(): ReactiveStringRedisTemplate {
-        val container = RedisDeployBootTests.redisContainer
         val factory = LettuceConnectionFactory(
-            RedisStandaloneConfiguration(container.host, container.getMappedPort(6379))
+            RedisStandaloneConfiguration(container.containerIpAddress, container.getMappedPort(6379))
         ).apply { afterPropertiesSet() }
         return ReactiveStringRedisTemplate(factory)
     }
 
-    private fun foreignClaim(nodeId: Int) {
-        template().opsForValue()
-            .setIfAbsent("chat:nodeclaim:long:$nodeId", "foreign-owner@host-z:1#deadbeef", Duration.ofSeconds(60))
+    private fun seedForeignClaim(nodeId: Int, owner: String) {
+        val applied = template().opsForValue()
+            .setIfAbsent("chat:nodeclaim:long:$nodeId", owner, Duration.ofSeconds(120))
             .block()
+        Assertions.assertEquals(true, applied, "the foreign claim seed must be applied")
     }
 
-    private fun boot(vararg properties: String, ready: AtomicBoolean): SpringApplicationBuilder =
+    // The launch surface of RedisDeployBootTests. Each test overrides only
+    // what it needs after this list.
+    private fun launchProperties(): Array<String> = arrayOf(
+        "spring.application.name=redis-claim-boot-test",
+        "spring.main.web-application-type=reactive",
+        "server.port=0",
+        "spring.rsocket.server.port=0",
+        "app.server.proto=rsocket",
+        "app.key.type=long",
+        "app.service.core.pubsub=redis-pubsub",
+        "app.service.core.index=lucene",
+        "app.service.core.secrets=memory",
+        "app.service.composite",
+        "app.service.composite.auth",
+        "app.controller.persistence",
+        "app.controller.index",
+        "app.controller.key",
+        "app.controller.pubsub",
+        "app.controller.secrets",
+        "app.controller.user",
+        "app.controller.topic",
+        "app.controller.message",
+        "spring.cloud.consul.enabled=false",
+        "spring.cloud.consul.discovery.enabled=false",
+        "spring.cloud.consul.config.enabled=false",
+        "redis-topics.host=${container.containerIpAddress}",
+        "redis-topics.port=${container.getMappedPort(6379)}"
+    )
+
+    private fun boot(vararg extra: String, ready: AtomicBoolean) =
         SpringApplicationBuilder(RedisDeployBootTests.BootApp::class.java)
-            .properties(*properties)
+            .web(WebApplicationType.REACTIVE)
+            .properties(*launchProperties(), *extra)
             .listeners(ApplicationListener<ApplicationReadyEvent> { ready.set(true) })
+
+    private fun allMessages(thrown: Throwable): String =
+        generateSequence(thrown) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
 
     @Test
     fun `a live claim fails startup with the actionable message`() {
-        foreignClaim(11)
+        seedForeignClaim(11, "foreign-owner@host-z:1#deadbeef")
         val ready = AtomicBoolean(false)
 
         val thrown = Assertions.assertThrows(Exception::class.java) {
             boot(
-                // PROPERTIES_FROM_EXISTING_BOOT_TEST, with app.nodeid=11
+                "app.nodeid=11",
+                "app.service.core.key=redis",
+                "app.service.core.persistence=redis",
                 ready = ready
             ).run().close()
         }
 
-        val text = generateSequence(thrown as Throwable) { it.cause }
-            .mapNotNull { it.message }.joinToString(" | ")
-
+        val text = allMessages(thrown)
         Assertions.assertTrue(text.contains("app.nodeid=11 is already claimed"), text)
         Assertions.assertTrue(text.contains("redis store for key type long"), text)
         Assertions.assertTrue(text.contains("foreign-owner@host-z:1#deadbeef"), text)
@@ -2372,8 +2413,9 @@ class RedisClaimBootTests {
         val ready = AtomicBoolean(false)
 
         boot(
-            // PROPERTIES_FROM_EXISTING_BOOT_TEST, with app.nodeid=12,
-            // app.service.core.key=memory, app.service.core.persistence=redis
+            "app.nodeid=12",
+            "app.service.core.key=memory",
+            "app.service.core.persistence=redis",
             ready = ready
         ).run().use { context ->
             val stores = context.getBeansOfType(NodeIdClaimStore::class.java)
@@ -2386,44 +2428,32 @@ class RedisClaimBootTests {
 }
 ```
 
-- [ ] **Step 3: Expose the container and the application class**
+- [ ] **Step 2: Run the boot tests**
 
-`RedisClaimBootTests` needs the container and the boot application class that `RedisDeployBootTests` already declares. In `RedisDeployBootTests.kt`, promote the container field and the `@SpringBootApplication` class to the companion object so both test classes share one container.
-
-Change the container declaration to a companion member named `redisContainer`, and make the nested application class visible. Do not change any existing property or assertion in that file.
-
-- [ ] **Step 4: Run the tests to verify they fail**
-
-Run: `mvn -o -pl chat-deploy-redis -Pintegration test -Dtest=RedisClaimBootTests`
-
-Expected: FAIL. The first test fails because startup succeeds, since no guard is on this classpath until `chat-persistence-redis` supplies it. Read the failure before fixing.
-
-- [ ] **Step 5: Make the tests pass**
-
-The guard reaches this classpath through `chat-persistence-redis`, which `chat-deploy-redis` already depends on. If the first test still starts cleanly, check that:
-
-1. `app.key.type` is set. `NodeIdClaimConfiguration` reads it with `@Value` and fails when it is absent.
-2. `app.service.core.key` or `app.service.core.persistence` is `redis`.
-3. `chat-persistence-redis` is on the test classpath.
-
-Fix the launch properties, not the guard.
-
-- [ ] **Step 6: Run the tests to verify they pass**
-
-Run: `mvn -o -pl chat-deploy-redis -Pintegration test -Dtest=RedisClaimBootTests`
+Run: `mvn -o -pl chat-deploy-redis -am -Pintegration test -Dtest=RedisClaimBootTests`
 
 Expected: PASS, 2 tests.
 
-- [ ] **Step 7: Run the whole redis deploy module**
+- [ ] **Step 3: Read a clean start as a seam failure**
 
-Run: `mvn -o -pl chat-deploy-redis -Pintegration test`
+If `a live claim fails startup with the actionable message` reports that no exception was thrown, the guard did not activate. Check three things in order:
 
-Expected: PASS. `RedisDeployBootTests` still boots on node id 1.
+1. `app.key.type` is set. `NodeIdClaimConfiguration` reads it with `@Value` and fails when it is absent.
+2. `app.service.core.key` or `app.service.core.persistence` is `redis`, so `OnSharedBackendCondition` matches.
+3. `chat-persistence-redis` is on the test classpath of `chat-deploy-redis`.
 
-- [ ] **Step 8: Commit**
+Fix the launch properties or the condition. Do not weaken the test.
+
+- [ ] **Step 4: Run the whole redis deploy module**
+
+Run: `mvn -o -pl chat-deploy-redis -am -Pintegration test`
+
+Expected: PASS. `RedisDeployBootTests` still boots on node id 1, and it now takes a real claim in the shared container.
+
+- [ ] **Step 5: Commit**
 
 ```bash
-git add chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/
+git add chat-deploy-redis/src/test/kotlin/com/demo/chat/test/deploy/redis/RedisClaimBootTests.kt
 git commit -m "boot the redis claim seams and prove the duplicate failure"
 ```
 
@@ -2435,12 +2465,16 @@ git commit -m "boot the redis claim seams and prove the duplicate failure"
 - Test: `chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt`
 
 **Interfaces:**
-- Consumes: the cassandra store and configuration from Task 8, and the `node_claim` table from Task 1.
+- Consumes: the cassandra store and configuration from Task 8, and the `node_claim` table from Task 1. Extends `CassandraContainerBase`, which already starts the container and applies both keyspaces.
 - Produces: no new type.
 
-- [ ] **Step 1: Write the failing boot tests**
+**Expected result.** Task 8 already put the guard on this classpath. These tests pass as soon as they are written. There is no red step here.
 
-Create `chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt`. Copy the property list from `CassandraDeployTest`, changing only the values each test states.
+**Seeding the foreign claim.** The seed must not run through a booted deploy context. A guarded context claims the id itself, so the seed insert would find the row taken. The context then releases the id on close, and the second boot would start cleanly. The seed therefore runs through `cqlsh` in the container, which is the pattern `CassandraContainerBase` already uses to apply the long keyspace. The test asserts that the seed row is present before it boots.
+
+- [ ] **Step 1: Write the boot tests**
+
+Create `chat-deploy-cassandra/src/test/kotlin/com/demo/chat/test/deploy/cassandra/CassandraClaimBootTests.kt`.
 
 ```kotlin
 package com.demo.chat.test.deploy.cassandra
@@ -2450,76 +2484,111 @@ import com.demo.chat.domain.NodeIdClaimStore
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Tag
 import org.junit.jupiter.api.Test
-import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.WebApplicationType
+import org.springframework.boot.builder.SpringApplicationBuilder
 import org.springframework.boot.context.event.ApplicationReadyEvent
 import org.springframework.context.ApplicationListener
-import org.springframework.data.cassandra.core.ReactiveCassandraTemplate
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Boot level tests for the cassandra claim seam.
  *
  * Node ids 21 and 22 belong to this class. See the allocation table in the
- * plan. `CassandraDeployTest` holds node id 1 in the same container.
+ * plan. `CassandraDeployTest` holds node id 1 in the same container, and
+ * truncate-long.cql does not clear node_claim.
  */
 @Tag("integration")
 class CassandraClaimBootTests : CassandraContainerBase() {
 
-    private val launchProperties = arrayOf(
+    private fun cqlsh(statement: String): String {
+        val result = cassandraContainer.execInContainer(
+            "cqlsh",
+            "-u", cassandraContainer.username,
+            "-p", cassandraContainer.password,
+            "-e", statement
+        )
+        Assertions.assertEquals(
+            0, result.exitCode,
+            "cqlsh failed. stdout: ${result.stdout} stderr: ${result.stderr}"
+        )
+        return result.stdout
+    }
+
+    /**
+     * Writes the claim with cqlsh, outside every application context.
+     *
+     * A booted context would take the id itself and release it on close, and
+     * the duplicate would not be there for the second boot.
+     */
+    private fun seedForeignClaim(nodeId: Int, owner: String) {
+        cqlsh(
+            "INSERT INTO chat_long.node_claim (node_id, owner_id) " +
+                "VALUES ($nodeId, '$owner') IF NOT EXISTS USING TTL 300;"
+        )
+        val readBack = cqlsh("SELECT owner_id FROM chat_long.node_claim WHERE node_id = $nodeId;")
+        Assertions.assertTrue(
+            readBack.contains(owner),
+            "the foreign claim seed must be applied. cqlsh said: $readBack"
+        )
+    }
+
+    private fun launchProperties(): Array<String> = arrayOf(
         "spring.config.location=classpath:/application.yml",
         "spring.config.additional-location=classpath:/config/logging.yml," +
             "classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
-        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long",
-        "app.service.core.pubsub=memory", "app.service.core.index=cassandra",
-        "app.service.core.secrets=cassandra", "app.service.composite", "app.service.composite.auth",
-        "app.controller.secrets", "app.controller.key", "app.controller.persistence",
-        "app.controller.index", "app.controller.user", "app.controller.message",
-        "app.controller.topic", "app.controller.pubsub", "app.service.security.userdetails",
-        "spring.profiles.active=cassandra-contact-point"
+        "server.port=0",
+        "spring.rsocket.server.port=0",
+        "app.key.type=long",
+        "app.service.core.pubsub=memory",
+        "app.service.core.index=cassandra",
+        "app.service.core.secrets=cassandra",
+        "app.service.composite",
+        "app.service.composite.auth",
+        "app.controller.secrets",
+        "app.controller.key",
+        "app.controller.persistence",
+        "app.controller.index",
+        "app.controller.user",
+        "app.controller.message",
+        "app.controller.topic",
+        "app.controller.pubsub",
+        "app.service.security.userdetails",
+        "spring.profiles.active=cassandra-contact-point",
+        // SpringApplicationBuilder does not read @DynamicPropertySource.
+        "spring.cassandra.contact-points=${cassandraContainer.host}",
+        "spring.cassandra.port=${cassandraContainer.getMappedPort(9042)}",
+        "spring.cassandra.username=${cassandraContainer.username}",
+        "spring.cassandra.password=${cassandraContainer.password}"
     )
 
     private fun boot(vararg extra: String, ready: AtomicBoolean) =
         SpringApplicationBuilder(ChatApp::class.java)
             .web(WebApplicationType.NONE)
-            .properties(*launchProperties, *extra)
+            .properties(*launchProperties(), *extra)
             .listeners(ApplicationListener<ApplicationReadyEvent> { ready.set(true) })
 
-    private fun foreignClaim(template: ReactiveCassandraTemplate, nodeId: Int) {
-        template.reactiveCqlOperations.queryForRows(
-            "INSERT INTO node_claim (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL ?",
-            nodeId, "foreign-owner@host-z:1#deadbeef", 120
-        ).next().block()
-    }
+    private fun allMessages(thrown: Throwable): String =
+        generateSequence(thrown) { it.cause }.mapNotNull { it.message }.joinToString(" | ")
 
     @Test
     fun `a live claim fails startup with the actionable message`() {
+        seedForeignClaim(21, "foreign-owner@host-z:1#deadbeef")
         val ready = AtomicBoolean(false)
 
-        boot(
-            "app.nodeid=21", "app.service.core.key=cassandra",
-            "app.service.core.persistence=cassandra",
-            ready = ready
-        ).run().use { context ->
-            foreignClaim(context.getBean(ReactiveCassandraTemplate::class.java), 21)
-        }
-
-        val second = AtomicBoolean(false)
         val thrown = Assertions.assertThrows(Exception::class.java) {
             boot(
-                "app.nodeid=21", "app.service.core.key=cassandra",
+                "app.nodeid=21",
+                "app.service.core.key=cassandra",
                 "app.service.core.persistence=cassandra",
-                ready = second
+                ready = ready
             ).run().close()
         }
 
-        val text = generateSequence(thrown as Throwable) { it.cause }
-            .mapNotNull { it.message }.joinToString(" | ")
-
+        val text = allMessages(thrown)
         Assertions.assertTrue(text.contains("app.nodeid=21 is already claimed"), text)
         Assertions.assertTrue(text.contains("cassandra keyspace chat_long"), text)
         Assertions.assertTrue(text.contains("foreign-owner@host-z:1#deadbeef"), text)
-        Assertions.assertFalse(second.get(), "ApplicationReadyEvent must not be published")
+        Assertions.assertFalse(ready.get(), "ApplicationReadyEvent must not be published")
     }
 
     @Test
@@ -2527,7 +2596,8 @@ class CassandraClaimBootTests : CassandraContainerBase() {
         val ready = AtomicBoolean(false)
 
         boot(
-            "app.nodeid=22", "app.service.core.key=memory",
+            "app.nodeid=22",
+            "app.service.core.key=memory",
             "app.service.core.persistence=cassandra",
             ready = ready
         ).run().use { context ->
@@ -2541,21 +2611,21 @@ class CassandraClaimBootTests : CassandraContainerBase() {
 }
 ```
 
-- [ ] **Step 2: Run the tests to verify they fail**
+- [ ] **Step 2: Run the boot tests**
 
-Run: `mvn -o -pl chat-deploy-cassandra -Pintegration test -Dtest=CassandraClaimBootTests`
+Run: `mvn -o -pl chat-deploy-cassandra -am -Pintegration test -Dtest=CassandraClaimBootTests`
 
-Expected: FAIL on the first run. Read the failure text before changing anything.
+Expected: PASS, 2 tests.
 
-The first test closes the first context on purpose. The guard releases the lease on close, so the test writes its own foreign claim before the second boot.
+- [ ] **Step 3: Read a clean start as a seam failure**
 
-- [ ] **Step 3: Make the tests pass**
+If the duplicate test reports that no exception was thrown, check the same three points as Task 9, Step 3, with `cassandra` in place of `redis`. Then check that the seed assertion passed. A seed that did not apply means node 21 was already held, and the allocation table was broken.
 
-If the first test starts cleanly, check the same three points as Task 9, Step 5, with `cassandra` in place of `redis`. Fix the launch properties, not the guard.
+Fix the launch properties or the condition. Do not weaken the test.
 
 - [ ] **Step 4: Run the whole cassandra deploy module**
 
-Run: `mvn -o -pl chat-deploy-cassandra -Pintegration test`
+Run: `mvn -o -pl chat-deploy-cassandra -am -Pintegration test`
 
 Expected: PASS. `CassandraDeployTest` still boots on node id 1.
 
@@ -2633,7 +2703,7 @@ class MemoryClaimAbsenceTests {
 
 - [ ] **Step 2: Run the tests**
 
-Run: `mvn -o -pl chat-deploy-memory test -Dtest=MemoryClaimAbsenceTests`
+Run: `mvn -o -pl chat-deploy-memory -am test -Dtest=MemoryClaimAbsenceTests`
 
 Expected: PASS, 3 tests. Nothing on this classpath names redis or cassandra, so the condition never matches.
 
@@ -2793,7 +2863,11 @@ git commit -m "document the node id claim lease and record the build gate"
 
 **Spec coverage.** Every spec section maps to a task. D1 to Task 6. D2 to Tasks 4 and 5. D3 to Task 1 and Task 12. D4 to Tasks 4, 9, and 10. D5 to Tasks 7 and 8. D6 to Task 11. The contract to Task 2. The guard to Tasks 4 and 5. The owner id and scheduler to Task 3. Redis to Task 7. Cassandra to Task 8. The message to Task 2. The Cassandra UUID note to Task 12. Every test in the spec test tables appears in a task. R1 appears as the allocation table in Global Constraints. R2 appears in Task 1 comments and Task 8. R3 appears in the properties. R4 appears in Tasks 3 and 5. Unverified claim 1 is Task 1. Unverified claim 2 is Task 9 Step 2 and Task 10 Step 1.
 
-**Two gaps to accept.** Task 9 leaves the exact property list to be copied from the existing boot test, because that list is long and already correct in the repository. Task 11 does the same for the memory deployment test. Both steps name the file and the fields to copy. Every other step carries its content.
+**One gap to accept.** Task 11 leaves the memory deployment classes and properties to be copied from `MemoryDeploymentTests` in the same package. The step names the file and the fields. Every other step carries its content, including the launch property lists in Tasks 9 and 10.
+
+**Red steps.** Tasks 1 to 8 each write a failing test first. Tasks 9, 10, and 11 do not, and they say so. By Task 9 the redis guard is already wired by Task 7, and by Task 10 the cassandra guard is already wired by Task 8. A boot test written after its guard cannot fail first. Those tasks instead state what a clean start means: the seam is broken, and the step lists what to check. The red step for the denial behaviour itself is Task 4.
+
+**Build order.** Every `mvn -pl` command outside `chat-core` carries `-am`. Task 1 needs it because `shared-resources-cassandra` changes. Tasks 7 to 11 need it because `chat-core` gains new types. Without `-am` those modules compile against the stale installed artifact.
 
 **Type consistency.** `NodeIdClaimException` takes `(nodeId, scope, holder, ttl)` in Task 2 and is constructed with those four arguments in Tasks 4 and 5. `NodeIdClaimStore` declares `backendName`, `scope`, `claim`, `renew`, `release` in Task 2 and is implemented with the same names in Tasks 7 and 8. `ClaimScheduler` declares five methods in Task 3, and `ManualClaimScheduler` in Task 4 implements all five. `NodeIdClaimProperties` exposes `ttl`, `renewInterval`, `safetyMargin`, `operationTimeout`, `closeDeadline` in Task 2 and is read with those names in Task 4.
 

--- a/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
+++ b/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
@@ -1,0 +1,468 @@
+# Node id claim lease, stage 2 of CHAT-koufkrsl
+
+Issue: `CHAT-wyssrokr`. Depends on `CHAT-koufkrsl`, which is done.
+
+## Goal
+
+Make a duplicate `app.nodeid` impossible to start.
+
+A Redis or Cassandra deployment must not start when a live `app.nodeid` claim
+for the same key space is already held in the same shared store.
+
+## Why a registry check cannot do this
+
+One store can be reached by deployments that do not share a registry.
+
+A Consul check sees only its own registry. Two deployments with separate
+registries can hold the same node id, write to one store, and detect nothing.
+The collision appears later as two entities that share a key.
+
+The claim must therefore live in the store that the deployments share.
+
+## Scope
+
+In scope:
+
+- A `NodeIdClaimStore` contract in `chat-core`.
+- A startup guard that claims, renews, and releases a lease.
+- A Redis implementation with atomic owner checks in Lua.
+- A Cassandra implementation with a claim table and lightweight transactions.
+- A claim table in `keyspace-long.cql` and `keyspace-uuid.cql`.
+- Tests for denial, release, expiry, boot failure, and memory absence.
+
+Out of scope:
+
+- Any claim for the memory backend. A memory store is per process.
+- Any change to `NodeId` or `NodeIdConfiguration` from stage 1.
+- Any change to the capability composition design.
+
+## Decisions
+
+### D1. The claim seam is the key selector or the persistence selector
+
+A process must claim a lease in every distinct shared backend that
+`app.service.core.key` or `app.service.core.persistence` names.
+
+| `app.service.core.key` | `app.service.core.persistence` | Claim |
+|---|---|---|
+| `redis` | `redis` | redis |
+| `cassandra` | `cassandra` | cassandra |
+| `memory` | `redis` | redis |
+| `redis` | `cassandra` | redis and cassandra |
+| `memory` | `memory` | none |
+| unset | unset | none |
+
+Reason: generated ids reach both the key store and the persistence store.
+A seam on one selector alone leaves a real pair unprotected. Current
+configuration permits every pair in the table.
+
+Spring cannot express this OR with `@ConditionalOnProperty`. A condition
+class `ConditionalOnSharedBackend` in `chat-core` reads both properties.
+
+### D2. Renewal failure closes the application context
+
+`Denied` means one thing only. Another owner holds a live claim.
+
+| Event | Action |
+|---|---|
+| `claim` returns `Denied` | Fail startup with the duplicate node message |
+| `claim` throws | Fail startup with the backend error |
+| `renew` returns `Denied` | Log ERROR. Close the context at once |
+| `renew` returns `Lost` | Log ERROR. Close the context at once |
+| `renew` throws | Log WARN. Retry at the next interval |
+| Close deadline reached | Log ERROR. Close the context |
+
+The close deadline is `ttl - safety-margin` after the last successful claim
+or renew. Every success reschedules a single shot deadline timer.
+
+Reason: a lost claim is a proven live collision. A store error is not.
+A short store outage must not stop a healthy process. The margin makes the
+process close before the lease can expire.
+
+### D3. The Cassandra claim table comes from the schema files
+
+`node_claim` is declared in `keyspace-long.cql` and `keyspace-uuid.cql`.
+
+The application runs no DDL. A missing table fails startup with a message
+that names the table and the schema file. The documentation carries a
+standalone `CREATE TABLE` statement for a keyspace that already exists.
+
+`node_claim` is not added to `truncate-long.cql` or `truncate-uuid.cql`.
+A live lease must expire. A test cleanup script must not delete it.
+
+Reason: schema authority stays outside the application, as it is today.
+
+### D4. The guard claims during context refresh
+
+Each backend module contributes a claim store. Each such configuration
+imports `NodeIdClaimGuardConfiguration`. The guard bean claims in
+`afterPropertiesSet`.
+
+A duplicate throws during refresh. The web server port never binds. No id
+is generated.
+
+Reason: a listener on `ApplicationReadyEvent` binds the port first. A
+duplicate deployment would serve traffic before it closes.
+
+### D5. Uniqueness is per key type per store
+
+Cassandra separates key types by keyspace. `chat_long` and `chat_uuid` hold
+separate `node_claim` tables.
+
+Redis has no such split. The claim key carries the key type.
+
+A `long` deployment and a `uuid` deployment on one Redis can both hold node
+id 7. This is safe. `UUIDKeyGenerator` hashes the Snowflake `Long`, so the
+two value spaces do not intersect.
+
+### D6. Memory contributes no claim store
+
+There is no no-operation implementation.
+
+A no-operation store that returns `Granted` is false safety. Memory
+contributes nothing, so the guard bean does not exist.
+
+Memory still requires `app.nodeid`. Stage 1 requires it wherever a key
+generator activates. This design adds no requirement to memory.
+
+## Activation invariant
+
+This invariant protects the stage 1 rule that `app.nodeid` stays scoped.
+
+1. A claim store configuration imports `NodeIdClaimGuardConfiguration`.
+2. A memory only context contributes no `NodeIdClaimStore`.
+3. No claim store means no guard bean.
+4. No guard bean means this design requests no `NodeId` bean.
+
+A test pins each statement.
+
+## Contract
+
+Package `com.demo.chat.domain`, module `chat-core`.
+
+```kotlin
+sealed class ClaimResult {
+    object Granted : ClaimResult()
+    data class Denied(val holder: String) : ClaimResult()
+    object Lost : ClaimResult()
+}
+
+interface NodeIdClaimStore {
+    val backendName: String
+    fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
+    fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
+    fun release(nodeId: NodeId, owner: String): Mono<Void>
+}
+```
+
+`claim` never returns `Lost`. `Lost` reports that a renew found no live
+claim.
+
+The stores compose on the reactive infrastructure. The guard is the only
+place that blocks. The guard applies `.timeout(operationTimeout).block()`.
+
+## Guard
+
+`NodeIdClaimGuard` implements `InitializingBean` and `DisposableBean`.
+
+It receives `List<NodeIdClaimStore>`, the `NodeId`, a `RuntimeOwnerId`,
+`NodeIdClaimProperties`, and the `ConfigurableApplicationContext`.
+
+### Startup
+
+1. Sort the stores by `backendName`. This is a stable total order.
+2. Claim each store in that order. Record each granted store.
+3. On a denial or an error, release the recorded stores in reverse order.
+4. Release is best effort. A release failure logs at DEBUG.
+5. Fail startup with `NodeIdClaimException`.
+
+### While the process runs
+
+The guard renews every store at `renew-interval`.
+
+A success reschedules the deadline timer to now plus `ttl - safety-margin`.
+
+The deadline timer closes the context when it fires.
+
+The guard owns one single thread scheduler. It creates the scheduler and it
+shuts the scheduler down. The guard does not use a shared task scheduler,
+because a shared pool can delay a renew behind unrelated work.
+
+A test supplies a virtual clock and a controlled scheduler. The unit tests
+therefore need no real waiting.
+
+### Shutdown
+
+`destroy` cancels the scheduler first. It then releases every granted store
+under the operation timeout. A failure logs at DEBUG and never blocks
+shutdown.
+
+Release is an optimisation. It makes a clean restart immediate. Expiry is
+what makes the design correct.
+
+## Runtime owner id
+
+`RuntimeOwnerId` is generated once at process start.
+
+Format: `$appName@$host:$pid#$random8hex`.
+
+The value is unique per process. A restart never reuses it. The value is
+readable in the failure message.
+
+## Properties
+
+Prefix `app.nodeid.claim`.
+
+| Property | Default | Rule |
+|---|---|---|
+| `ttl` | `30s` | At least 1s. Whole seconds only |
+| `renew-interval` | `10s` | `renew-interval <= ttl / 3` |
+| `safety-margin` | `5s` | Greater than zero. Less than `ttl` |
+| `operation-timeout` | `5s` | `operation-timeout < renew-interval` |
+
+One more rule: `ttl - safety-margin` must be greater than `renew-interval`.
+
+`ttl` uses whole seconds because Cassandra TTL uses whole seconds.
+
+`operation-timeout` is strictly less than `renew-interval`. A blocked call
+must not consume the next renewal slot.
+
+A rule failure fails startup and states the rule.
+
+The default set gives a close deadline of 25s. A renew error at 10s and at
+20s keeps the process running. The deadline timer closes it at 25s.
+
+## Redis implementation
+
+Module `chat-persistence-redis`. Bean on `ReactiveStringRedisTemplate`.
+
+Key: `chat:nodeclaim:<keyType>:<nodeId>`.
+
+No braces. Redis Cluster hash tags are not intended.
+
+### Claim
+
+```
+SET chat:nodeclaim:long:7 <owner> NX PX 30000
+```
+
+A nil reply means another owner holds the claim. The store then reads the
+key for diagnostics only.
+
+A holder that disappears between the two calls is retried once. A second
+failure to name the holder throws a backend error. The store never invents
+a holder.
+
+### Renew
+
+```lua
+local v = redis.call('GET', KEYS[1])
+if v == false then return {0} end
+if v == ARGV[1] then
+    redis.call('PEXPIRE', KEYS[1], ARGV[2])
+    return {1}
+end
+return {2, v}
+```
+
+`{0}` is `Lost`. `{1}` is `Granted`. `{2, owner}` is `Denied`.
+
+The script returns the state and the holder in one round trip. No read
+follows a failed script. The value can change between two calls.
+
+### Release
+
+```lua
+local v = redis.call('GET', KEYS[1])
+if v == false then return {0} end
+if v == ARGV[1] then return {1, redis.call('DEL', KEYS[1])} end
+return {2, v}
+```
+
+`PX` makes the Redis server the clock. No application clock enters the
+decision.
+
+## Cassandra implementation
+
+Module `chat-persistence-cassandra`. Bean on the reactive session.
+
+```sql
+CREATE TABLE chat_long.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+```
+
+The same table is declared in the `chat_uuid` keyspace.
+
+| Operation | Statement |
+|---|---|
+| Claim | `INSERT INTO node_claim (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL 30` |
+| Renew | `UPDATE node_claim USING TTL 30 SET owner_id = ? WHERE node_id = ? IF owner_id = ?` |
+| Release | `DELETE FROM node_claim WHERE node_id = ? IF owner_id = ?` |
+
+A claim that is not applied returns the current `owner_id` in the result
+row. That value becomes `Denied(holder)`.
+
+A renew that is not applied returns the current row. An absent row is
+`Lost`. A different owner is `Denied`.
+
+Lightweight transactions run at `SERIAL`. The coordinator applies the TTL.
+No application clock enters the decision.
+
+A missing table raises `InvalidQueryException`. The store converts it into
+a startup failure that names `node_claim` and `keyspace-<type>.cql`.
+
+Reference for the statement order and TTL behaviour:
+https://cassandra.apache.org/doc/latest/cassandra/developing/cql/dml.html
+
+## Failure message
+
+`NodeIdClaimException` carries `nodeId`, `backendName`, `holder`, and
+`ttl`. It builds the text in one place in `chat-core`.
+
+```
+app.nodeid=7 is already claimed in the redis store.
+Holder: core-service@host-a:4711#a3f19c2b
+Two deployments that write to one store must not use the same app.nodeid.
+Set a different app.nodeid, or stop the other deployment and wait 30s
+for its lease to expire.
+```
+
+The text is identical for both backends. Only the backend name and the wait
+time differ.
+
+## Cassandra UUID note
+
+The Cassandra UUID path uses `CassandraUUIDKeyGenerator`. That generator
+ignores the node id.
+
+A Cassandra UUID deployment still claims a lease.
+
+This is policy uniformity, not collision prevention. One contract covers
+every backend and every key type. An operator does not have to remember an
+exception.
+
+## Testing
+
+### Unit tests in chat-core
+
+These use fake stores. They need no container.
+
+| Test | Assertion |
+|---|---|
+| Grace window holds | A renew error at 10s and at 20s keeps the process running |
+| Grace window closes | The deadline timer at 25s closes the context |
+| Success resets | A successful renew reschedules the deadline timer |
+| Lost closes at once | A `Lost` renew closes the context with no grace |
+| Denied closes at once | A `Denied` renew closes the context with no grace |
+| Ordered claim | Two stores are claimed in `backendName` order |
+| Ordered release | A denial at store two releases store one first |
+| Property rules | Each rule in the properties table fails startup and states the rule |
+| Message text | The text names the property, the backend, the holder, and the wait |
+
+### Store integration tests
+
+These reuse `RedisTestContainer` and `CassandraTestContainerConfiguration`.
+This design adds no container base class.
+
+| Test | Backend |
+|---|---|
+| A second owner is denied | redis, cassandra |
+| A release allows a takeover | redis, cassandra |
+| An expiry allows a takeover | redis, cassandra |
+| A `long` claim and a `uuid` claim on node 7 both hold | redis |
+| A missing table names the table and the schema file | cassandra |
+
+These tests call the store directly. They pass the TTL as a method
+argument. The guard property rules do not apply to them.
+
+The expiry tests use a short lease. Redis uses `ttl=1s`. Cassandra uses
+`ttl=3s`, because Cassandra TTL uses whole seconds.
+
+Write the Cassandra expiry test first. It is the probe for the unverified
+claim below. A failure there changes the schema before any other code
+depends on it.
+
+### Boot tests
+
+`chat-deploy-redis` and `chat-deploy-cassandra` each gain one test.
+
+The test claims the node id in the container under a foreign owner. It then
+boots the deploy context. It asserts a `NodeIdClaimException` and the
+actionable text.
+
+### Memory test
+
+`chat-deploy-memory` asserts that no `NodeIdClaimStore` bean and no
+`NodeIdClaimGuard` bean exist.
+
+The test states the limit in a comment. Memory still requires `app.nodeid`.
+This design adds no requirement and offers no false safety.
+
+### Build gate
+
+`./shell-scripts/build-health.sh` reports no new failures.
+
+`./shell-scripts/build-health.sh --integration` reports no new failures.
+
+`KNOWN_FAILING_INTEGRATION` stays empty. A container backed regression here
+is signal. It is not a line to add to the list.
+
+## Risks
+
+### R1. Shared container and shared node id
+
+Every test in the repository uses `app.nodeid=1`.
+
+Spring caches contexts. Two container backed test classes in one module can
+hold two open contexts against one store. The second boot is then denied.
+
+The denial is correct behaviour, so it appears as a real test failure.
+
+Mitigation: every container backed test class that activates a claim store
+gets its own `app.nodeid`. The implementation plan allocates the values.
+This allocation is not optional.
+
+### R2. Truncate scripts omit the claim table
+
+`truncate-long.cql` and `truncate-uuid.cql` do not truncate `node_claim`.
+
+A test that truncates and reboots therefore meets its own earlier claim.
+
+Mitigation: the same distinct node id allocation from R1.
+
+### R3. The startup guard blocks
+
+The guard blocks the refresh thread on a store call.
+
+Mitigation: `operation-timeout` bounds every call. The default is 5s.
+
+## Claims that are load bearing and unverified
+
+1. Cassandra treats a TTL expired row as absent for `IF NOT EXISTS`.
+   When `owner_id` expires, `node_claim` holds a primary key with no live
+   columns. A takeover must then apply. This is the documented behaviour.
+   The Cassandra expiry test proves it. If the claim is false, the fallback
+   adds an explicit `expires_at` column and a takeover condition on it.
+   That fallback returns a clock question to the design.
+
+2. The reactive Redis and Cassandra beans are present at every claim seam.
+   A `key=memory` and `persistence=redis` process must still supply
+   `ReactiveStringRedisTemplate`. This was read from module configuration.
+   It was not observed. The implementation plan must boot that pair once.
+
+## Consequences
+
+This is a breaking change for an operator who runs two deployments with one
+node id against one store. That deployment fails to start. This is the
+intent of the issue.
+
+An existing Cassandra keyspace needs the `node_claim` table before an
+upgrade. The documentation carries the statement.
+
+A deployment that adds `app.service.core.key=redis` or
+`app.service.core.persistence=redis` now needs the store to be reachable at
+startup. The store was already needed for service. The guard moves the
+failure earlier and makes the message clearer.

--- a/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
+++ b/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
@@ -555,12 +555,13 @@ waits from a scheduler thread. Two unit tests pin both rules.
 
 ## Claims that are load bearing and unverified
 
-1. Cassandra treats a TTL expired row as absent for `IF NOT EXISTS`.
-   When `owner_id` expires, `node_claim` holds a primary key with no live
-   columns. A takeover must then apply. This is the documented behaviour.
-   The Cassandra expiry test proves it. If the claim is false, the fallback
-   adds an explicit `expires_at` column and a takeover condition on it.
-   That fallback returns a clock question to the design.
+1. ~~Cassandra treats a TTL expired row as absent for `IF NOT EXISTS`.~~
+   **Verified on 2026-08-28.** `NodeClaimTableProbeTests` ran against
+   `cassandra:4.1.3` in Testcontainers. Three tests passed. A row whose
+   `owner_id` expired accepted a takeover by a second owner. A live row
+   refused one. A deleted row accepted one.
+   The `expires_at` fallback is not needed. The design keeps the
+   coordinator applied TTL, and no application clock enters the decision.
 
 2. The reactive Redis and Cassandra beans are present at every claim seam.
    A `key=memory` and `persistence=redis` process must still supply

--- a/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
+++ b/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
@@ -43,14 +43,23 @@ Out of scope:
 A process must claim a lease in every distinct shared backend that
 `app.service.core.key` or `app.service.core.persistence` names.
 
-| `app.service.core.key` | `app.service.core.persistence` | Claim |
-|---|---|---|
-| `redis` | `redis` | redis |
-| `cassandra` | `cassandra` | cassandra |
-| `memory` | `redis` | redis |
-| `redis` | `cassandra` | redis and cassandra |
-| `memory` | `memory` | none |
-| unset | unset | none |
+The table below is exhaustive. The row is `app.service.core.key`. The
+column is `app.service.core.persistence`. The cell is the set of backends
+that the process claims.
+
+| key \ persistence | `memory` | `redis` | `cassandra` |
+|---|---|---|---|
+| `memory` | none | redis | cassandra |
+| `redis` | redis | redis | redis and cassandra |
+| `cassandra` | cassandra | cassandra and redis | cassandra |
+
+An unset selector counts as `memory` in this table. `app.service.core.key`
+is unset for the client launches, and the memory `KeyGenConfiguration`
+carries `matchIfMissing = true`. An unset `app.service.core.persistence`
+names no shared persistence backend.
+
+So an unset key with an unset persistence claims nothing. A client keeps
+its current startup behaviour.
 
 Reason: generated ids reach both the key store and the persistence store.
 A seam on one selector alone leaves a real pair unprotected. Current
@@ -75,9 +84,14 @@ class `ConditionalOnSharedBackend` in `chat-core` reads both properties.
 The close deadline is `ttl - safety-margin` after the last successful claim
 or renew. Every success reschedules a single shot deadline timer.
 
-Reason: a lost claim is a proven live collision. A store error is not.
-A short store outage must not stop a healthy process. The margin makes the
-process close before the lease can expire.
+Reason: a lost claim is proven loss of ownership. The process closes before
+another owner can safely continue.
+
+`Lost` does not prove that another owner exists. `Denied` does prove it,
+because the store named the other holder.
+
+A store error proves neither. A short store outage must not stop a healthy
+process. The margin makes the process close before the lease can expire.
 
 ### D3. The Cassandra claim table comes from the schema files
 
@@ -98,11 +112,17 @@ Each backend module contributes a claim store. Each such configuration
 imports `NodeIdClaimGuardConfiguration`. The guard bean claims in
 `afterPropertiesSet`.
 
-A duplicate throws during refresh. The web server port never binds. No id
-is generated.
+A duplicate throws during refresh. Startup then fails before the
+application is ready and before the process serves normal traffic.
 
-Reason: a listener on `ApplicationReadyEvent` binds the port first. A
-duplicate deployment would serve traffic before it closes.
+The stronger statement is that the web server port never binds. Bean
+instantiation runs before `WebServerStartStopLifecycle`, so the port should
+still be closed. That order is not asserted anywhere today. The spec does
+not rely on it. A lifecycle proof test measures it, and the result is
+recorded as an observation, not as a requirement.
+
+Reason: a listener on `ApplicationReadyEvent` runs after the web server
+starts. A duplicate deployment would serve traffic before it closes.
 
 ### D5. Uniqueness is per key type per store
 
@@ -149,6 +169,7 @@ sealed class ClaimResult {
 
 interface NodeIdClaimStore {
     val backendName: String
+    val scope: String
     fun claim(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
     fun renew(nodeId: NodeId, owner: String, ttl: Duration): Mono<ClaimResult>
     fun release(nodeId: NodeId, owner: String): Mono<Void>
@@ -157,6 +178,10 @@ interface NodeIdClaimStore {
 
 `claim` never returns `Lost`. `Lost` reports that a renew found no live
 claim.
+
+`backendName` orders the stores and names the backend in the message.
+`scope` names the space that the claim covers, such as `key type long` or
+`keyspace chat_long`. The failure message states both.
 
 The stores compose on the reactive infrastructure. The guard is the only
 place that blocks. The guard applies `.timeout(operationTimeout).block()`.
@@ -192,6 +217,24 @@ A test supplies a virtual clock and a controlled scheduler. The unit tests
 therefore need no real waiting.
 
 ### Shutdown
+
+A renew task can decide to close the context. That task runs on the guard
+scheduler. `destroy` then runs inside `close`, on that same thread.
+
+A `destroy` that waits for the scheduler to finish would wait for itself.
+That is a deadlock.
+
+Two rules prevent it.
+
+1. The guard never closes the context from the scheduler thread. It
+   dispatches `context.close()` to a separate daemon thread named
+   `nodeid-claim-close`. The scheduler task returns at once.
+2. `destroy` calls `shutdownNow` on the scheduler. It never calls
+   `awaitTermination` from a scheduler thread. It checks the current thread
+   before any wait.
+
+Rule 1 alone is enough. Rule 2 stays as a second barrier, because a future
+caller may close the context from an unexpected thread.
 
 `destroy` cancels the scheduler first. It then releases every granted store
 under the operation timeout. A failure logs at DEBUG and never blocks
@@ -239,6 +282,9 @@ Module `chat-persistence-redis`. Bean on `ReactiveStringRedisTemplate`.
 Key: `chat:nodeclaim:<keyType>:<nodeId>`.
 
 No braces. Redis Cluster hash tags are not intended.
+
+The key type comes from `app.key.type`. The store reports
+`scope = "key type <keyType>"`.
 
 ### Claim
 
@@ -296,6 +342,9 @@ CREATE TABLE chat_long.node_claim(
 
 The same table is declared in the `chat_uuid` keyspace.
 
+The keyspace comes from the configured session. The store reports
+`scope = "keyspace <keyspace>"`.
+
 | Operation | Statement |
 |---|---|
 | Claim | `INSERT INTO node_claim (node_id, owner_id) VALUES (?, ?) IF NOT EXISTS USING TTL 30` |
@@ -319,18 +368,39 @@ https://cassandra.apache.org/doc/latest/cassandra/developing/cql/dml.html
 
 ## Failure message
 
-`NodeIdClaimException` carries `nodeId`, `backendName`, `holder`, and
-`ttl`. It builds the text in one place in `chat-core`.
+`NodeIdClaimException` carries `nodeId`, `backendName`, `scope`, `holder`,
+and `ttl`. It builds the text in one place in `chat-core`.
+
+`scope` names the exact space that the claim covers. The store supplies it.
+Redis supplies `key type long`. Cassandra supplies `keyspace chat_long`.
+
+The message must state the scope, because uniqueness is per key type per
+store. A message that says "one store" is false for a Redis `long`
+deployment beside a Redis `uuid` deployment. See D5.
+
+Redis:
 
 ```
-app.nodeid=7 is already claimed in the redis store.
+app.nodeid=7 is already claimed in the redis store for key type long.
 Holder: core-service@host-a:4711#a3f19c2b
-Two deployments that write to one store must not use the same app.nodeid.
+Two deployments that write to this store with key type long must not use
+the same app.nodeid.
 Set a different app.nodeid, or stop the other deployment and wait 30s
 for its lease to expire.
 ```
 
-The text is identical for both backends. Only the backend name and the wait
+Cassandra:
+
+```
+app.nodeid=7 is already claimed in the cassandra keyspace chat_long.
+Holder: core-service@host-a:4711#a3f19c2b
+Two deployments that write to keyspace chat_long must not use the same
+app.nodeid.
+Set a different app.nodeid, or stop the other deployment and wait 30s
+for its lease to expire.
+```
+
+One template builds both. Only the backend name, the scope, and the wait
 time differ.
 
 ## Cassandra UUID note
@@ -360,7 +430,9 @@ These use fake stores. They need no container.
 | Ordered claim | Two stores are claimed in `backendName` order |
 | Ordered release | A denial at store two releases store one first |
 | Property rules | Each rule in the properties table fails startup and states the rule |
-| Message text | The text names the property, the backend, the holder, and the wait |
+| Message text | The text names the property, the backend, the scope, the holder, and the wait |
+| Close is off the scheduler | A `Denied` renew closes the context on the `nodeid-claim-close` thread, not on a scheduler thread |
+| Shutdown does not deadlock | `destroy` completes inside that close, within a bounded time |
 
 ### Store integration tests
 
@@ -392,6 +464,13 @@ depends on it.
 The test claims the node id in the container under a foreign owner. It then
 boots the deploy context. It asserts a `NodeIdClaimException` and the
 actionable text.
+
+The same test records the lifecycle observation from D4. It asserts that
+`ApplicationReadyEvent` is never published. It then reports whether the
+server port accepted a connection at any point. The port result is
+recorded in the spec as an observation. A port that binds does not fail
+the test, because the requirement is failure before ready and before
+normal traffic.
 
 ### Memory test
 
@@ -438,6 +517,15 @@ Mitigation: the same distinct node id allocation from R1.
 The guard blocks the refresh thread on a store call.
 
 Mitigation: `operation-timeout` bounds every call. The default is 5s.
+
+### R4. The guard can close the context from its own scheduler thread
+
+A renew task decides to close. `destroy` then runs on the scheduler thread
+and can wait for that same thread.
+
+Mitigation: the guard dispatches `context.close()` to the
+`nodeid-claim-close` daemon thread. `destroy` calls `shutdownNow` and never
+waits from a scheduler thread. Two unit tests pin both rules.
 
 ## Claims that are load bearing and unverified
 

--- a/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
+++ b/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
@@ -563,10 +563,19 @@ waits from a scheduler thread. Two unit tests pin both rules.
    The `expires_at` fallback is not needed. The design keeps the
    coordinator applied TTL, and no application clock enters the decision.
 
-2. The reactive Redis and Cassandra beans are present at every claim seam.
-   A `key=memory` and `persistence=redis` process must still supply
-   `ReactiveStringRedisTemplate`. This was read from module configuration.
-   It was not observed. The implementation plan must boot that pair once.
+2. ~~The reactive Redis and Cassandra beans are present at every claim
+   seam.~~ **Verified on 2026-08-28.** `RedisClaimBootTests` boots
+   `key=memory` with `persistence=redis` and finds exactly one redis claim
+   store. `CassandraClaimBootTests` boots `key=memory` with
+   `persistence=cassandra` and finds exactly one cassandra claim store.
+   The cassandra case needed `chat-persistence-memory` on the test
+   classpath of `chat-deploy-cassandra`, for the memory `KeyServiceBeans`.
+   It is declared in test scope only.
+
+3. Whether the web server port binds before the claim fails is not
+   measured. The boot tests assert the requirement, which is that
+   `ApplicationReadyEvent` is never published. The stronger statement in D4
+   is still an expectation, not a result. Do not quote it as verified.
 
 ## Consequences
 

--- a/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
+++ b/docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md
@@ -179,9 +179,15 @@ interface NodeIdClaimStore {
 `claim` never returns `Lost`. `Lost` reports that a renew found no live
 claim.
 
-`backendName` orders the stores and names the backend in the message.
-`scope` names the space that the claim covers, such as `key type long` or
-`keyspace chat_long`. The failure message states both.
+`backendName` orders the stores. It is `redis` or `cassandra`.
+
+`scope` is the full phrase that names the space the claim covers. Redis
+supplies `redis store for key type long`. Cassandra supplies
+`cassandra keyspace chat_long`.
+
+`scope` carries the whole phrase so that one message template serves both
+backends. A template that joined a backend name to a short scope would need
+a branch per backend.
 
 The stores compose on the reactive infrastructure. The guard is the only
 place that blocks. The guard applies `.timeout(operationTimeout).block()`.
@@ -303,15 +309,20 @@ a holder.
 
 ```lua
 local v = redis.call('GET', KEYS[1])
-if v == false then return {0} end
+if v == false then return 'lost' end
 if v == ARGV[1] then
     redis.call('PEXPIRE', KEYS[1], ARGV[2])
-    return {1}
+    return 'granted'
 end
-return {2, v}
+return 'denied:' .. v
 ```
 
-`{0}` is `Lost`. `{1}` is `Granted`. `{2, owner}` is `Denied`.
+The reply is one string. `lost` is `Lost`. `granted` is `Granted`.
+`denied:<owner>` is `Denied`.
+
+A single string keeps one serializer in play. A Lua array that mixes a
+number and a string needs a mixed result type, and
+`ReactiveStringRedisTemplate` carries a string serializer.
 
 The script returns the state and the holder in one round trip. No read
 follows a failed script. The value can change between two calls.
@@ -320,9 +331,12 @@ follows a failed script. The value can change between two calls.
 
 ```lua
 local v = redis.call('GET', KEYS[1])
-if v == false then return {0} end
-if v == ARGV[1] then return {1, redis.call('DEL', KEYS[1])} end
-return {2, v}
+if v == false then return 'lost' end
+if v == ARGV[1] then
+    redis.call('DEL', KEYS[1])
+    return 'granted'
+end
+return 'denied:' .. v
 ```
 
 `PX` makes the Redis server the clock. No application clock enters the
@@ -368,23 +382,36 @@ https://cassandra.apache.org/doc/latest/cassandra/developing/cql/dml.html
 
 ## Failure message
 
-`NodeIdClaimException` carries `nodeId`, `backendName`, `scope`, `holder`,
-and `ttl`. It builds the text in one place in `chat-core`.
+`NodeIdClaimException` carries `nodeId`, `scope`, `holder`, and `ttl`. It
+builds the text in one place in `chat-core`.
 
-`scope` names the exact space that the claim covers. The store supplies it.
-Redis supplies `key type long`. Cassandra supplies `keyspace chat_long`.
+The exception carries no `backendName`. The scope phrase already names the
+backend. `backendName` stays on the store, where it orders the claims.
+
+`scope` is the full phrase that names the space the claim covers. The store
+supplies it.
 
 The message must state the scope, because uniqueness is per key type per
 store. A message that says "one store" is false for a Redis `long`
 deployment beside a Redis `uuid` deployment. See D5.
+
+The template is one string:
+
+```
+app.nodeid=<id> is already claimed in the <scope>.
+Holder: <holder>
+Two deployments that write to the <scope> must not use the same app.nodeid.
+Set a different app.nodeid, or stop the other deployment and wait <ttl>
+for its lease to expire.
+```
 
 Redis:
 
 ```
 app.nodeid=7 is already claimed in the redis store for key type long.
 Holder: core-service@host-a:4711#a3f19c2b
-Two deployments that write to this store with key type long must not use
-the same app.nodeid.
+Two deployments that write to the redis store for key type long must not
+use the same app.nodeid.
 Set a different app.nodeid, or stop the other deployment and wait 30s
 for its lease to expire.
 ```
@@ -394,14 +421,13 @@ Cassandra:
 ```
 app.nodeid=7 is already claimed in the cassandra keyspace chat_long.
 Holder: core-service@host-a:4711#a3f19c2b
-Two deployments that write to keyspace chat_long must not use the same
-app.nodeid.
+Two deployments that write to the cassandra keyspace chat_long must not
+use the same app.nodeid.
 Set a different app.nodeid, or stop the other deployment and wait 30s
 for its lease to expire.
 ```
 
-One template builds both. Only the backend name, the scope, and the wait
-time differ.
+One template builds both. Only the scope and the wait time differ.
 
 ## Cassandra UUID note
 

--- a/forward-register.md
+++ b/forward-register.md
@@ -156,8 +156,9 @@ built on top of them inherits the risk.
   is the normal launch path, and the argument is required. Do not add a shared
   `app.nodeid` value to deployment yml. A committed default would make every
   deployment the same node in silence, which is the failure this change removed.
-  Tests can use `app.nodeid=1`. Uniqueness across deployments is still not
-  enforced. That remains `CHAT-wyssrokr`.
+  Tests can use `app.nodeid=1` where the deployment claims nothing. Uniqueness
+  across deployments is now enforced by a store-side lease. See the node id claim
+  lease section below.
 - **A sandboxed build run can fail on agent self-attach, not on the code.**
   Mockito loads the Byte Buddy agent into the running JVM. A sandbox can block that
   self-attach on a GraalVM JVM, and `build-health.sh` then fails for a reason that
@@ -170,3 +171,68 @@ built on top of them inherits the risk.
   was `@Disabled` with an accurate comment explaining why, and the backend stayed
   broken behind it. Every composition gets a boot test in the plan, and they stay
   enabled.
+
+## Node id claim lease (2026-08-28)
+
+`CHAT-wyssrokr` is implemented on branch `nodeid-claim-lease`. Spec:
+`docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md`. Plan:
+`docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md`. Operator document:
+`docs/NODEID-CLAIM.md`.
+
+Four rules that are load bearing and easy to lose:
+
+1. **The claim seam is either core selector.** A process claims when
+   `app.service.core.key` or `app.service.core.persistence` names `redis` or
+   `cassandra`. Generated ids reach the key store and the persistence store, so a
+   condition on one selector alone would leave `key=memory` with
+   `persistence=redis` unprotected. `@ConditionalOnProperty` cannot express that
+   OR, so `ConditionalOnSharedBackend` in `chat-core` reads both properties.
+2. **Uniqueness is per key type per store.** Cassandra separates key types by
+   keyspace. Redis carries the key type in `chat:nodeclaim:<keyType>:<nodeId>`. A
+   `long` deployment and a `uuid` deployment can both hold node id 7 on one redis,
+   and that is correct. The failure message states the scope for this reason. A
+   message that said "one store" would be false.
+3. **`node_claim` is absent from the truncate scripts on purpose.** A live lease
+   must expire. A test cleanup script must not delete it.
+4. **Every container-backed test that claims owns a distinct `app.nodeid`.** The
+   allocation table is in `docs/NODEID-CLAIM.md`. Spring caches contexts, so two
+   open contexts against one store would collide. That collision is correct
+   behaviour and appears as a test failure, not as a flake.
+
+Two claims from the spec were verified while building:
+
+- **Cassandra treats a TTL expired row as absent for `IF NOT EXISTS`.**
+  `NodeClaimTableProbeTests` proves it against `cassandra:4.1.3`. The `expires_at`
+  fallback is not needed, and no application clock enters the decision.
+- **The reactive store beans are present at the mixed seam.** A deployment with
+  `key=memory` and `persistence=redis` supplies `ReactiveStringRedisTemplate` and
+  registers one redis claim store. The cassandra equivalent also boots.
+
+Traps found while building, each of which cost a debugging cycle:
+
+- **`@Container` on a static field stops the container after the first test
+  class.** `CassandraContainerBase` applies `keyspace-long.cql` once per JVM in an
+  `init` block, so a second test class met a fresh container with no `chat_long`
+  keyspace and `CassandraDeployTest` failed with `Invalid keyspace chat_long`. The
+  annotation is gone. The `init` block starts the container, which is how
+  `RedisTestContainer` already worked.
+- **`SpringApplicationBuilder.properties()` is the lowest precedence source.** It
+  writes to `defaultProperties`, so `application.yml` overrode the test container
+  address with `localhost`. Pass a launch surface as command line arguments
+  instead.
+- **A lightweight transaction that did not apply because no row exists returns a
+  row with only the `[applied]` column.** Asking that row for `owner_id` throws
+  `IllegalArgumentException`. Test for the column, not for null.
+- **Spring Data wraps the driver `InvalidQueryException`.** `onErrorMap` on the
+  driver type never matches. Walk the cause chain.
+- **`mvn -pl <module> -am -Dtest=X` fails on every upstream module** with "No tests
+  matching pattern". Add `-Dsurefire.failIfNoSpecifiedTests=false`. Surefire joins
+  several test names with a comma, not a plus sign.
+
+One item recorded as unmeasured, not as a result:
+
+- **Whether the web server port binds before the claim fails is not measured.**
+  The boot tests assert the requirement, which is that `ApplicationReadyEvent` is
+  never published for a duplicate. The stronger statement, that the port never
+  binds, rests on bean instantiation running before `WebServerStartStopLifecycle`,
+  and nothing in the suite asserts it. Do not quote it as verified.

--- a/shared-resources-cassandra/src/main/resources/keyspace-long.cql
+++ b/shared-resources-cassandra/src/main/resources/keyspace-long.cql
@@ -10,6 +10,16 @@ id BIGINT,
 kind varchar ,
 PRIMARY KEY(id) );
 
+-- Holds the app.nodeid lease. One row per claimed node id.
+-- The row carries a TTL, so a crashed deployment releases its own id.
+-- This table is deliberately absent from truncate-long.cql. A live lease
+-- must expire. A test cleanup script must not delete it.
+CREATE TABLE chat_long.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+
 CREATE TABLE chat_long.kv_pair(
     id BIGINT,
     vdata text,

--- a/shared-resources-cassandra/src/main/resources/keyspace-uuid.cql
+++ b/shared-resources-cassandra/src/main/resources/keyspace-uuid.cql
@@ -10,6 +10,18 @@ CREATE TABLE chat_uuid.keys(
                           kind varchar ,
                           PRIMARY KEY(id) );
 
+-- Holds the app.nodeid lease. One row per claimed node id.
+-- The row carries a TTL, so a crashed deployment releases its own id.
+-- The columns do not change with the key type. A claim holds a node id,
+-- not a domain key.
+-- This table is deliberately absent from truncate-uuid.cql. A live lease
+-- must expire. A test cleanup script must not delete it.
+CREATE TABLE chat_uuid.node_claim(
+    node_id  int,
+    owner_id text,
+    PRIMARY KEY(node_id)
+);
+
 CREATE TABLE chat_uuid.kv_pair(
                                   id UUID,
                                   vdata text,


### PR DESCRIPTION
Stage 2 of `CHAT-koufkrsl`.

Covers `CHAT-wyssrokr`.

Stage 1 made `app.nodeid` explicit and validated.

Stage 1 did not detect two deployments that choose the same value.

This PR adds that check.

## Why The Claim Lives In The Store

One store can receive writes from deployments that do not share a registry.

A Consul check sees only its own registry.

Two deployments with separate registries can hold the same node id.

They can write to one store and detect nothing.

The collision appears later as two entities with the same key.

The claim must live in the shared store.

## What This Does

A Redis or Cassandra deployment fails to start in this condition:

- A live `app.nodeid` claim exists in the same shared store.
- The claim is for the same key space.

`NodeIdClaimStore` lives in `chat-core`.

It exposes `claim`, `renew`, and `release`.

It returns `Mono`.

The guard is the only component that blocks.

Redis uses `SET NX PX` for claims.

Redis uses Lua for owner checks.

The Redis server supplies the expiry clock.

Cassandra uses a `node_claim` table.

Cassandra uses lightweight transactions.

The Cassandra coordinator applies the TTL.

The application clock does not decide ownership.

`NodeIdClaimGuard` claims during context refresh.

It renews the claim on its own scheduler.

It closes the context when the lease is lost.

## Decisions For Review

### The Claim Seam Uses Either Core Selector

A process claims when either selector names a shared backend:

- `app.service.core.key`
- `app.service.core.persistence`

Generated ids reach both stores.

A condition on one selector leaves one pair unprotected:

- `key=memory`
- `persistence=redis`

The configuration permits that pair.

`@ConditionalOnProperty` cannot express that OR.

`ConditionalOnSharedBackend` reads both properties.

| key \ persistence | `memory` | `redis` | `cassandra` |
|---|---|---|---|
| `memory` | none | redis | cassandra |
| `redis` | redis | redis | redis and cassandra |
| `cassandra` | cassandra | cassandra and redis | cassandra |

### Uniqueness Is Per Key Type Per Store

Cassandra separates key types by keyspace.

Redis puts the key type in the claim key.

The Redis key is `chat:nodeclaim:<keyType>:<nodeId>`.

A `long` deployment and a `uuid` deployment can both use node id `7` on one Redis.

That is correct.

`UUIDKeyGenerator` hashes the Snowflake `Long`.

The two value spaces do not intersect.

The failure message states the claim scope for this reason.

### Renewal Failure

A denied renew closes the context immediately.

A lost renew closes the context immediately.

A store error retries.

The process closes at `ttl` minus `safety-margin`.

With defaults, the process closes after `25s`.

It closes before the lease can expire.

### Memory Contributes Nothing

There is no no-operation store.

A no-operation store that returned `Granted` would be false safety.

A test proves that a memory deployment registers no store and no guard.

### Activation Invariant

No claim store means no guard.

No guard means this design requests no `NodeId` bean.

The stage 1 scope rule is unchanged.

## Two Spec Unknowns Settled By Tests

### Cassandra TTL Expiry

Cassandra treats a TTL-expired row as absent for `IF NOT EXISTS`.

`NodeClaimTableProbeTests` was written first.

It ran before any guard code existed.

It used `cassandra:4.1.3`.

The `expires_at` fallback is not needed.

### Mixed Seam Store Beans

The reactive store beans exist at the mixed seam.

Both `key=memory` seams boot.

Each seam registers exactly one store.

## One Item Not Claimed

This PR does not measure whether the web server port binds before the claim fails.

The boot tests assert the requirement.

`ApplicationReadyEvent` is never published for a duplicate.

The stronger statement depends on bean creation order.

No test asserts that statement.

## Changes Reviewers Should Check First

`chat-deploy-cassandra` gains `chat-persistence-memory` in test scope.

The mixed seam needs the memory `KeyServiceBeans`.

Production selects Cassandra for both selectors.

So this dependency stays out of runtime.

`CassandraContainerBase` loses its `@Container` annotation.

On a static field, that annotation makes JUnit stop the container after the first test class.

The `init` block applies `keyspace-long.cql` once per JVM.

A second test class then got a fresh container with no `chat_long` keyspace.

`RedisTestContainer` already starts its container this way.

`node_claim` is absent from `truncate-long.cql` and `truncate-uuid.cql` on purpose.

A live lease must expire.

A cleanup script must not delete it.

Each container-backed test that claims uses a distinct `app.nodeid`.

The allocation table is in `docs/NODEID-CLAIM.md`.

## Operator Impact

This is a breaking change for one deployment shape.

It affects two deployments that use one node id against one store.

That deployment now fails to start.

That is the intent.

An existing Cassandra keyspace needs the `node_claim` table before upgrade.

`docs/NODEID-CLAIM.md` gives the statement.

## Testing

- 42 unit tests in `chat-core`.
- The timing tests use a hand-fired scheduler.
- So the timing tests do not wait in real time.
- 21 container tests run across the two persistence modules.
- They cover denial, release takeover, and expiry takeover on each backend.
- 7 boot and absence tests run across the three deploy modules.
- `./shell-scripts/build-health.sh` passes with exit status `0`.
- `./shell-scripts/build-health.sh --integration` passes with exit status `0`.
- `KNOWN_FAILING_INTEGRATION` stays empty.

## Documents

- Spec: `docs/superpowers/specs/2026-08-28-nodeid-claim-lease-design.md`
- Plan: `docs/superpowers/plans/2026-08-28-nodeid-claim-lease.md`
- Operator document: `docs/NODEID-CLAIM.md`
- `forward-register.md` records the load-bearing rules and five traps found during the work.
