### PR TITLE
B5: CI runs container tests, plus B6 repackage fix

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,3 +39,38 @@ jobs:
     - name: Test
       run: mvn -B clean test
 
+  # Container-backed half of the suite. The build job's `test` phase never
+  # reaches `package`, so it cannot produce the image chat-shell's tests
+  # consume. `verify` builds the image (module at pom.xml line 83, before
+  # chat-shell at 84) and runs the @Tag("integration") tests. -Ptest-build
+  # opts the image build in. The job re-runs unit tests inside verify on
+  # purpose: one reactor invocation keeps image, dependencies and container
+  # tests in one ordering. Informational: no branch protection gates on it.
+  # Spec: docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.m2/wrapper
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+          ${{ runner.os }}-
+    - name: Integration tests
+      run: mvn -B clean verify -Ptest-build,integration
+

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -39,14 +39,12 @@ jobs:
     - name: Test
       run: mvn -B clean test
 
-  # Container-backed half of the suite. The build job's `test` phase never
-  # reaches `package`, so it cannot produce the image chat-shell's tests
-  # consume. `verify` builds the image (module at pom.xml line 83, before
-  # chat-shell at 84) and runs the @Tag("integration") tests. The
-  # test-build profile enables the image build. The job re-runs unit tests
-  # inside verify on purpose: one reactor invocation keeps image,
-  # dependencies and container tests in one ordering. Informational: no
-  # merge gate applies.
+  # This job runs the container tests. The build job's `test` phase never
+  # reaches `package`, so it cannot create the image for chat-shell tests.
+  # `verify` creates that image before chat-shell starts. See pom.xml lines
+  # 83 and 84. The test-build profile enables the image build. The job also
+  # runs unit tests during verify. One Maven reactor run preserves the order
+  # of image creation, dependencies, and container tests. No merge gate applies.
   # Spec: docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
   integration:
     runs-on: ubuntu-latest
@@ -74,4 +72,3 @@ jobs:
           ${{ runner.os }}-
     - name: Integration tests
       run: mvn -B clean verify -Ptest-build,integration
-

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -42,10 +42,11 @@ jobs:
   # Container-backed half of the suite. The build job's `test` phase never
   # reaches `package`, so it cannot produce the image chat-shell's tests
   # consume. `verify` builds the image (module at pom.xml line 83, before
-  # chat-shell at 84) and runs the @Tag("integration") tests. -Ptest-build
-  # opts the image build in. The job re-runs unit tests inside verify on
-  # purpose: one reactor invocation keeps image, dependencies and container
-  # tests in one ordering. Informational: no branch protection gates on it.
+  # chat-shell at 84) and runs the @Tag("integration") tests. The
+  # test-build profile enables the image build. The job re-runs unit tests
+  # inside verify on purpose: one reactor invocation keeps image,
+  # dependencies and container tests in one ordering. Informational: no
+  # merge gate applies.
   # Spec: docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
   integration:
     runs-on: ubuntu-latest

--- a/chat-deploy-memory-integration-test/pom.xml
+++ b/chat-deploy-memory-integration-test/pom.xml
@@ -18,11 +18,10 @@
     </properties>
     <profiles>
         <profile>
-            <!-- Opt-in: mvn -Ptest-build. Building a container image on every
-                 install made a Docker daemon a prerequisite for a plain build,
-                 and a Docker failure failed the whole reactor. The only consumer
-                 is chat-shell's integration tests, themselves opt-in behind
-                 -Pintegration, so the two are enabled together:
+            <!-- Opt-in: mvn -Ptest-build. This profile builds a container image.
+                 A plain build must not need a Docker daemon. The only consumer
+                 is chat-shell integration tests. Those tests need -Pintegration.
+                 Enable the two profiles together:
 
                    mvn -Ptest-build install    # produce the image
                    mvn -Pintegration test      # run the tests that use it -->
@@ -33,12 +32,12 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
-                        <!-- Pinned ahead of the managed version (Spring Boot
-                             3.3.13). 3.3.x hardcodes Docker API v1.24 in
-                             DockerApi, and Docker Engine 29 refuses anything
-                             below v1.40; 3.5.x negotiates instead. Only this
-                             module builds an image, so the skew is contained
-                             here. Remove the pin when the parent moves to a
+                        <!-- This plugin is newer than the managed version.
+                             Spring Boot 3.3.13 hardcodes Docker API v1.24.
+                             Docker Engine 29 refuses API versions below v1.40.
+                             Spring Boot 3.5.x negotiates the API version. Only
+                             this module builds an image, so the version skew
+                             stays here. Remove the pin after the parent uses a
                              Boot version that negotiates. CHAT-gtcnjyit. -->
                         <version>3.5.12</version>
                         <configuration>
@@ -61,12 +60,11 @@
 -Dapp.rootkeys.create=true -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790
 -Dapp.primary=core -Dspring.shell.interactive.enabled=false -Dapp.key.type=long
 -Dapp.service.core.key=memory -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene
-<!-- app.nodeid became required with PR #51 (2026-08-28). The memory key
-generators read it at startup, because KeyGenConfiguration imports
-NodeIdConfiguration and NodeId.parse fails without a value. 900 is this
-test deployment's own value, set in the image at build time. It is
-not a shared YAML default. The memory backend has no claim store, so
-no lease check applies. -->
+<!-- PR #51 (2026-08-28) made app.nodeid required. The memory key generators
+read it at startup. KeyGenConfiguration imports NodeIdConfiguration.
+NodeId.parse fails without a value. 900 is this test deployment value. The
+image receives it at build time. It is not a shared YAML default. The memory
+backend has no claim store, so no lease check applies. -->
 -Dapp.nodeid=900
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite -Dapp.service.composite.auth
 -Dapp.controller.persistence -Dapp.controller.index
@@ -114,11 +112,10 @@ no lease check applies. -->
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
             <plugin>
-                <!-- This module exists only to produce a container image, and it
-                     has no main class of its own. Outside -Ptest-build the Boot
-                     plugin must stay out of the way, or the repackage goal
-                     inherited from spring-boot-starter-parent fails with
-                     "Unable to find main class". The profile sets skip false. -->
+                <!-- This module exists only to create a container image. It has
+                     no main class. Without -Ptest-build, the Boot plugin must
+                     stay disabled. If repackage runs, it fails with "Unable to
+                     find main class". The profile sets skip to false. -->
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>

