### PR TITLE
Add Java 25 vector runtime flags

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -41,10 +41,10 @@ jobs:
 
   # This job runs the container tests. The build job's `test` phase never
   # reaches `package`, so it cannot create the image for chat-shell tests.
-  # `verify` creates that image before chat-shell starts. See pom.xml lines
-  # 83 and 84. The test-build profile enables the image build. The job also
-  # runs unit tests during verify. One Maven reactor run preserves the order
-  # of image creation, dependencies, and container tests. No merge gate applies.
+  # `verify` creates that image before chat-shell starts. The test-build
+  # profile enables the image build. The job also runs unit tests during
+  # verify. One Maven reactor run preserves image, dependency, and test order.
+  # No merge gate applies.
   # Spec: docs/superpowers/specs/2026-08-28-ci-integration-execution-design.md
   integration:
     runs-on: ubuntu-latest

--- a/chat-authorization-server/pom.xml
+++ b/chat-authorization-server/pom.xml
@@ -39,6 +39,11 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArgs>
+                                <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                            </buildArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/chat-deploy-memory-integration-test/pom.xml
+++ b/chat-deploy-memory-integration-test/pom.xml
@@ -32,13 +32,9 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
-                        <!-- This plugin is newer than the managed version.
-                             Spring Boot 3.3.13 hardcodes Docker API v1.24.
-                             Docker Engine 29 refuses API versions below v1.40.
-                             Spring Boot 3.5.x negotiates the API version. Only
-                             this module builds an image, so the version skew
-                             stays here. Remove the pin after the parent uses a
-                             Boot version that negotiates. CHAT-gtcnjyit. -->
+                        <!-- Keep this pin until the executable image format is
+                             checked against chat-shell RSocket tests. Removing
+                             it makes index query payloads decode as maps. -->
                         <version>3.5.12</version>
                         <configuration>
                             <skip>false</skip>
@@ -50,7 +46,8 @@
                                 <name>${appImageName}</name>
                                 <cleanCache>true</cleanCache>
                                 <env>
-                                    <BPE_APPEND_JAVA_TOOL_OPTIONS>-Dspring.application.name=chat-integration-test
+                                    <BPE_APPEND_JAVA_TOOL_OPTIONS>--enable-native-access=ALL-UNNAMED
+-Dspring.application.name=chat-integration-test
 -Dspring.profiles.active=prod -Dserver.port=6791
 -Dspring.rsocket.server.ssl.enabled=false
 -Dapp.actuator.username=actuator -Dapp.actuator.password=actuator

--- a/chat-deploy-redis/build-core.sh
+++ b/chat-deploy-redis/build-core.sh
@@ -10,7 +10,7 @@ export APP_VERSION=0.0.1
 
 # makes no use of cloud configuration or config-maps
 # TODO: difference between '-D' and '--'
-export JAVA_TOOL_OPTIONS=" -Dspring.profiles.active=${SPRING_PROFILE} \
+export JAVA_TOOL_OPTIONS=" --enable-native-access=ALL-UNNAMED -Dspring.profiles.active=${SPRING_PROFILE} \
 -Dserver.port=$((CORE_PORT+1)) -Dspring.rsocket.server.port=${CORE_PORT} \
 -Dapp.service.core.pubsub=redis-pubsub \
 -Dapp.service.edge.topic \

--- a/chat-deploy/pom.xml
+++ b/chat-deploy/pom.xml
@@ -24,6 +24,11 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArgs>
+                                <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                            </buildArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/chat-service-controller/src/main/kotlin/com/demo/chat/config/controller/core/IndexControllersConfiguration.kt
+++ b/chat-service-controller/src/main/kotlin/com/demo/chat/config/controller/core/IndexControllersConfiguration.kt
@@ -1,7 +1,8 @@
 package com.demo.chat.config.controller.core
 
 import com.demo.chat.config.IndexServiceBeans
-import com.demo.chat.controller.core.IndexServiceController
+import com.demo.chat.controller.core.IndexSearchRequestIndexServiceController
+import com.demo.chat.controller.core.MapIndexServiceController
 import com.demo.chat.domain.*
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Configuration
@@ -14,30 +15,70 @@ class IndexControllersConfiguration {
     @Controller
     @MessageMapping("index.kv")
     @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
-    class KeyValueIndexController<T, V, Q>(s: IndexServiceBeans<T, V, Q>):
-        IndexServiceController<T, KeyValuePair<T, Any>, Q>(s.KVPairIndex())
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "lucene", matchIfMissing = true)
+    class KeyValueIndexController<T, V>(s: IndexServiceBeans<T, V, IndexSearchRequest>):
+        IndexSearchRequestIndexServiceController<T, KeyValuePair<T, Any>>(s.KVPairIndex())
 
     @Controller
     @MessageMapping("index.user")
     @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
