### PR TITLE
Add shell launch recipes to the justfile

### DIFF
--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -90,10 +90,17 @@ Start the core service with memory storage:
 just launch-memory 0
 ```
 
-Print the launch command without execution:
+Start the interactive shell client against a running core service:
+
+```bash
+just launch-shell 1
+```
+
+Print a launch command without execution:
 
 ```bash
 just dry-run-memory 0
+just dry-run-shell 1
 ```
 
 `app.nodeid` has no default.

--- a/justfile
+++ b/justfile
@@ -36,6 +36,14 @@ launch-memory node_id="0":
 dry-run-memory node_id="0":
 	./shell-scripts/chat-build core --memory --run --notls --node-id {{node_id}} --init users,rootkeys --dry-run
 
+# Start the interactive shell client. Start a core service first.
+launch-shell node_id="1":
+	./shell-scripts/chat-build shell --run --notls --node-id {{node_id}}
+
+# Print the shell client launch command and properties.
+dry-run-shell node_id="1":
+	./shell-scripts/chat-build shell --run --notls --node-id {{node_id}} --dry-run
+
 # Build a Cassandra core service image.
 build-cassandra node_id:
 	./shell-scripts/chat-build core --cassandra --build --notls --node-id {{node_id}}


### PR DESCRIPTION
The justfile covers the memory core launch only. Starting the shell client needs the direct script call.

- `just launch-shell 1` runs `chat-build shell --run --notls --node-id 1`.
- `just dry-run-shell 1` prints the command and properties.
- `docs/BUILD.md` records both beside the memory pair.

Verified: `just --list` shows both recipes, `just -n` expands correctly, the composed command is `mvn -DimageName=chat-shell -Pdeploy,shell,client-backend -Dmaven.test.skip=true spring-boot:run`, `git diff --check` pass, `drift check` ok.

fp issue: CHAT-szmlwdjm.