--- a/chat-deploy-memory-integration-test/pom.xml
+++ b/chat-deploy-memory-integration-test/pom.xml
@@ -64,9 +64,9 @@
 <!-- app.nodeid became required with PR #51 (2026-08-28). The memory key
 generators read it at startup, because KeyGenConfiguration imports
 NodeIdConfiguration and NodeId.parse fails without a value. 900 is this
-test deployment's own value, baked into the image at build time. It is
-not a shared YAML default. The memory backend enforces no cross-store
-claim, so the value collides with nothing. -->
+test deployment's own value, set in the image at build time. It is
+not a shared YAML default. The memory backend has no claim store, so
+no lease check applies. -->
 -Dapp.nodeid=900
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite -Dapp.service.composite.auth
 -Dapp.controller.persistence -Dapp.controller.index

--- a/chat-deploy-memory-integration-test/pom.xml
+++ b/chat-deploy-memory-integration-test/pom.xml
@@ -61,6 +61,13 @@
 -Dapp.rootkeys.create=true -Dmanagement.server.port=6791 -Dspring.rsocket.server.port=6790
 -Dapp.primary=core -Dspring.shell.interactive.enabled=false -Dapp.key.type=long
 -Dapp.service.core.key=memory -Dapp.service.core.pubsub=memory -Dapp.service.core.index=lucene
+<!-- app.nodeid became required with PR #51 (2026-08-28). The memory key
+generators read it at startup, because KeyGenConfiguration imports
+NodeIdConfiguration and NodeId.parse fails without a value. 900 is this
+test deployment's own value, baked into the image at build time. It is
+not a shared YAML default. The memory backend enforces no cross-store
+claim, so the value collides with nothing. -->
+-Dapp.nodeid=900
 -Dapp.service.core.persistence=memory -Dapp.service.core.secrets=memory -Dapp.service.composite -Dapp.service.composite.auth
 -Dapp.controller.persistence -Dapp.controller.index
 -Dapp.controller.key -Dapp.controller.pubsub -Dapp.controller.secrets

--- a/docs/superpowers/plans/2026-08-28-ci-integration-execution.md
+++ b/docs/superpowers/plans/2026-08-28-ci-integration-execution.md
@@ -41,7 +41,7 @@ green measurement. Without this fix, Task 1 fails for the wrong reason.
       branch work must not leave them behind.
 - [ ] Branch `ci-integration-execution` off master.
 - [ ] Add `-Dapp.nodeid=900` to `BPE_APPEND_JAVA_TOOL_OPTIONS` in that pom.
-- [ ] Comment it: 900 is this test deployment's own value, baked into the image
+- [ ] Comment it: 900 is this test deployment's own value, set in the image
       at build time. It is not a shared YAML default. The memory backend
       enforces no cross-deployment claim, so no collision check applies.
 - [ ] Commit on the branch.

--- a/docs/superpowers/plans/2026-08-28-ci-integration-execution.md
+++ b/docs/superpowers/plans/2026-08-28-ci-integration-execution.md
@@ -1,10 +1,10 @@
-# CI integration test execution Implementation Plan
+# CI Integration Test Execution Plan
 
-> **For agentic workers:** Implement this plan inline, task by task. This
-> repository forbids subagent-driven development. See `CLAUDE.md`.
+> **For agents:** Implement this plan inline, task by task. This repository
+> forbids subagent-driven development. See `CLAUDE.md`.
 
-**Goal:** Make CI run the container-backed half of the test suite, and prove — by
-making it fail on purpose — that both CI jobs report red when a test fails.
+**Goal:** Make CI run the container tests. Prove that both CI jobs fail when a
+test fails.
 
 **Architecture:** No production code. One workflow file, one doc, one fp record.
 The design and its verified mechanism live in the spec.
@@ -21,52 +21,52 @@ JDK 17, Spring Boot build-image (plugin pinned 3.5.12 for the image module).
 - Prose uses plain controlled English. Short sentences. Active voice. No
   semicolons.
 - Do not add branch protection or required checks. The job is informational.
-- Do not use `continue-on-error`. Red must show as red.
+- Do not use `continue-on-error`. A failed job must show as failed.
 - The unit job (`mvn -B clean test`) stays unchanged.
 - `KNOWN_FAILING_INTEGRATION` in `shell-scripts/build-health.sh` stays empty.
 - Check drift bindings on edited docs with `drift refs`. `drift check` must pass.
 
 ---
 
-### Task 0 — Node id for the test image, branch start (`CHAT-lxsimrkl`)
+### Task 0 - Node id for the test image, branch start (`CHAT-lxsimrkl`)
 
 Reviewer blocker, confirmed against source on 2026-08-28. The image is built
 without `-Dapp.nodeid` (`chat-deploy-memory-integration-test/pom.xml:54`). The
-image activates the memory key (`app.service.core.key=memory`), and
-`KeyGenConfiguration` imports `NodeIdConfiguration`, so `NodeId.parse` fails the
-container at startup. PR #51 made the property required after the 2026-08-23
-green measurement. Without this fix, Task 1 fails for the wrong reason.
+image activates the memory key (`app.service.core.key=memory`).
+`KeyGenConfiguration` imports `NodeIdConfiguration`. Thus, `NodeId.parse` fails
+the container at startup. PR #51 made the property required after the
+2026-08-23 passing measurement. Without this fix, Task 1 fails for the wrong
+reason.
 
-- [ ] Commit the spec and plan docs on master. They are untracked today, and
+- [ ] Commit the spec and plan docs on master. They are untracked today.
       branch work must not leave them behind.
 - [ ] Branch `ci-integration-execution` off master.
 - [ ] Add `-Dapp.nodeid=900` to `BPE_APPEND_JAVA_TOOL_OPTIONS` in that pom.
-- [ ] Comment it: 900 is this test deployment's own value, set in the image
-      at build time. It is not a shared YAML default. The memory backend
-      enforces no cross-deployment claim, so no collision check applies.
+- [ ] Comment it: 900 is this test deployment value. The image receives it at
+      build time. It is not a shared YAML default. The memory backend has no
+      claim store, so no lease check applies.
 - [ ] Commit on the branch.
 
 Done when: the pom contains the flag and its comment, committed on the branch.
 Master has no `app.nodeid` in that pom until this task lands.
 