-    class UserIndexController<T, V, Q>(s: IndexServiceBeans<T, V, Q>) :
-        IndexServiceController<T, User<T>, Q>(s.userIndex())
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "lucene", matchIfMissing = true)
+    class UserIndexController<T, V>(s: IndexServiceBeans<T, V, IndexSearchRequest>) :
+        IndexSearchRequestIndexServiceController<T, User<T>>(s.userIndex())
 
     @Controller
     @MessageMapping("index.message")
     @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
-    class MessageIndexController<T, V, Q>(s: IndexServiceBeans<T, V, Q>) :
-        IndexServiceController<T, Message<T, V>, Q>(s.messageIndex())
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "lucene", matchIfMissing = true)
+    class MessageIndexController<T, V>(s: IndexServiceBeans<T, V, IndexSearchRequest>) :
+        IndexSearchRequestIndexServiceController<T, Message<T, V>>(s.messageIndex())
 
     @Controller
     @MessageMapping("index.topic")
     @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
-    class TopicIndexController<T, V, Q>(s: IndexServiceBeans<T, V, Q>) :
-        IndexServiceController<T, MessageTopic<T>, Q>(s.topicIndex())
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "lucene", matchIfMissing = true)
+    class TopicIndexController<T, V>(s: IndexServiceBeans<T, V, IndexSearchRequest>) :
+        IndexSearchRequestIndexServiceController<T, MessageTopic<T>>(s.topicIndex())
 
     @Controller
     @MessageMapping("index.authmetadata")
     @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
-    class AuthMetaIndexController<T, V, Q>(s: IndexServiceBeans<T, V, Q>) :
-        IndexServiceController<T, AuthMetadata<T>, Q>(s.authMetadataIndex())
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "lucene", matchIfMissing = true)
+    class AuthMetaIndexController<T, V>(s: IndexServiceBeans<T, V, IndexSearchRequest>) :
+        IndexSearchRequestIndexServiceController<T, AuthMetadata<T>>(s.authMetadataIndex())
+
+    @Controller
+    @MessageMapping("index.kv")
+    @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "cassandra")
+    class CassandraKeyValueIndexController<T, V>(s: IndexServiceBeans<T, V, Map<String, String>>):
+        MapIndexServiceController<T, KeyValuePair<T, Any>>(s.KVPairIndex())
+
+    @Controller
+    @MessageMapping("index.user")
+    @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "cassandra")
+    class CassandraUserIndexController<T, V>(s: IndexServiceBeans<T, V, Map<String, String>>) :
+        MapIndexServiceController<T, User<T>>(s.userIndex())
+
+    @Controller
+    @MessageMapping("index.message")
+    @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "cassandra")
+    class CassandraMessageIndexController<T, V>(s: IndexServiceBeans<T, V, Map<String, String>>) :
+        MapIndexServiceController<T, Message<T, V>>(s.messageIndex())
+
+    @Controller
+    @MessageMapping("index.topic")
+    @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "cassandra")
+    class CassandraTopicIndexController<T, V>(s: IndexServiceBeans<T, V, Map<String, String>>) :
+        MapIndexServiceController<T, MessageTopic<T>>(s.topicIndex())
+
+    @Controller
+    @MessageMapping("index.authmetadata")
+    @ConditionalOnProperty(prefix = "app.controller", name = ["index"])
+    @ConditionalOnProperty(prefix = "app.service.core", name = ["index"], havingValue = "cassandra")
+    class CassandraAuthMetaIndexController<T, V>(s: IndexServiceBeans<T, V, Map<String, String>>) :
+        MapIndexServiceController<T, AuthMetadata<T>>(s.authMetadataIndex())
 }

--- a/chat-service-controller/src/main/kotlin/com/demo/chat/controller/core/IndexServiceController.kt
+++ b/chat-service-controller/src/main/kotlin/com/demo/chat/controller/core/IndexServiceController.kt
@@ -1,6 +1,43 @@
 package com.demo.chat.controller.core
 
 import com.demo.chat.controller.core.mapping.IndexServiceMapping
+import com.demo.chat.domain.IndexSearchRequest
 import com.demo.chat.service.core.IndexService
