### PR TITLE
Reject a topic add whose name already exists

### DIFF
--- a/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/rsocket/controller/composite/TopicControllerTests.kt
+++ b/chat-client-rsocket/src/test/kotlin/com/demo/chat/test/rsocket/controller/composite/TopicControllerTests.kt
@@ -109,6 +109,11 @@ open class TopicControllerTests : RSocketTestBase() {
             .given(topicIndex.add(TestBase.anyObject()))
             .willReturn(Mono.empty())
 
+        // addRoom now checks the index first. No room carries this name yet.
+        BDDMockito
+            .given(topicIndex.findBy(TestBase.anyObject()))
+            .willReturn(Flux.empty())
+
         BDDMockito
             .given(topicPersistence.key())
             .willReturn(Mono.just(Key.funKey(theRoomId)))
@@ -313,6 +318,30 @@ open class TopicControllerTests : RSocketTestBase() {
                 Assertions.assertThat(it)
                     .isInstanceOf(ApplicationErrorException::class.java)
                     .hasMessageContaining("Object not Found")
+            }
+            .verify()
+    }
+
+    @Test
+    fun `should not add a room whose name already exists`() {
+        // A room with this name is already indexed. addRoom must reject the
+        // duplicate instead of creating a second room. fp issue CHAT-qktlglfa.
+        BDDMockito
+            .given(topicIndex.findBy(TestBase.anyObject()))
+            .willReturn(Flux.just(Key.funKey(randomTopicId)))
+
+        StepVerifier
+            .create(
+                requester
+                    .route("topic-add")
+                    .data(ByStringRequest(randomRoomName))
+                    .retrieveMono(Void::class.java)
+            )
+            .expectSubscription()
+            .expectErrorSatisfies {
+                Assertions.assertThat(it)
+                    .isInstanceOf(ApplicationErrorException::class.java)
+                    .hasMessageContaining("Object already exists")
             }
             .verify()
     }

--- a/chat-service-composite/src/main/kotlin/com/demo/chat/service/composite/impl/TopicServiceImpl.kt
+++ b/chat-service-composite/src/main/kotlin/com/demo/chat/service/composite/impl/TopicServiceImpl.kt
@@ -25,16 +25,30 @@ open class TopicServiceImpl<T, V, Q>(
 ) : ChatTopicService<T, V> {
     val logger: Logger = LoggerFactory.getLogger(this::class.simpleName)
 
+    // Names are unique. The index schemas tolerate duplicate names, but the
+    // product decision is that a name names one room. Enforce it here, at the
+    // source, so no backend holds a duplicate and getRoomByName's single() is
+    // always safe. Without this, Cassandra orphans the older room in silence
+    // and memory throws a raw IllegalStateException. fp issue CHAT-qktlglfa.
     override fun addRoom(req: ByStringRequest): Mono<out Key<T>> =
-        topicPersistence
-            .key()
-            .map { key -> MessageTopic.create(key, req.name) }
-            .flatMap { room ->
-                topicPersistence
-                    .add(room)
-                    .then(topicIndex.add(room))
-                    .then(pubsub.open(room.key.id))
-                    .then(Mono.just(room.key))
+        topicIndex
+            .findBy(topicNameToQuery.apply(req))
+            .hasElements()
+            .flatMap { exists ->
+                if (exists) {
+                    Mono.error(DuplicateException)
+                } else {
+                    topicPersistence
+                        .key()
+                        .map { key -> MessageTopic.create(key, req.name) }
+                        .flatMap { room ->
+                            topicPersistence
+                                .add(room)
+                                .then(topicIndex.add(room))
+                                .then(pubsub.open(room.key.id))
+                                .then(Mono.just(room.key))
+                        }
+                }
             }
 
     override fun deleteRoom(req: ByIdRequest<T>): Mono<Void> =

--- a/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellTopicCommandsTests.kt
+++ b/chat-shell/src/test/kotlin/com/demo/chat/test/init/ShellTopicCommandsTests.kt
@@ -1,6 +1,7 @@
 package com.demo.chat.test.init
 
 import com.demo.chat.shell.commands.TopicCommands
+import io.rsocket.exceptions.ApplicationErrorException
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Tag
@@ -106,5 +107,21 @@ open class ShellTopicCommandsTests<T> : ShellIntegrationTestBase() {
 
         Assertions.assertThat(members)
             .isNullOrEmpty()
+    }
+
+    @Test
+    @Order(6)
+    fun `adding a topic with an existing name fails`() {
+        // Names are unique. The first add creates the room; the second must
+        // fail with the duplicate error, not create a second room. fp issue
+        // CHAT-qktlglfa.
+        topicCommands.addTopic("_", "dupRoom")
+
+        val error = org.junit.jupiter.api.Assertions.assertThrows(ApplicationErrorException::class.java) {
+            topicCommands.addTopic("_", "dupRoom")
+        }
+
+        Assertions.assertThat(error.message)
+            .contains("Object already exists")
     }
 }


### PR DESCRIPTION
## What

A topic name names one room. addRoom now checks the index before creating. A name that already names a room fails with DuplicateException (Object already exists).

## Why

The index schemas tolerate duplicate names, and the two backends diverged on the outcome:

- Cassandra: the PK (name, room_id) inserts a second row. findByKeyName returns the newest. The older room is orphaned in silence.
- Memory (Lucene): findBy returns both rows. getRoomByName single() throws a raw IllegalStateException.

Same action, two undesigned outcomes. The product decision is to reject at the source, so no backend holds a duplicate and getRoomByName single() is always safe.

## Changes

- TopicServiceImpl.addRoom: findBy().hasElements() check-then-act. A hit fails with DuplicateException.
- Composite test: an indexed name fails topic-add with the duplicate error. The create-and-join test stubs the index lookup, since addRoom checks it first.
- Shell test: a second addTopic with the same name fails with the duplicate error.

## Verification

- TopicControllerTests 8/8 green.
- Full chat-shell integration suite green: LongShellTopicCommandsTests 4/4, LongPubSubCommandsTests 5/5, LongUserCommandsTests 8/8, LongLoginCommandsTests 5/5, ShellRequesterTests 2/2, ContextTest 1/1.

fp issue CHAT-qktlglfa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)