-### Task 1 — Local zero-to-one check (`CHAT-cndmlnjn`)
+### Task 1 - Local clean-image check (`CHAT-cndmlnjn`)
 
 Prove the CI command before the CI uses it. Needs Task 0: the image will not boot
 without the node id.
 
-- [ ] `docker rmi docker.io/library/chat-deploy-long-memory-integration-test:0.0.1`
-      — "No such image" is success. The point is the image is absent before the
-      run. `docker rmi ... || true` is the honest form.
+- [ ] `docker rmi docker.io/library/chat-deploy-long-memory-integration-test:0.0.1 || true`
+      "No such image" is success. The image must be absent before the run.
 - [ ] `mvn -B clean verify -Ptest-build,integration`
 - [ ] Confirm BUILD SUCCESS. Confirm the image rebuilds in the run. Confirm
       chat-shell reports about 19 tests run, not 36 with 17 skipped.
 - [ ] `fp comment CHAT-cndmlnjn` with the tail of the reactor summary and the
       wall time. Set the issue done.
 
-If this fails, stop. The ordering claim in the spec is wrong, and the job design
-needs revising before any workflow is touched.
+If this fails, stop. The ordering claim in the spec is wrong. Revise the job
+design before you edit the workflow.
 
-### Task 2 — Add the integration job, open the PR (`CHAT-vndtryfh`)
+### Task 2 - Add the integration job, open the PR (`CHAT-vndtryfh`)
 
 On the Task 0 branch.
 
@@ -102,55 +102,57 @@ On the Task 0 branch.
 - [ ] Watch both jobs (`gh pr checks --watch`). Record run times in an fp
       comment. This is the first real run of the new job.
 
-### Task 3 — Red proof, then revert (`CHAT-zljzaiox`)
+### Task 3 - Failure proof, then revert (`CHAT-zljzaiox`)
 
 The workflow version a `pull_request` run uses comes from the PR head. The proof
 must ride the same PR.
 
-Reactor position is load-bearing. `verify` runs without `-fae`, so a broken test
-in an early module stops the integration job before any container starts. The
-failures go where the job must execute container tests before failing.
+Reactor position is load-bearing. `verify` runs without `-fae`. Thus, a broken
+test in an early module stops the integration job before any container starts.
+Place the failures where the job must run container tests before it fails.
 
 - [ ] Integration break: add one failing `@Test` to `LongUserCommandsTests` in
       `chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellUserCommandsTests.kt`.
-      The class carries `@Tag("integration")`, so the unit job never loads it and
-      the daemon never starts there. Surefire runs the sibling container classes
-      in the same module before the module fails, so the job shows container
-      execution, then red.
+      The class carries `@Tag("integration")`. Thus, the unit job never loads it,
+      and the daemon does not start there. Surefire runs sibling container
+      classes in the same module before the module fails. The job shows
+      container execution, then failure.
 - [ ] Unit break: flip one assertion in
       `chat-authorization-server/src/test/kotlin/com/demo/chat/ClientInitializerTest.kt`.
       That module sits at `pom.xml` line 85, after `chat-shell` at line 84. The
-      integration job therefore fails in chat-shell and never reaches this break.
-      The unit job excludes chat-shell's tagged tests and fails here. Each job
-      proves its own kind of execution.
+      integration job therefore fails in chat-shell. It never reaches this
+      break. The unit job excludes chat-shell tagged tests and fails here. Each
+      job proves its own execution type.
 - [ ] Commit both, message marked `B5-RED-PROOF` for searchability.
-- [ ] Push. Let both jobs finish. Do not push over them — the concurrency group
+- [ ] Push. Let both jobs finish. Do not push again. The concurrency group
       cancels superseded runs.
-- [ ] Confirm: unit job red, integration job red, one run per commit. Confirm
-      the integration log shows container tests executing before the red.
-- [ ] Revert the commit. Push. Watch both jobs green again.
+- [ ] Confirm that the unit job fails. Confirm that the integration job fails.
+      Confirm one run per commit. Confirm that the integration log shows
+      container tests before the failure.
+- [ ] Revert the commit. Push. Watch both jobs pass again.
 - [ ] Record run IDs and outcome in an fp comment. Set the issue done.
 
-### Task 4 — BUILD-HEALTH doc (`CHAT-tdfjpmed`)
+### Task 4 - BUILD-HEALTH doc (`CHAT-tdfjpmed`)
 
 - [ ] Extend the B5 row: CI also runs
       `mvn -B clean verify -Ptest-build,integration`.
-- [ ] Update the "what the default run no longer covers" note: the container
-      half is now checked per commit, informational until 10 runs are recorded.
+- [ ] Update the "what the default run no longer covers" note. CI now checks
+      container tests for each commit. It stays informational until 10 runs are
+      recorded.
 - [ ] `drift refs docs/BUILD-HEALTH.md`, then `drift check`.
 - [ ] Commit on the same branch.
 
-### Task 5 — Merge and record (`CHAT-oitsmdwe`)
+### Task 5 - Merge and record (`CHAT-oitsmdwe`)
 
-- [ ] Merge after the red-then-green sequence is recorded.
+- [ ] Merge after the fail-then-pass sequence is recorded.
 - [ ] `fp issue assign CHAT-uortzsbx --rev <commits>`.
 - [ ] `fp comment CHAT-uortzsbx`: outcome, PR number, both job run times,
-      gating decision, and the 10-run flakiness baseline note.
+      merge-gate decision, and the 10-run flakiness baseline note.
 - [ ] `fp issue update --status done CHAT-uortzsbx`.
 - [ ] Refresh `forward-register.md` on master: landed row, Last merged PR
       fields. `drift check`.
 
-## Follow-up, not in this chain
+## Follow-Up
 
 - After 10 integration runs: read the flakiness record, then decide required
   check versus status quo. That decision needs run data this plan produces.