+import com.demo.chat.domain.Key
+import org.springframework.messaging.handler.annotation.MessageMapping
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 open class IndexServiceController<T, E, Q>(private val that: IndexService<T, E, Q>) : IndexServiceMapping<T, E, Q>, IndexService<T, E, Q> by that
+
+open class IndexSearchRequestIndexServiceController<T, E>(
+    private val that: IndexService<T, E, IndexSearchRequest>
+) : IndexService<T, E, IndexSearchRequest> by that {
+    @MessageMapping("add")
+    override fun add(entity: E): Mono<Void> = that.add(entity)
+
+    @MessageMapping("rem")
+    override fun rem(key: Key<T>): Mono<Void> = that.rem(key)
+
+    @MessageMapping("query")
+    override fun findBy(query: IndexSearchRequest): Flux<out Key<T>> = that.findBy(query)
+
+    @MessageMapping("unique")
+    override fun findUnique(query: IndexSearchRequest): Mono<out Key<T>> = that.findUnique(query)
+}
+
+open class MapIndexServiceController<T, E>(
+    private val that: IndexService<T, E, Map<String, String>>
+) : IndexService<T, E, Map<String, String>> by that {
+    @MessageMapping("add")
+    override fun add(entity: E): Mono<Void> = that.add(entity)
+
+    @MessageMapping("rem")
+    override fun rem(key: Key<T>): Mono<Void> = that.rem(key)
+
+    @MessageMapping("query")
+    override fun findBy(query: Map<String, String>): Flux<out Key<T>> = that.findBy(query)
+
+    @MessageMapping("unique")
+    override fun findUnique(query: Map<String, String>): Mono<out Key<T>> = that.findUnique(query)
+}

--- a/chat-vector-embedded/pom.xml
+++ b/chat-vector-embedded/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.demo</groupId>
+        <artifactId>chat-parent</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <groupId>com.demo</groupId>
+    <artifactId>chat-vector-embedded</artifactId>
+    <version>0.0.1</version>
+    <name>chat-vector-embedded</name>
+    <description>Embedded Vector API provider ground for the Vectors adapter</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--add-modules</arg>
+                        <arg>jdk.incubator.vector</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-modules jdk.incubator.vector</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/VectorApiFlagTests.java
+++ b/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/VectorApiFlagTests.java
@@ -1,0 +1,17 @@
+package com.demo.chat.test.vector.embedded;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VectorApiFlagTests {
+
+    @Test
+    void vectorApiModuleLoads() {
+        VectorSpecies<Float> species = FloatVector.SPECIES_PREFERRED;
+
+        assertThat(species.length()).isGreaterThan(0);
+    }
+}

--- a/forward-register.md
+++ b/forward-register.md
@@ -493,3 +493,47 @@ search. The critical path to phase 2 is now:
   compile scope, not test scope. The pom declares no scope element. This predates
   wave 1. Removing the version pins made it visible in the dependency tree.
 - `CHAT-pkolwuqm` Boot 4 and `CHAT-ygllyglb` Spring AI 2.0. Parallel track.
+
+## JDK 25 vector runtime flags (2026-09-06)
+
+Issue `CHAT-eroapfub`.
+
+### What changed
+
+- Added `chat-vector-embedded` as the narrow compile and test ground for the
+  JDK Vector API.
+- Added `--add-modules jdk.incubator.vector` only to `chat-vector-embedded`.
+- Added `--enable-native-access=ALL-UNNAMED` to generated deploy runtime flags.
+- Added the native access flag to the static memory integration image flags.
+- Added the native access flag to legacy Redis deploy startup.
+- Added the native access flag to GraalVM native build arguments.
+- Kept the `chat-deploy-memory-integration-test` Boot plugin pin at `3.5.12`.
+
+### Flag reach
+
+Keep the incubator Vector API flag narrow. Only code that compiles or loads
+`jdk.incubator.vector` receives `--add-modules jdk.incubator.vector`.
+
+Keep native access broad for deploy runtimes. Netty uses native access on Java
+25. Future JDKs may block that path without `--enable-native-access=ALL-UNNAMED`.
+
+### Controller finding
+
+The chat-shell integration image exposed a Boot 3.5 and Java 25 RSocket decode
+change. Generic index controllers used `Q` for the query payload. The server
+decoded that payload as `LinkedHashMap`. Lucene index services require
+`IndexSearchRequest`.
+
+The controller layer now binds query payloads explicitly:
+
+- Lucene index controllers bind `IndexSearchRequest`.
+- Cassandra index controllers bind `Map<String,String>`.
+- The generic controller stays for existing test-only use.
+
+### Proof
+
+- `mvn -o -B -pl chat-vector-embedded test` passed.
+- `shell-scripts/test-flags.sh` passed all 15 golden cases.
+- `mvn -o -B -pl chat-service-controller -am test` passed.
+- `mvn -o -B -pl chat-deploy-memory -am -Dtest=MemoryDeploymentTests -Dsurefire.failIfNoSpecifiedTests=false test` passed.
+- The user reported `mvn -B clean verify -Ptest-build,integration -fae` passed.

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>chat-index-lucene</module>
         <module>chat-vector-simple</module>
         <module>chat-vector-redis</module>
