### PR TITLE
build: move Kotlin to 2.4.10

### DIFF
--- a/chat-index-lucene/pom.xml
+++ b/chat-index-lucene/pom.xml
@@ -143,7 +143,6 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
-                    <languageVersion>1.9</languageVersion>
                 </configuration>
 				<dependencies>
 					<dependency>

--- a/chat-messaging-kafka/pom.xml
+++ b/chat-messaging-kafka/pom.xml
@@ -168,7 +168,6 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
-					<languageVersion>1.8</languageVersion>
 				</configuration>
 				<dependencies>
 					<dependency>

--- a/chat-messaging-memory/pom.xml
+++ b/chat-messaging-memory/pom.xml
@@ -153,7 +153,6 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
-                    <languageVersion>1.8</languageVersion>
                 </configuration>
 				<dependencies>
 					<dependency>

--- a/chat-persistence-memory/pom.xml
+++ b/chat-persistence-memory/pom.xml
@@ -153,7 +153,6 @@
 					<compilerPlugins>
 						<plugin>spring</plugin>
 					</compilerPlugins>
-                    <languageVersion>1.9</languageVersion>
                 </configuration>
 				<dependencies>
 					<dependency>

--- a/chat-shell/pom.xml
+++ b/chat-shell/pom.xml
@@ -190,7 +190,6 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <languageVersion>1.8</languageVersion>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>17</java.version>
-        <kotlin.version>1.9.25</kotlin.version>
+        <kotlin.version>2.4.10</kotlin.version>
         <serialization.version>1.6.3</serialization.version>
         <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud-bom.version>2025.0.3</spring-cloud-bom.version>


### PR DESCRIPTION
Issue `CHAT-dixbadbc`. Two commits. No Kotlin source file changes.

## Why

Kotlin 1.9 cannot target a JVM above 22. JDK 25 needs Kotlin 2.x. This is the first step on the critical path to the [Vectors](https://integrallis.github.io/vectors/) library and phase 2 of vector search.

## What landed

| Commit | Issue | What |
|--------|-------|------|
| `9a85e4ef` | `CHAT-trikxali` | Deleted five hardcoded `<languageVersion>` elements |
| `24a51d67` | `CHAT-bmlrlemb` | `kotlin.version` 1.9.25 to 2.4.10 |

`java.version` and `jvmTarget` stay 17. The JDK move is `CHAT-hczlsjqu`. `serialization.version` stays 1.6.3.

## The scope was measured before it was written

A probe on 2026-09-05 ran the reactor with `-Dkotlin.version=2.4.10`.

Round 1, as-is: 24 modules pass, 5 fail. Every failure read `Language version 1.9 is no longer supported`. No failure named a Kotlin source file. The cause was five pins:

- `chat-shell`, `chat-messaging-kafka`, `chat-messaging-memory` at 1.8
- `chat-index-lucene`, `chat-persistence-memory` at 1.9

Round 2, pins removed: 34 modules pass, 0 fail.

Round 3, `mvn test`: 34 modules pass, 534 tests, 0 failures.

The K2 compiler needed no source change anywhere in the repo. This migration is one version bump plus five deletions.

The pins are inert on Kotlin 1.9.25, so `9a85e4ef` is a no-op on its own. It lands first so the compiler bump has no blocker.

## Verification

`mvn -B clean verify -Pintegration` exits 0. BUILD SUCCESS.

| Metric | Baseline | This branch |
|--------|----------|-------------|
| Modules SUCCESS | 34 | 34 |
| Modules FAILURE | 0 | 0 |
| Container starts | 28 | 28 |
| Tests run | 736 | 736 |
| Failures | 0 | 0 |
| Errors | 0 | 0 |
| Skipped | 52 | 52 |

Every number matches the wave 1 baseline exactly.

The log shows `kotlin:2.4.10:compile` and `kotlin:2.4.10:test-compile`, so the build used the new compiler.

## The named risk is closed

The scope named the all-open compiler plugin as the blocking risk. Every Spring `@Configuration` class in the repo depends on it.

All 28 containers started. Every deploy composition root started its Spring context. Those are the widest contexts in the repo, and the default mode probe never reached them. `chat-core` declares `kotlin-maven-allopen` without a `<compilerPlugins>` block and still compiles and tests clean.

kotlinx-serialization 1.6.3 works with the 2.4.10 plugin. All seven serializer and wire shape test classes pass.

Zero Kotlin compiler warnings. The warnings in the log are the known Byte Buddy agent and JVM class sharing messages that the forward register already records.

## Not in this PR

- 2.4.20-RC3 exists on Maven Central. It is a release candidate. 2.4.10 is the latest release.
- Raising kotlinx-serialization above 1.6.3 is optional and not required.
- `CHAT-hczlsjqu`, JDK 17 to 25, is next on the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JpbDMU3hCfR633tYpAopH