--- a/docs/superpowers/plans/2026-08-28-ci-integration-execution.md
+++ b/docs/superpowers/plans/2026-08-28-ci-integration-execution.md
@@ -1,0 +1,156 @@
+# CI integration test execution Implementation Plan
+
+> **For agentic workers:** Implement this plan inline, task by task. This
+> repository forbids subagent-driven development. See `CLAUDE.md`.
+
+**Goal:** Make CI run the container-backed half of the test suite, and prove — by
+making it fail on purpose — that both CI jobs report red when a test fails.
+
+**Architecture:** No production code. One workflow file, one doc, one fp record.
+The design and its verified mechanism live in the spec.
+
+**Tech Stack:** GitHub Actions, `ubuntu-latest` (Docker daemon included), Maven,
+JDK 17, Spring Boot build-image (plugin pinned 3.5.12 for the image module).
+
+**Spec:** `docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md`
+
+**Issues:** tasks are fp subissues of `CHAT-uortzsbx`.
+
+## Global Constraints
+
+- Prose uses plain controlled English. Short sentences. Active voice. No
+  semicolons.
+- Do not add branch protection or required checks. The job is informational.
+- Do not use `continue-on-error`. Red must show as red.
+- The unit job (`mvn -B clean test`) stays unchanged.
+- `KNOWN_FAILING_INTEGRATION` in `shell-scripts/build-health.sh` stays empty.
+- Check drift bindings on edited docs with `drift refs`. `drift check` must pass.
+
+---
+
+### Task 0 — Node id for the test image, branch start (`CHAT-lxsimrkl`)
+
+Reviewer blocker, confirmed against source on 2026-08-28. The image is built
+without `-Dapp.nodeid` (`chat-deploy-memory-integration-test/pom.xml:54`). The
+image activates the memory key (`app.service.core.key=memory`), and
+`KeyGenConfiguration` imports `NodeIdConfiguration`, so `NodeId.parse` fails the
+container at startup. PR #51 made the property required after the 2026-08-23
+green measurement. Without this fix, Task 1 fails for the wrong reason.
+
+- [ ] Commit the spec and plan docs on master. They are untracked today, and
+      branch work must not leave them behind.
+- [ ] Branch `ci-integration-execution` off master.
+- [ ] Add `-Dapp.nodeid=900` to `BPE_APPEND_JAVA_TOOL_OPTIONS` in that pom.
+- [ ] Comment it: 900 is this test deployment's own value, baked into the image
+      at build time. It is not a shared YAML default. The memory backend
+      enforces no cross-deployment claim, so no collision check applies.
+- [ ] Commit on the branch.
+
+Done when: the pom contains the flag and its comment, committed on the branch.
+Master has no `app.nodeid` in that pom until this task lands.
+
+### Task 1 — Local zero-to-one check (`CHAT-cndmlnjn`)
+
+Prove the CI command before the CI uses it. Needs Task 0: the image will not boot
+without the node id.
+
+- [ ] `docker rmi docker.io/library/chat-deploy-long-memory-integration-test:0.0.1`
+      — "No such image" is success. The point is the image is absent before the
+      run. `docker rmi ... || true` is the honest form.
+- [ ] `mvn -B clean verify -Ptest-build,integration`
+- [ ] Confirm BUILD SUCCESS. Confirm the image rebuilds in the run. Confirm
+      chat-shell reports about 19 tests run, not 36 with 17 skipped.
+- [ ] `fp comment CHAT-cndmlnjn` with the tail of the reactor summary and the
+      wall time. Set the issue done.
+
+If this fails, stop. The ordering claim in the spec is wrong, and the job design
+needs revising before any workflow is touched.
+
+### Task 2 — Add the integration job, open the PR (`CHAT-vndtryfh`)
+
+On the Task 0 branch.
+
+- [ ] Add the job to `.github/workflows/maven.yml`:
+
+```yaml
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.m2/repository
+          ~/.m2/wrapper
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
+          ${{ runner.os }}-
+    - name: Integration tests
+      run: mvn -B clean verify -Ptest-build,integration
+```
+
+- [ ] Commit, push, open PR.
+- [ ] Watch both jobs (`gh pr checks --watch`). Record run times in an fp
+      comment. This is the first real run of the new job.
+
+### Task 3 — Red proof, then revert (`CHAT-zljzaiox`)
+
+The workflow version a `pull_request` run uses comes from the PR head. The proof
+must ride the same PR.
+
+Reactor position is load-bearing. `verify` runs without `-fae`, so a broken test
+in an early module stops the integration job before any container starts. The
+failures go where the job must execute container tests before failing.
+
+- [ ] Integration break: add one failing `@Test` to `LongUserCommandsTests` in
+      `chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellUserCommandsTests.kt`.
+      The class carries `@Tag("integration")`, so the unit job never loads it and
+      the daemon never starts there. Surefire runs the sibling container classes
+      in the same module before the module fails, so the job shows container
+      execution, then red.
+- [ ] Unit break: flip one assertion in
+      `chat-authorization-server/src/test/kotlin/com/demo/chat/ClientInitializerTest.kt`.
+      That module sits at `pom.xml` line 85, after `chat-shell` at line 84. The
+      integration job therefore fails in chat-shell and never reaches this break.
+      The unit job excludes chat-shell's tagged tests and fails here. Each job
+      proves its own kind of execution.
+- [ ] Commit both, message marked `B5-RED-PROOF` for searchability.
+- [ ] Push. Let both jobs finish. Do not push over them — the concurrency group
+      cancels superseded runs.
+- [ ] Confirm: unit job red, integration job red, one run per commit. Confirm
+      the integration log shows container tests executing before the red.
+- [ ] Revert the commit. Push. Watch both jobs green again.
+- [ ] Record run IDs and outcome in an fp comment. Set the issue done.
+
+### Task 4 — BUILD-HEALTH doc (`CHAT-tdfjpmed`)
+
+- [ ] Extend the B5 row: CI also runs
+      `mvn -B clean verify -Ptest-build,integration`.
+- [ ] Update the "what the default run no longer covers" note: the container
+      half is now checked per commit, informational until 10 runs are recorded.
+- [ ] `drift refs docs/BUILD-HEALTH.md`, then `drift check`.
+- [ ] Commit on the same branch.
+
+### Task 5 — Merge and record (`CHAT-oitsmdwe`)
+
+- [ ] Merge after the red-then-green sequence is recorded.
+- [ ] `fp issue assign CHAT-uortzsbx --rev <commits>`.
+- [ ] `fp comment CHAT-uortzsbx`: outcome, PR number, both job run times,
+      gating decision, and the 10-run flakiness baseline note.
+- [ ] `fp issue update --status done CHAT-uortzsbx`.
+- [ ] Refresh `forward-register.md` on master: landed row, Last merged PR
+      fields. `drift check`.
+
+## Follow-up, not in this chain
+
+- After 10 integration runs: read the flakiness record, then decide required
+  check versus status quo. That decision needs run data this plan produces.

