### PR TITLE
B7: compile scope for chat-service-controller, skip test compilation on launch

### DIFF
--- a/chat-deploy-memory/pom.xml
+++ b/chat-deploy-memory/pom.xml
@@ -54,7 +54,12 @@
             <groupId>com.demo</groupId>
             <artifactId>chat-service-controller</artifactId>
             <version>0.0.1</version>
-            <scope>test</scope>
+            <!-- Compile scope, not test. The launch surface runs
+                 spring-boot:run, which uses the runtime classpath. The
+                 controllers and the password encoder configuration of
+                 chat-security must be present at boot. The cassandra,
+                 kafka, and image modules all use compile scope. B7,
+                 fp issue CHAT-uxmjaebs. -->
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -106,6 +106,20 @@ See `docs/NODEID-CLAIM.md` for the node-id lease rules.
 
 See `shell-scripts/README-chat-build.md` for all `chat-build` flags.
 
+## Installed Artifacts
+
+`chat-build` resolves library modules from the local Maven repository. The launch also uses the installed `chat-deploy` jar.
+
+After a pull or a branch switch, refresh the installed artifacts once:
+
+```bash
+mvn clean install -DskipTests
+```
+
+The launch and image commands pass `-Dmaven.test.skip=true`. Stale test classes in the local repository cannot break a launch.
+
+Use `mvn clean` whenever you build. A stale `target/` directory reports false results. See B6 in `docs/BUILD-HEALTH.md`.
+
 ## Direct Script Use
 
 Use scripts directly when a recipe does not cover the task.

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -569,7 +569,11 @@ class BuildContext:
             "mvn",
             f"-DimageName={self.image_name}",
             "-P" + ",".join(self.maven_profiles()),
-            "-DskipTests",
+            # Skip test compilation too. spring-boot:run forks the
+            # test-compile lifecycle, and -DskipTests does not stop
+            # that compilation. A stale local repository then breaks a
+            # launch in test classes. B7, fp issue CHAT-uxmjaebs.
+            "-Dmaven.test.skip=true",
             self.maven_goal(),
         ]
 


### PR DESCRIPTION
Direct launch of the memory deployment fails. `ActuatorWebSecurityConfiguration` requires a `PasswordEncoder` bean. The bean is absent from the runtime classpath.

1. `chat-deploy-memory/pom.xml`: `chat-service-controller` moves from `test` scope to compile. The scope dates to `6c2b6a076` (2023-10-12). `spring-boot:run` uses the runtime classpath, so the controllers and the `chat-security` encoder config were missing at boot. Surefire hides this because tests use the test classpath. The image module, cassandra, and kafka all use compile scope. chat-deploy-memory was the outlier.
2. `shell-scripts/chat-build`: the launch path passes `-Dmaven.test.skip=true` instead of `-DskipTests`. `spring-boot:run` forks `test-compile`, and `-DskipTests` does not stop that compilation. A stale local repository then breaks a launch inside test classes. `docs/BUILD.md` records the installed-artifact rule.

Verification: dependency tree shows both artifacts at compile scope. `test-flags.sh` exit 0, `dry-run-memory` prints the new flag, `git diff --check` pass, `drift check` ok. Boot proof: Netty RSocket on port 6790, `Started ChatApp` in 1.95s, `/actuator/health` returned 200.

fp issues: CHAT-uxmjaebs (parent), CHAT-lkrmbxev (T1), CHAT-snknebnn (T2).