### PR TITLE
Shell hangup command, plus not-found on unknown room name and bare leave

### DIFF
--- a/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/rsocket/controller/composite/TopicControllerTests.kt
+++ b/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/rsocket/controller/composite/TopicControllerTests.kt
@@ -245,6 +245,78 @@ open class TopicControllerTests : RSocketTestBase() {
             .verifyComplete()
     }
 
+    @Test
+    fun `should report not found when no room carries the name`() {
+        // Guards the fallback position in getRoomByName. With switchIfEmpty
+        // after single(), an empty index throws NoSuchElementException
+        // instead. fp issue CHAT-fplhtycq.
+        BDDMockito
+            .given(topicIndex.findBy(TestBase.anyObject()))
+            .willReturn(Flux.empty())
+
+        StepVerifier
+            .create(
+                requester
+                    .route("topic-by-name")
+                    .data(ByStringRequest("no-such-room-" + TestBase.randomAlphaNumeric(4)))
+                    .retrieveMono(MessageTopic::class.java)
+            )
+            .expectSubscription()
+            .expectErrorSatisfies {
+                Assertions.assertThat(it)
+                    .isInstanceOf(ApplicationErrorException::class.java)
+                    .hasMessageContaining("Object not Found")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `should report not found when an index hit has no persistence row`() {
+        BDDMockito
+            .given(topicIndex.findBy(TestBase.anyObject()))
+            .willReturn(Flux.just(Key.funKey(randomTopicId)))
+        BDDMockito
+            .given(topicPersistence.get(TestBase.anyObject()))
+            .willReturn(Mono.empty())
+
+        StepVerifier
+            .create(
+                requester
+                    .route("topic-by-name")
+                    .data(ByStringRequest(randomRoomName))
+                    .retrieveMono(MessageTopic::class.java)
+            )
+            .expectSubscription()
+            .expectErrorSatisfies {
+                Assertions.assertThat(it)
+                    .isInstanceOf(ApplicationErrorException::class.java)
+                    .hasMessageContaining("Object not Found")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `should not leave a room that holds no membership`() {
+        BDDMockito
+            .given(membershipIndex.findBy(TestBase.anyObject()))
+            .willReturn(Flux.empty())
+
+        StepVerifier
+            .create(
+                requester
+                    .route("topic-leave")
+                    .data(MembershipRequest(randomUserId, randomTopicId))
+                    .retrieveMono(Void::class.java)
+            )
+            .expectSubscription()
+            .expectErrorSatisfies {
+                Assertions.assertThat(it)
+                    .isInstanceOf(ApplicationErrorException::class.java)
+                    .hasMessageContaining("Object not Found")
+            }
+            .verify()
+    }
+
     @TestConfiguration
     class TestTopicControllerConfiguration {
         @Bean

--- a/chat-service-composite/src/main/kotlin/com/demo/chat/service/composite/impl/TopicServiceImpl.kt
+++ b/chat-service-composite/src/main/kotlin/com/demo/chat/service/composite/impl/TopicServiceImpl.kt
@@ -56,13 +56,19 @@ open class TopicServiceImpl<T, V, Q>(
         topicPersistence
             .get(Key.funKey(req.id))
 
+    // The first switchIfEmpty must sit before single(). An empty index makes
+    // single() throw NoSuchElementException, which would outrun a fallback
+    // placed after it. The second switchIfEmpty answers an index hit whose
+    // persistence row is gone. fp issue CHAT-fplhtycq.
     override fun getRoomByName(req: ByStringRequest): Mono<out MessageTopic<T>> =
         topicIndex
             .findBy(topicNameToQuery.apply(req))
+            .switchIfEmpty(Mono.error(NotFoundException))
             .single()
             .flatMap {
                 topicPersistence.get(it)
             }
+            .switchIfEmpty(Mono.error(NotFoundException))
 
     override fun joinRoom(req: MembershipRequest<T>): Mono<Void> {
         return topicPersistence
@@ -89,6 +95,7 @@ open class TopicServiceImpl<T, V, Q>(
     override fun leaveRoom(req: MembershipRequest<T>): Mono<Void> =
         membershipIndex
             .findBy(memberWithTopicToQuery.apply(req))
+            .switchIfEmpty(Mono.error(NotFoundException))
             .last()
             .flatMap { key ->
                 membershipPersistence.rem(key)

--- a/chat-shell/src/main/kotlin/com/demo/chat/config/shell/deploy/ShellStateConfiguration.kt
+++ b/chat-shell/src/main/kotlin/com/demo/chat/config/shell/deploy/ShellStateConfiguration.kt
@@ -10,8 +10,10 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.security.rsocket.metadata.UsernamePasswordMetadata
 import org.springframework.util.MimeTypeUtils
+import reactor.core.Disposable
 import reactor.core.publisher.Sinks.Empty
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 import java.util.function.Supplier
 
 @Configuration
@@ -23,6 +25,7 @@ class ShellStateConfiguration {
     companion object {
         var loggedInUser: Optional<Any> = Optional.empty()
         var loginMetadata: Optional<UsernamePasswordMetadata> = Optional.empty()
+        val listeners: MutableMap<String, Disposable> = ConcurrentHashMap()
     }
 
     @Bean

--- a/chat-shell/src/main/kotlin/com/demo/chat/shell/commands/PubSubCommands.kt
+++ b/chat-shell/src/main/kotlin/com/demo/chat/shell/commands/PubSubCommands.kt
@@ -1,6 +1,7 @@
 package com.demo.chat.shell.commands
 
 import com.demo.chat.config.CompositeServiceBeans
+import com.demo.chat.config.shell.deploy.ShellStateConfiguration
 import com.demo.chat.domain.*
 import com.demo.chat.domain.knownkey.RootKeys
 import com.demo.chat.service.composite.ChatMessageService
@@ -84,9 +85,18 @@ class PubSubCommands<T>(
     @ShellMethod("Listen to a topic")
     fun listen(
         @ShellOption topicId: String
-    ) = messageService.listenTopic(ByIdRequest(typeUtil.assignFrom(topicId)))
-        .doOnNext { message ->
-            println("Message: ${message.key.from} : ${message.data}\n")
-        }
-        .subscribe()
+    ) {
+        val d = messageService.listenTopic(ByIdRequest(typeUtil.assignFrom(topicId)))
+            .doOnNext { message ->
+                println("Message: ${message.key.from} : ${message.data}\n")
+            }
+            .subscribe()
+
+        ShellStateConfiguration.listeners[topicId] = d
+    }
+
+    @ShellMethod("Stop listening to a topic")
+    fun hangup(@ShellOption topicId: String) {
+        ShellStateConfiguration.listeners.remove(topicId)?.dispose()
+    }
 }

--- a/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellPubSubCommandsTests.kt
+++ b/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellPubSubCommandsTests.kt
@@ -1,9 +1,15 @@
 package com.demo.chat.test.init
 
+import com.demo.chat.config.shell.deploy.ShellStateConfiguration
 import com.demo.chat.shell.commands.PubSubCommands
 import com.demo.chat.shell.commands.TopicCommands
+import io.rsocket.exceptions.ApplicationErrorException
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.MethodOrderer
 import org.junit.jupiter.api.Order
@@ -52,6 +58,45 @@ open class ShellPubSubCommandsTests<T> : ShellIntegrationTestBase() {
         assertDoesNotThrow {
             pubSubCommands.send(topicName = "_", topicId = topicId,
                 userName = "_", messageText = "hello by id")
+        }
+    }
+
+    @Test
+    @Order(3)
+    fun `send to an unknown topic name reports not found`() {
+        // Before the fallback fix, an unknown name died in single() as a
+        // raw NoSuchElementException. fp issue CHAT-fplhtycq.
+        val error = assertThrows(ApplicationErrorException::class.java) {
+            pubSubCommands.send(topicName = "no-such-room-${System.nanoTime()}",
+                topicId = "_", userName = "_", messageText = "hello nowhere")
+        }
+        Assertions.assertThat(error.message).contains("Object not Found")
+    }
+
+    @Test
+    @Order(4)
+    fun `hangup disposes the stored listener and forgets it`() {
+        val raw = topicCommands.topicByName("_", "pubsubA")
+        val topicId = raw!!.substringBefore(" | ")
+
+        pubSubCommands.listen(topicId)
+
+        val stored = ShellStateConfiguration.listeners[topicId]
+        assertTrue(stored != null && !stored.isDisposed,
+            "listen must store a live Disposable for the topic id")
+
+        pubSubCommands.hangup(topicId)
+
+        assertTrue(stored!!.isDisposed, "hangup must dispose the listener")
+        assertFalse(ShellStateConfiguration.listeners.containsKey(topicId),
+            "hangup must remove the entry from the listener map")
+    }
+
+    @Test
+    @Order(5)
+    fun `hangup on a topic never listened to is a no-op`() {
+        assertDoesNotThrow {
+            pubSubCommands.hangup("999999999999")
         }
     }
 }


### PR DESCRIPTION
Owner-authored production changes plus the test pairs that pin them.

**Shell hangup.** `listen` now stores its `Disposable` per topic id in `ShellStateConfiguration.listeners`; the new `hangup` command disposes and forgets it. Cancellation rides the rsocket CANCEL frame to the server subscription, so no server API was added.

**Loud NotFound.** `getRoomByName` and `leaveRoom` answer `NotFoundException` instead of completing empty. One placement correction: the by-name fallback sat after `.single()`, and an empty index makes `single()` throw `NoSuchElementException` first. Moved before `.single()`; the index-hit/persistence-miss fallback stays after.

**Tests.** Composite level, in `TopicControllerTests` over mocked cores: unknown name, index/persistence mismatch, leave without membership. Shell level, in `LongPubSubCommandsTests`: send to unknown name fails with Object not Found, hangup disposes and removes, hangup of an unknown id is a no-op.

Results: TopicControllerTests 7/7. LongPubSubCommandsTests 5/5. Full chat-shell integration suite green (0 failures) against an image rebuilt from this code. fp issue CHAT-fplhtycq.