--- a/docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
+++ b/docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
@@ -1,0 +1,154 @@
+# CI Integration Test Execution
+
+Extends B5 (`CHAT-uortzsbx`). PR #38 made CI run the default test phase. This spec
+makes CI run the tests the default phase excludes.
+
+Status: draft for review, 2026-08-28.
+
+## What #38 already fixed
+
+The workflow now:
+
+1. Runs `mvn -B clean test` instead of `mvn clean test-compile`.
+2. Fires once per commit: `push` is restricted to master, and a concurrency group
+   cancels superseded runs.
+3. Uses a cache key with no undefined variable, and action pins at v4.
+
+`docs/BUILD-HEALTH.md` records B5 as resolved by #38.
+
+## The remaining problem
+
+A default Maven run excludes every test tagged `integration`. That is about 160
+tests (`docs/BUILD-HEALTH.md`, "What the default run no longer covers"). They cover
+cassandra, redis, xstream, index-cassandra, the deploy tests, and chat-shell. CI
+does not run any of them. The container-backed half of the suite therefore has the
+same property B3 had: nothing checks it between commits, and a green check says
+nothing about it.
+
+The original blockers are gone. B1, B2 and B4 are all done. The verifier reports
+the full `-Pintegration` reactor green against Docker Engine 29.7.2 on 2026-08-23,
+and its `KNOWN_FAILING_INTEGRATION` list is empty and measured.
+
+That measurement predates one change. PR #51 (2026-08-28) made `app.nodeid`
+explicit, required, and validated. The test image does not set it:
+`chat-deploy-memory-integration-test/pom.xml` bakes no `-Dapp.nodeid` into
+`BPE_APPEND_JAVA_TOOL_OPTIONS`, while the image activates the memory key, whose
+`KeyGenConfiguration` imports `NodeIdConfiguration` and fails startup without the
+value. Task 0 of the plan fixes the launch flags before anything runs. The
+2026-08-23 green claim for the image-backed path is treated as stale until the
+Task 1 re-measurement.
+
+## Mechanism
+
+One fact drives the design. `chat-shell` consumes a container image that the build
+does not produce by default:
+
+- `chat-deploy-memory-integration-test` builds the image only under `-Ptest-build`.
+- The image build runs in the `package` phase.
+- So `mvn test -Pintegration` cannot pass chat-shell in a clean environment. It
+  stops before `package`, and the image is never built.
+- `mvn verify -Ptest-build,integration` works. The reactor builds the integration
+  module first (`pom.xml` lists it at line 83, chat-shell at line 84), so the image
+  exists before chat-shell's tests run.
+
+The CI job must use the second form. The local verifier cannot be copied directly,
+because it assumes the image already exists in the local Docker daemon.
+
+## Design
+
+Add a second job to `.github/workflows/maven.yml`. Keep the existing job unchanged.
+
+```yaml
+  integration:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    # same checkout, setup-java, cache steps as the test job
+    - name: Integration tests
+      run: mvn -B clean verify -Ptest-build,integration
+```
+
+Details, with reasons:
+
+1. **Triggers: every pull request and every master push.** This catches container
+   regressions before merge. The unit job stays fast, so this does not slow the
+   quick signal.
+2. **Informational, not a merge gate.** Master has no branch protection, so no
+   check gates anything today. Do not add protection in this change. A red X is
+   visible and does not block. That is the correct posture for a suite with no
+   CI flakiness history.
+3. **No `continue-on-error`.** The job must report red honestly. It is
+   informational because nothing is protected, not because it forces success.
+4. **`timeout-minutes: 30`.** Container suites can hang instead of fail. A hang
+   with no timeout burns runner minutes and looks like a queued job.
+5. **Same cache key as the unit job.** Both restore the same `~/.m2` cache. On a
+   PR, the two jobs start at once, so neither reliably populates the cache for the
+   other. Accept the duplicate first-run download.
+6. **Shared setup stays duplicated, not extracted.** Two jobs of eight steps are
+   clearer than one reusable workflow. GitHub does not support YAML anchors in
+   workflow files.
+7. **The job re-runs the unit tests inside `verify`.** This is deliberate. One
+   reactor invocation mirrors the local verifier and keeps the image build, the
+   dependency modules and the container tests in one ordering. The repeated unit
+   phase costs about 3 minutes. Do not "fix" it with `-pl` scoping: the image
+   build needs its dependency modules in the same reactor.
+
+## Verification (part of the change, not after it)
+
+The issue names the criterion: a test job that has never failed is indistinguishable
+from one that does not run. No CI run has failed since #38 merged. Neither job has
+ever proved it can go red. The integration job is new, so it needs the proof twice.
+
+Two checks, before and during review:
+
+**Local zero-to-one check (before pushing).** Delete the image from a running
+Docker daemon, then run the exact CI command from the repo root:
+
+```bash
+docker rmi docker.io/library/chat-deploy-long-memory-integration-test:0.0.1
+mvn -B clean verify -Ptest-build,integration
+```
+
+This proves the ordering claim (image module at `pom.xml` line 83, chat-shell at
+line 84, and Maven keeps declaration order because chat-shell does not depend on
+the image module). A local `~/.m2` cache is acceptable. The image must not exist
+in the Docker daemon beforehand.
+
+**Red proof (on the feature PR, never merged to master).** The issue names the
+criterion: a test job that has never failed is indistinguishable from one that
+does not run. A `pull_request` run uses the workflow file from the PR head, so a
+separate throwaway branch cannot exercise the new job until it is merged. The
+proof therefore rides the same PR:
+
+1. Push a commit that breaks one unit test (in the default reactor) and one test
+   tagged `integration`.
+2. Confirm: unit job red, integration job red, one run per commit, and the
+   integration report shows container tests executing. chat-shell reports about
+   19 tests running, not 36 with 17 skipped.
+3. Push the revert, confirm both jobs green, then merge. The red commit never
+   reaches master.
+
+## Documentation
+
+1. `docs/BUILD-HEALTH.md`: extend the B5 row to say CI also runs
+   `-Ptest-build,integration`, and that the container half of the suite is now
+   checked per commit.
+2. Comment the outcome, the flakiness baseline, and the gating decision on
+   `CHAT-uortzsbx`, then close it.
+
+## Decisions
+
+| Question | Decision | Why |
+|---|---|---|
+| Where does the integration job run? | Every PR and master push | Catch container regressions before merge |
+| Does it gate merges? | No. Revisit after 10 runs | No flakiness record exists yet, and a flaky gate trains people to ignore checks |
+| How far does red verification go? | Both jobs, on the feature PR. The red commit is never merged | The new job gets the same proof the old one lacked, and the PR head carries the workflow the proof exercises |
+
+## Out of scope
+
+- Branch protection and required checks. Revisit after 10 integration runs.
+- Nightly scheduled runs. The per-PR trigger already covers the detection need.
+- Docker API version on GitHub runners. The pinned plugin (3.5.12) negotiates
+  instead of hardcoding v1.24, so runner lag is not a failure mode. If a first run
+  disagrees, the run log will say so.
+- B1/B2/B4. All done.

