### PR TITLE
Fix shell send by topic name, and make pubsub provider beans singletons

### DIFF
--- a/chat-messaging-kafka/src/main/kotlin/com/demo/chat/config/pubsub/kafka/KafkaPubSubBeans.kt
+++ b/chat-messaging-kafka/src/main/kotlin/com/demo/chat/config/pubsub/kafka/KafkaPubSubBeans.kt
@@ -9,10 +9,14 @@ import com.demo.chat.service.core.TopicPubSubService
 import org.apache.kafka.clients.admin.AdminClient
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate
-import org.springframework.stereotype.Component
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import reactor.kafka.receiver.ReceiverOptions
 
-@Component
+// Configuration plus Bean, not Component. The service keeps membership state
+// per instance, so every holder must get the same one. fp issue B9,
+// CHAT-ouzjdxun.
+@Configuration
 @ConditionalOnProperty(prefix = "app.service.core", name = ["pubsub"], havingValue = "kafka")
 class KafkaPubSubBeans<T, V>(
     private val producer: ReactiveKafkaProducerTemplate<String, Message<T, V>>,
@@ -21,6 +25,7 @@ class KafkaPubSubBeans<T, V>(
     private val receiverOptions: ReceiverOptions<String, Message<T, V>>
 ) : PubSubServiceBeans<T, V> {
 
+    @Bean
     override fun pubSubService(): TopicPubSubService<T, V> =
         KafkaTopicPubSubService(
             producer,

--- a/chat-messaging-memory/src/main/kotlin/com/demo/chat/config/pubsub/memory/MemoryPubSubBeans.kt
+++ b/chat-messaging-memory/src/main/kotlin/com/demo/chat/config/pubsub/memory/MemoryPubSubBeans.kt
@@ -5,9 +5,16 @@ import com.demo.chat.domain.TypeUtil
 import com.demo.chat.pubsub.memory.impl.MemoryTopicPubSubService
 import com.demo.chat.service.core.TopicPubSubService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Component
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
-@Component
+// Configuration plus Bean, not Component. The pubsub service keeps all state
+// in instance maps. Spring injects this provider into the composite topic
+// service, the composite message service, and the pubsub controller. A plain
+// method call would give each holder a different instance, so opening a room
+// in one instance would be invisible to a send in another. That produced
+// NotFoundException on every send. fp issue B9, CHAT-ouzjdxun.
+@Configuration
 @ConditionalOnProperty(
     prefix = "app.service.core",
     name = ["pubsub"],
@@ -16,5 +23,6 @@ import org.springframework.stereotype.Component
 )
 class MemoryPubSubBeans<T, V>(val typeUtil: TypeUtil<T>) : PubSubServiceBeans<T, String> {
 
+    @Bean
     override fun pubSubService(): TopicPubSubService<T, String> = MemoryTopicPubSubService()
 }

--- a/chat-persistence-xstream/src/main/kotlin/com/demo/chat/config/pubsub/redis/RedisPubSubBeans.kt
+++ b/chat-persistence-xstream/src/main/kotlin/com/demo/chat/config/pubsub/redis/RedisPubSubBeans.kt
@@ -7,19 +7,26 @@ import com.demo.chat.pubsub.impl.memory.messaging.KeyConfigurationPubSub
 import com.demo.chat.pubsub.impl.memory.messaging.RedisTopicPubSubService
 import com.demo.chat.service.core.TopicPubSubService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Component
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
 /**
  * Non-durable messaging over Redis Pub/Sub channels, selected by
  * `app.service.core.pubsub=redis-pubsub`.
+ *
+ * Configuration plus Bean, not Component. The service keeps its sinks and
+ * Redis listeners in instance maps. Every holder of this provider must get
+ * the same instance, or a subscription in one instance receives nothing from
+ * another. fp issue B9, CHAT-ouzjdxun.
  */
-@Component
+@Configuration
 @ConditionalOnProperty(prefix = "app.service.core", name = ["pubsub"], havingValue = "redis-pubsub")
 class RedisPubSubBeans<T>(
     private val config: RedisTemplateConfiguration,
     private val typeUtil: TypeUtil<T>
 ) : PubSubServiceBeans<T, String> {
 
+    @Bean
     override fun pubSubService(): TopicPubSubService<T, String> =
         RedisTopicPubSubService(
             KeyConfigurationPubSub(

--- a/chat-persistence-xstream/src/main/kotlin/com/demo/chat/config/pubsub/redis/XStreamPubSubBeans.kt
+++ b/chat-persistence-xstream/src/main/kotlin/com/demo/chat/config/pubsub/redis/XStreamPubSubBeans.kt
@@ -8,19 +8,24 @@ import com.demo.chat.pubsub.impl.memory.messaging.KeyConfiguration
 import com.demo.chat.pubsub.impl.memory.messaging.XStreamTopicPubSubService
 import com.demo.chat.service.core.TopicPubSubService
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
-import org.springframework.stereotype.Component
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 
 /**
  * Durable messaging over Redis Streams, selected by
  * `app.service.core.pubsub=redis-xstream`.
+ *
+ * Configuration plus Bean, not Component. Every holder of this provider must
+ * get the same pubsub instance. fp issue B9, CHAT-ouzjdxun.
  */
-@Component
+@Configuration
 @ConditionalOnProperty(prefix = "app.service.core", name = ["pubsub"], havingValue = "redis-xstream")
 class XStreamPubSubBeans<T>(
     private val config: RedisTemplateConfiguration,
     private val typeUtil: TypeUtil<T>
 ) : PubSubServiceBeans<T, String> {
 
+    @Bean
     override fun pubSubService(): TopicPubSubService<T, String> =
         XStreamTopicPubSubService(
             KeyConfiguration(

--- a/chat-shell/src/main/kotlin/com/demo/chat/config/shell/deploy/ShellStateConfiguration.kt
+++ b/chat-shell/src/main/kotlin/com/demo/chat/config/shell/deploy/ShellStateConfiguration.kt
@@ -27,7 +27,6 @@ class ShellStateConfiguration {
 
     @Bean
     fun requestMetadataProvider(): Supplier<RequestMetadata> = Supplier {
-        println("SUPPLIER SUPPLIES")
         val metadata =
             loginMetadata
                 .map<RequestMetadata> { SimpleRequestMetadata(UsernamePasswordMetadata(it.username, it.password),

--- a/chat-shell/src/main/kotlin/com/demo/chat/shell/commands/PubSubCommands.kt
+++ b/chat-shell/src/main/kotlin/com/demo/chat/shell/commands/PubSubCommands.kt
@@ -47,9 +47,9 @@ class PubSubCommands<T>(
         if (!topicName.equals("_")) {
             topicService
                 .getRoomByName(ByStringRequest(topicName))
-                .flatMap {
+                .flatMap { room ->
                     messageService
-                        .send(MessageSendRequest(messageText, identity, typeUtil.assignFrom(topicId)))
+                        .send(MessageSendRequest(messageText, identity, room.key.id))
                 }
                 .doOnNext { key ->
                     println("Message Id: ${key.id}")

--- a/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellPubSubCommandsTests.kt
+++ b/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellPubSubCommandsTests.kt
@@ -1,0 +1,57 @@
+package com.demo.chat.test.init
+
+import com.demo.chat.shell.commands.PubSubCommands
+import com.demo.chat.shell.commands.TopicCommands
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.springframework.beans.factory.annotation.Autowired
+
+@Tag("integration")
+class LongPubSubCommandsTests : ShellPubSubCommandsTests<Long>()
+
+@Disabled
+@TestMethodOrder(MethodOrderer.OrderAnnotation::class)
+@Tag("integration")
+open class ShellPubSubCommandsTests<T> : ShellIntegrationTestBase() {
+
+    @Autowired
+    private lateinit var pubSubCommands: PubSubCommands<T>
+
+    @Autowired
+    private lateinit var topicCommands: TopicCommands<T>
+
+    @Test
+    @Order(1)
+    fun `send by topic name uses the looked-up room id`() {
+        // The defect: the topicName branch sent with the topicId option,
+        // which still held its default underscore. Parsing the underscore
+        // as a key threw NumberFormatException before any request left the
+        // client. fp issue B8, CHAT-qonhhtuq.
+        topicCommands.addTopic("_", "pubsubA")
+
+        assertDoesNotThrow {
+            pubSubCommands.send(topicName = "pubsubA", topicId = "_",
+                userName = "_", messageText = "hello by name")
+        }
+    }
+
+    @Test
+    @Order(2)
+    fun `send by topic id reaches the room`() {
+        val raw = topicCommands.topicByName("_", "pubsubA")
+        Assertions.assertThat(raw).isNotBlank
+
+        val topicId = raw!!.substringBefore(" | ")
+
+        assertDoesNotThrow {
+            pubSubCommands.send(topicName = "_", topicId = topicId,
+                userName = "_", messageText = "hello by id")
+        }
+    }
+}


### PR DESCRIPTION
Two defects, one test pair.

**B8 (CHAT-qonhhtuq):** the send command topicName branch discarded the room it looked up and sent with the topicId option, which still held its default underscore. Parsing the underscore threw NumberFormatException client-side. The branch now sends to the looked-up room id. Also removed a stray debug print from the shell metadata supplier.

**B9 (CHAT-ouzjdxun):** the send then failed server-side with Object not Found. All four pubsub provider beans constructed a new service instance on every call. The composite topic service, the composite message service, and the pubsub controller each held a different instance. The room sink opened in one map was invisible to a send checking another. The providers are now Configuration classes with Bean-annotated pubSubService(), the pattern the memory persistence providers already use.

**Tests:** new LongPubSubCommandsTests covers send by name and send by id. Both green. Full chat-shell integration suite green (0 failures). The image was rebuilt from the fixed source.

Fix in b5a3d277..ed383656 is on this branch. Merge pending owner review.