+        <module>chat-vector-embedded</module>
 
         <module>chat-messaging-kafka</module>
 

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -311,6 +311,7 @@ RSOCKET_SERVER_AUTOCONFIG_EXCLUDE = (
     "-Dspring.autoconfigure.exclude="
     "org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
 )
+NATIVE_ACCESS_FLAG = "--enable-native-access=ALL-UNNAMED"
 
 COMMON_FEATURES = ["local", "consul", "long", "uuid", "websocket", "debug"]
 
@@ -590,7 +591,10 @@ class BuildContext:
         return flags
 
     def main_flags(self) -> list[str]:
-        flags = [f"-Dspring.profiles.active={','.join(self.spring_profiles())}"]
+        flags = [
+            NATIVE_ACCESS_FLAG,
+            f"-Dspring.profiles.active={','.join(self.spring_profiles())}",
+        ]
         flags += self.endpoint_flags()
         flags += [
             f"-Dapp.key.type={self.key_type}",

--- a/shell-scripts/golden/authserv-client.flags
+++ b/shell-scripts/golden/authserv-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,jdbc
+--enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket
 -Dapp.client.rsocket.composite.user

--- a/shell-scripts/golden/core-build-image.flags
+++ b/shell-scripts/golden/core-build-image.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-cassandra.flags
+++ b/shell-scripts/golden/core-cassandra.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-debug.flags
+++ b/shell-scripts/golden/core-debug.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-e2ee.flags
+++ b/shell-scripts/golden/core-e2ee.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,e2ee,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-kafka.flags
+++ b/shell-scripts/golden/core-kafka.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-memory-consul.flags
+++ b/shell-scripts/golden/core-memory-consul.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket,register-consul
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-memory-init.flags
+++ b/shell-scripts/golden/core-memory-init.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-memory-tls.flags
+++ b/shell-scripts/golden/core-memory-tls.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-redis.flags
+++ b/shell-scripts/golden/core-redis.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-uuid.flags
+++ b/shell-scripts/golden/core-uuid.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-websocket.flags
+++ b/shell-scripts/golden/core-websocket.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/gateway-client.flags
+++ b/shell-scripts/golden/gateway-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,expose-gateway
+--enable-native-access=ALL-UNNAMED
 -Dapp.key.type=long
 -Dapp.kv.store=none
 -Dapp.nodeid=0

--- a/shell-scripts/golden/rest-client.flags
+++ b/shell-scripts/golden/rest-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,expose-webflux
+--enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket
 -Dapp.client.rsocket.composite.message

--- a/shell-scripts/golden/shell-client.flags
+++ b/shell-scripts/golden/shell-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,shell
+--enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket
 -Dapp.client.rsocket.composite.message


### PR DESCRIPTION
## Summary
- Add `chat-vector-embedded` as the narrow Vector API flag target.
- Add `--add-modules jdk.incubator.vector` only to that module.
- Add `--enable-native-access=ALL-UNNAMED` to deploy runtime paths.
- Bind RSocket index controllers to concrete query payload types.

## Test Plan
- [x] `mvn -o -B -pl chat-vector-embedded test`
- [x] `CONDA_NO_PLUGINS=true bash -lc 'source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate base && ./shell-scripts/test-flags.sh'`
- [x] `mvn -o -B -pl chat-service-controller -am test`
- [x] `mvn -o -B -pl chat-deploy-memory -am -Dtest=MemoryDeploymentTests -Dsurefire.failIfNoSpecifiedTests=false test`
- [x] `git diff --check`
- [x] `drift check`
- [x] User reported `mvn -B clean verify -Ptest-build,integration -fae` passed.

## Notes
- Keep `chat-deploy-memory-integration-test` on Boot plugin `3.5.12`.
- Issue: `CHAT-eroapfub`