--- a/docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
+++ b/docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
@@ -1,7 +1,7 @@
 # CI Integration Test Execution
 
-Extends B5 (`CHAT-uortzsbx`). PR #38 made CI run the default test phase. This spec
-makes CI run the tests the default phase excludes.
+Extends B5 (`CHAT-uortzsbx`). PR #38 made CI run the default test phase.
+This spec makes CI run the tests that the default phase excludes.
 
 Status: draft for review, 2026-08-28.
 
@@ -16,47 +16,46 @@ The workflow now:
 
 `docs/BUILD-HEALTH.md` records B5 as resolved by #38.
 
-## The remaining problem
+## Remaining Problem
 
 A default Maven run excludes every test tagged `integration`. That is about 160
-tests (`docs/BUILD-HEALTH.md`, "What the default run no longer covers"). They cover
-cassandra, redis, xstream, index-cassandra, the deploy tests, and chat-shell. CI
-does not run any of them. The container-backed half of the suite therefore has the
-same property B3 had: nothing checks it between commits, and a green check says
-nothing about it.
+tests. See `docs/BUILD-HEALTH.md`, "What the default run no longer covers".
+They cover cassandra, redis, xstream, index-cassandra, deploy tests, and
+chat-shell. CI does not run these tests. Thus, a passing CI check says nothing
+about container-backed tests.
 
-The original blockers are gone. B1, B2 and B4 are all done. The verifier reports
-the full `-Pintegration` reactor green against Docker Engine 29.7.2 on 2026-08-23,
-and its `KNOWN_FAILING_INTEGRATION` list is empty and measured.
+The original blockers are gone. B1, B2, and B4 are done. The verifier reported a
+passing `-Pintegration` reactor against Docker Engine 29.7.2 on 2026-08-23.
+The `KNOWN_FAILING_INTEGRATION` list was empty and measured.
 
 That measurement predates one change. PR #51 (2026-08-28) made `app.nodeid`
 explicit, required, and validated. The test image does not set it:
-`chat-deploy-memory-integration-test/pom.xml` bakes no `-Dapp.nodeid` into
-`BPE_APPEND_JAVA_TOOL_OPTIONS`, while the image activates the memory key, whose
-`KeyGenConfiguration` imports `NodeIdConfiguration` and fails startup without the
-value. Task 0 of the plan fixes the launch flags before anything runs. The
-2026-08-23 green claim for the image-backed path is treated as stale until the
-Task 1 re-measurement.
+`chat-deploy-memory-integration-test/pom.xml` has no `-Dapp.nodeid` in
+`BPE_APPEND_JAVA_TOOL_OPTIONS`. The image activates the memory key. Its
+`KeyGenConfiguration` imports `NodeIdConfiguration`. Startup fails without the
+value. Task 0 of the plan fixes the launch flags before any test run. Treat the
+2026-08-23 image-backed test result as stale until Task 1 measures it again.
 
 ## Mechanism
 
-One fact drives the design. `chat-shell` consumes a container image that the build
-does not produce by default:
+One fact drives the design. `chat-shell` consumes a container image. The build
+does not create that image by default:
 
 - `chat-deploy-memory-integration-test` builds the image only under `-Ptest-build`.
 - The image build runs in the `package` phase.
-- So `mvn test -Pintegration` cannot pass chat-shell in a clean environment. It
-  stops before `package`, and the image is never built.
+- Thus, `mvn test -Pintegration` cannot pass chat-shell in a clean environment.
+  It stops before `package`, and the image does not exist.
 - `mvn verify -Ptest-build,integration` works. The reactor builds the integration
-  module first (`pom.xml` lists it at line 83, chat-shell at line 84), so the image
-  exists before chat-shell's tests run.
+  module first. `pom.xml` lists it at line 83, and chat-shell at line 84.
+  The image exists before chat-shell tests run.
 
-The CI job must use the second form. The local verifier cannot be copied directly,
-because it assumes the image already exists in the local Docker daemon.
+The CI job must use the second command. The local verifier cannot be copied
+directly. It assumes that the local Docker daemon already has the image.
 
 ## Design
 
-Add a second job to `.github/workflows/maven.yml`. Keep the existing job unchanged.
+Add a second job to `.github/workflows/maven.yml`. Keep the existing job
+unchanged.
 
 ```yaml
   integration:
@@ -68,40 +67,41 @@ Add a second job to `.github/workflows/maven.yml`. Keep the existing job unchang
       run: mvn -B clean verify -Ptest-build,integration
 ```
 
-Details, with reasons:
+Details and reasons:
 
-1. **Triggers: every pull request and every master push.** This catches container
-   regressions before merge. The unit job stays fast, so this does not slow the
-   quick signal.
+1. **Triggers: every pull request and every master push.** This finds container
+   regressions before merge. The unit job stays fast.
 2. **Informational, not a merge gate.** Master has no branch protection, so no
-   check gates anything today. Do not add protection in this change. A red X is
-   visible and does not block. That is the correct posture for a suite with no
-   CI flakiness history.
-3. **No `continue-on-error`.** The job must report red honestly. It is
-   informational because nothing is protected, not because it forces success.
+   check gates anything today. Do not add protection in this change. A failed
+   check is visible and does not block.
+3. **No `continue-on-error`.** The job must report failure as failure. It is
+   informational because nothing is protected.
 4. **`timeout-minutes: 30`.** Container suites can hang instead of fail. A hang
