### PR TITLE
DO NOT MERGE: B5 red proof for both CI jobs

### DIFF
--- a/chat-authorization-server/src/test/kotlin/com/demo/chat/ClientInitializerTest.kt
+++ b/chat-authorization-server/src/test/kotlin/com/demo/chat/ClientInitializerTest.kt
@@ -39,7 +39,9 @@ class ClientInitializerTest {
         ClientInitializer(repo, mapper).loadClient().run(args)
 
         val clientCaptor = ArgumentCaptor.forClass(RegisteredClient::class.java)
-        Mockito.verify(repo, Mockito.times(1)).save(clientCaptor.capture())
+        // B5-RED-PROOF: times(2) cannot hold. One save happens. The unit job
+        // must report failure. Do not merge.
+        Mockito.verify(repo, Mockito.times(2)).save(clientCaptor.capture())
     }
 
 

--- a/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellUserCommandsTests.kt
+++ b/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellUserCommandsTests.kt
@@ -15,7 +15,15 @@ import reactor.core.publisher.Mono
 import reactor.core.scheduler.Schedulers
 
 @Tag("integration")
-class LongUserCommandsTests : ShellUserCommandsTests<Long>()
+class LongUserCommandsTests : ShellUserCommandsTests<Long>() {
+    // B5-RED-PROOF: deliberate failure inside a container-backed class. The
+    // integration job must run this after starting the test container and
+    // report failure. Do not merge.
+    @Test
+    fun `red proof container test fails`() {
+        Assertions.assertThat(true).isFalse
+    }
+}
 
 @Disabled
 @TestMethodOrder(MethodOrderer.OrderAnnotation::class)


### PR DESCRIPTION
Throwaway branch. CHAT-zljzaiox. This PR exists so GitHub runs both jobs against deliberate test failures, then it is closed without merging.

- Integration break: one failing test in LongUserCommandsTests (chat-shell, @Tag integration, container-backed).
- Unit break: ClientInitializerTest verifies times(2) for one save.

Expected: build fails, integration fails, integration log shows container tests running before the failure. Master never sees these commits.