### PR TITLE
build: move to JDK 25

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -20,10 +20,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     - name: Cache Maven packages
@@ -54,10 +54,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
 
-    - name: Set up JDK 17
+    - name: Set up JDK 25
       uses: actions/setup-java@v4
       with:
-        java-version: '17'
+        java-version: '25'
         distribution: 'temurin'
 
     - name: Cache Maven packages

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <image.repo>${env.IMAGE_REPO_PREFIX}</image.repo>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <java.version>17</java.version>
+        <java.version>25</java.version>
         <kotlin.version>2.4.10</kotlin.version>
         <serialization.version>1.6.3</serialization.version>
         <spring-boot.version>3.5.16</spring-boot.version>


### PR DESCRIPTION
Issue `CHAT-hczlsjqu`. Two commits.

## Why

The Vectors library ships Java 25 class files. A compiler running with release 17 cannot read them. This is the last gate before phase 2 of vector search.

## What landed

| Commit | Issue | What |
|--------|-------|------|
| `4c023ec9` | `CHAT-kmudsbck` | `java.version` 17 to 25 |
| `6215e042` | `CHAT-jnkzsdhl` | Both CI jobs to JDK 25 |

No source file changes. No flag is added. Nothing uses the Vector API yet.

## The two commits must land together

`java.version` sets the compiler release. A JDK 17 toolchain cannot compile at release 25. If the pom change merged alone, both CI jobs would fail on master. The CI change is not a follow-up.

Temurin publishes Java 25, so the distribution does not change.

## Verification

The build ran on GraalVM CE 25+37.1.

| Metric | Baseline | This branch |
|--------|----------|-------------|
| Modules SUCCESS | 34 | 34 |
| Modules FAILURE | 0 | 0 |
| Container starts | 28 | 28 |
| Tests run | 736 | 736 |
| Failures / Errors | 0 / 0 | 0 / 0 |
| Skipped | 52 | 52 |

Default mode also passes: 34 modules, 534 tests, 0 failures.

**Proof the release actually moved.** A compiled class in `chat-core/target/classes` carries major version 69, which is Java 25. It carried 61 before, which is Java 17. The property is not merely set. The compiler used it.

**Image proof.** The deploy image builds with `-Ptest-build` and starts. Its log reads `Starting ChatApp.Companion v0.0.1 using Java 25.0.4`. So `BP_JVM_VERSION` carried 25 into the image. The build JDK is GraalVM CE 25+37.1 and the image JRE is 25.0.4, because the buildpack supplies its own Java 25 runtime. Both are Java 25.

## Two traps found, recorded on the issues

1. **Do not check this property with `mvn help:evaluate -Dexpression=java.version`.** That name is also a standard JVM system property, and it shadows the pom value. The goal reported `21.0.2` while the pom said 25 and the compiler emitted class version 69. Read the class file version instead.
2. **`chat-index-elastic/pom.xml` line 128 pins `jvmTarget` to 1.8.** It is the only pom that sets it. Every other module inherits from `java.version`. Nothing breaks today. It is the same shape as the five `languageVersion` pins that blocked Kotlin 2.4. Tracked as `CHAT-ixazwico`.

## Two Java 25 runtime warnings, neither fatal

Both come from Netty and both are recorded as separate issues.

- `sun.misc.Unsafe::allocateMemory` is terminally deprecated and is called by `netty-common-4.1.135.Final`. It will be removed in a future release. Tracked as `CHAT-gidbchkx`.
- `java.lang.System::loadLibrary` is a restricted method and is called by Netty. The JVM asks for `--enable-native-access=ALL-UNNAMED`, and says restricted methods will be blocked in a future release. This changes the flag plan: that flag is a Netty need today, not only a Vectors need. Recorded on `CHAT-eroapfub`.

## Still open under this scope

- `CHAT-hvactuvm`. The GraalVM native profile has not been built on Java 25.
- `CHAT-eroapfub`. The Vector API incubator flag. Nothing needs it until the Vectors module lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JpbDMU3hCfR633tYpAopH