-   with no timeout burns runner minutes and looks like a queued job.
-5. **Same cache key as the unit job.** Both restore the same `~/.m2` cache. On a
-   PR, the two jobs start at once, so neither reliably populates the cache for the
-   other. Accept the duplicate first-run download.
+   with no timeout uses runner minutes and can look like a queued job.
+5. **Same cache key as the unit job.** Both jobs restore the same `~/.m2` cache.
+   On a PR, the two jobs start together. Neither job reliably populates the cache
+   for the other. Accept the duplicate first-run download.
 6. **Shared setup stays duplicated, not extracted.** Two jobs of eight steps are
-   clearer than one reusable workflow. GitHub does not support YAML anchors in
-   workflow files.
-7. **The job re-runs the unit tests inside `verify`.** This is deliberate. One
-   reactor invocation mirrors the local verifier and keeps the image build, the
-   dependency modules and the container tests in one ordering. The repeated unit
-   phase costs about 3 minutes. Do not "fix" it with `-pl` scoping: the image
-   build needs its dependency modules in the same reactor.
+   clearer than one reusable workflow. GitHub workflow files do not support YAML
+   anchors.
+7. **The job runs unit tests again inside `verify`.** This is deliberate. One
+   reactor run matches the local verifier. It keeps image creation, dependency
+   modules, and container tests in one order. The repeated unit phase costs about
+   3 minutes. Do not change it to `-pl` scoping. The image build needs its
+   dependency modules in the same reactor.
 
-## Verification (part of the change, not after it)
+## Verification
 
-The issue names the criterion: a test job that has never failed is indistinguishable
-from one that does not run. No CI run has failed since #38 merged. Neither job has
-ever proved it can go red. The integration job is new, so it needs the proof twice.
+Verification is part of the change. It is not after the change.
+
+The issue names the criterion. A test job that has never failed is
+indistinguishable from one that does not run. No CI run has failed since #38
+merged. Neither job has proved that it can fail. The integration job is new, so
+it needs the proof twice.
 
 Two checks, before and during review:
 
-**Local zero-to-one check (before pushing).** Delete the image from a running
+**Local clean-image check (before pushing).** Delete the image from a running
 Docker daemon, then run the exact CI command from the repo root:
 
 ```bash
@@ -109,46 +109,46 @@ docker rmi docker.io/library/chat-deploy-long-memory-integration-test:0.0.1
 mvn -B clean verify -Ptest-build,integration
 ```
 
-This proves the ordering claim (image module at `pom.xml` line 83, chat-shell at
-line 84, and Maven keeps declaration order because chat-shell does not depend on
-the image module). A local `~/.m2` cache is acceptable. The image must not exist
-in the Docker daemon beforehand.
+This proves the ordering claim. The image module is at `pom.xml` line 83.
+chat-shell is at line 84. Maven keeps declaration order because chat-shell does
+not depend on the image module. A local `~/.m2` cache is acceptable. The image
+must not exist in the Docker daemon before the run.
 
-**Red proof (on the feature PR, never merged to master).** The issue names the
-criterion: a test job that has never failed is indistinguishable from one that
-does not run. A `pull_request` run uses the workflow file from the PR head, so a
-separate throwaway branch cannot exercise the new job until it is merged. The
-proof therefore rides the same PR:
+**Failure proof (on the feature PR, never merged to master).** The issue names
+the criterion. A test job that has never failed is indistinguishable from one
+that does not run. A `pull_request` run uses the workflow file from the PR head.
+A separate throwaway branch cannot exercise the new job before merge. The proof
+therefore rides the same PR:
 
 1. Push a commit that breaks one unit test (in the default reactor) and one test
    tagged `integration`.
-2. Confirm: unit job red, integration job red, one run per commit, and the
-   integration report shows container tests executing. chat-shell reports about
-   19 tests running, not 36 with 17 skipped.
-3. Push the revert, confirm both jobs green, then merge. The red commit never
+2. Confirm that the unit job fails. Confirm that the integration job fails.
+   Confirm one run per commit. Confirm that the integration log shows container
+   tests. chat-shell reports about 19 tests running, not 36 with 17 skipped.
+3. Push the revert, confirm both jobs pass, then merge. The failed commit never
    reaches master.
 
 ## Documentation
 
-1. `docs/BUILD-HEALTH.md`: extend the B5 row to say CI also runs
-   `-Ptest-build,integration`, and that the container half of the suite is now
-   checked per commit.
-2. Comment the outcome, the flakiness baseline, and the gating decision on
+1. `docs/BUILD-HEALTH.md`: extend the B5 row. State that CI also runs
+   `-Ptest-build,integration`. State that CI checks container tests for each
+   commit.
+2. Comment the outcome, the flakiness baseline, and the merge-gate decision on
    `CHAT-uortzsbx`, then close it.
 
 ## Decisions
 
 | Question | Decision | Why |
 |---|---|---|
-| Where does the integration job run? | Every PR and master push | Catch container regressions before merge |
-| Does it gate merges? | No. Revisit after 10 runs | No flakiness record exists yet, and a flaky gate trains people to ignore checks |
-| How far does red verification go? | Both jobs, on the feature PR. The red commit is never merged | The new job gets the same proof the old one lacked, and the PR head carries the workflow the proof exercises |
+| Where does the integration job run? | Every PR and master push | Find container regressions before merge |
+| Does it gate merges? | No. Revisit after 10 runs | No flakiness record exists yet |
+| How far does failure verification go? | Both jobs, on the feature PR. The failed commit is never merged | The PR head carries the workflow that the proof exercises |
 
 ## Out of scope
 
 - Branch protection and required checks. Revisit after 10 integration runs.
-- Nightly scheduled runs. The per-PR trigger already covers the detection need.
+- Nightly scheduled runs. The per-PR trigger covers the detection need.
 - Docker API version on GitHub runners. The pinned plugin (3.5.12) negotiates
-  instead of hardcoding v1.24, so runner lag is not a failure mode. If a first run
-  disagrees, the run log will say so.
+  instead of hardcoding v1.24. Thus, runner lag is not a failure mode. If a first
+  run disagrees, the run log will show it.
 - B1/B2/B4. All done.

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,18 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
+                <!-- Repackage is off by default. A default build produces plain
+                     jars, so library modules stay usable on a test classpath.
+                     The `deploy` profile below and a module's own image-build
+                     profile turn it back on. An earlier design used an
+                     activeByDefault `noartifact` profile for the same effect,
+                     and it failed silently. Maven deactivates an activeByDefault
+                     profile when any profile in the same POM is activated. So
+                     `-Pintegration` switched repackage on for every module, and
+                     library consumers stopped compiling. CHAT-kaaupcvu. -->
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -179,32 +191,12 @@
              are here so every module can use them, which is what lets the
              chat-deploy-<backend> modules act as composition roots.
 
-             `deploy` and `noartifact` MUST stay in the same POM as each other.
-             noartifact is activeByDefault, and Maven only deactivates an
-             activeByDefault profile when another profile in the SAME POM is
-             activated. Split them across poms and activating deploy no longer
-             switches noartifact off, so skip=true wins and nothing is
-             packaged. -->
-        <profile>
-            <!-- Default: build a plain jar, not a Spring Boot artifact.
-                 Deactivated automatically when any other profile here is
-                 activated - see the note above. -->
-            <id>noartifact</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.springframework.boot</groupId>
-                        <artifactId>spring-boot-maven-plugin</artifactId>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
+             No profile in this POM is activeByDefault. Repackage defaults to
+             skip=true in the `<build>` section above, and the `deploy`
+             profile passes skip=false. Activating any other profile therefore
+             changes nothing about packaging. The old `noartifact`
+             activeByDefault profile made that false: every activation
+             switched it off. It is removed. CHAT-kaaupcvu. -->
         <profile>
             <id>deploy</id>
             <build>
@@ -213,6 +205,10 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
+                            <!-- The only root profile that packages Boot
+                                 artifacts. Overrides the default skip=true in
+                                 the `<build>` section. -->
+                            <skip>false</skip>
                             <mainClass>${appMainClass}</mainClass>
                             <image>
                                 <name>${appImageName}</name>

--- a/pom.xml
+++ b/pom.xml
@@ -152,15 +152,15 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <!-- Repackage is off by default. A default build produces plain
-                     jars, so library modules stay usable on a test classpath.
-                     The `deploy` profile below and a module's own image-build
-                     profile enable it again. An earlier design used an
-                     activeByDefault `noartifact` profile for the same effect,
-                     and it failed silently. Maven deactivates an activeByDefault
-                     profile when any profile in the same POM is activated. So
-                     `-Pintegration` enabled repackage for every module, and
-                     library consumers stopped compiling. CHAT-kaaupcvu. -->
+                <!-- Repackage is disabled by default. A default build produces
+                     plain jars. Library modules stay usable on a test
+                     classpath. The `deploy` profile below enables repackage.
+                     A module image profile can also enable it. The old design
+                     used an activeByDefault `noartifact` profile. Maven
+                     deactivates an activeByDefault profile when any profile in
+                     the same POM is active. Thus, `-Pintegration` enabled
+                     repackage for every module. Library consumers stopped
+                     compiling. CHAT-kaaupcvu. -->
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -192,12 +192,10 @@
              chat-deploy-<backend> modules act as composition roots.
 
              No profile in this POM is activeByDefault. Repackage defaults to
-             skip=true in the `<build>` section above, and the `deploy`
-             profile passes skip=false. Activating any other profile therefore
-             changes nothing about packaging. The old `noartifact`
-             activeByDefault profile broke that rule: Maven deactivated it
-             whenever any profile in this POM was active. It is removed.
-             CHAT-kaaupcvu. -->
+             skip=true in the `<build>` section above. The `deploy` profile
+             passes skip=false. Other profiles do not change packaging. The old
+             `noartifact` profile broke that rule. Maven deactivated it when
+             any profile in this POM was active. It is removed. CHAT-kaaupcvu. -->
         <profile>
             <id>deploy</id>
             <build>
@@ -206,9 +204,9 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <!-- The only root profile that packages Boot
-                                 artifacts. Overrides the default skip=true in
-                                 the `<build>` section. -->
+                            <!-- This is the only root profile that packages
+                                 Boot artifacts. It overrides the default
+                                 skip=true in the `<build>` section. -->
                             <skip>false</skip>
                             <mainClass>${appMainClass}</mainClass>
                             <image>

--- a/pom.xml
+++ b/pom.xml
@@ -155,11 +155,11 @@
                 <!-- Repackage is off by default. A default build produces plain
                      jars, so library modules stay usable on a test classpath.
                      The `deploy` profile below and a module's own image-build
-                     profile turn it back on. An earlier design used an
+                     profile enable it again. An earlier design used an
                      activeByDefault `noartifact` profile for the same effect,
                      and it failed silently. Maven deactivates an activeByDefault
                      profile when any profile in the same POM is activated. So
-                     `-Pintegration` switched repackage on for every module, and
+                     `-Pintegration` enabled repackage for every module, and
                      library consumers stopped compiling. CHAT-kaaupcvu. -->
                 <configuration>
                     <skip>true</skip>
@@ -195,8 +195,9 @@
              skip=true in the `<build>` section above, and the `deploy`
              profile passes skip=false. Activating any other profile therefore
              changes nothing about packaging. The old `noartifact`
-             activeByDefault profile made that false: every activation
-             switched it off. It is removed. CHAT-kaaupcvu. -->
+             activeByDefault profile broke that rule: Maven deactivated it
+             whenever any profile in this POM was active. It is removed.
+             CHAT-kaaupcvu. -->
         <profile>
             <id>deploy</id>
             <build>


### PR DESCRIPTION
Extends B5 (`CHAT-uortzsbx`). PR #38 made CI execute unit tests. This PR adds the container tests.

**Changes**
- Adds an `integration` job in `maven.yml`. It runs `mvn -B clean verify -Ptest-build,integration` on every PR and master push. It is informational. It has a 30 minute timeout. The build job is unchanged.
- Fixes B6 (`CHAT-kaaupcvu`). `spring-boot-maven-plugin` now defaults to `skip=true` at the root. The `deploy` profile passes `skip=false`. The `activeByDefault` `noartifact` profile is removed. Before this, `-Pintegration` deactivated `noartifact`. Maven repackaged every module. Library test compile failed.
- Adds `-Dapp.nodeid=900` to the test image. PR #51 requires this value.

**Verification**
- Local clean-image check: deleted the image, then ran the full command. All 32 modules passed in 5:23 min. `chat-shell` executed 19 container tests. The 17 skipped tests are permanent `@Disabled` classes.
- Failure proof (T3) rides this PR next. One unit test will fail. One container test will fail. Then the commit is reverted. The failed commits are never merged.

Spec: `docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md`
Plan: `docs/superpowers/plans/2026-08-28-ci-integration-execution.md`

Co-Authored-By: Claude Code <noreply@anthropic.com>