### PR TITLE
Add Java 25 vector runtime flags

### DIFF
--- a/chat-authorization-server/pom.xml
+++ b/chat-authorization-server/pom.xml
@@ -39,6 +39,11 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArgs>
+                                <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                            </buildArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/chat-deploy-memory-integration-test/pom.xml
+++ b/chat-deploy-memory-integration-test/pom.xml
@@ -50,7 +50,8 @@
                                 <name>${appImageName}</name>
                                 <cleanCache>true</cleanCache>
                                 <env>
-                                    <BPE_APPEND_JAVA_TOOL_OPTIONS>-Dspring.application.name=chat-integration-test
+                                    <BPE_APPEND_JAVA_TOOL_OPTIONS>--enable-native-access=ALL-UNNAMED
+-Dspring.application.name=chat-integration-test
 -Dspring.profiles.active=prod -Dserver.port=6791
 -Dspring.rsocket.server.ssl.enabled=false
 -Dapp.actuator.username=actuator -Dapp.actuator.password=actuator

--- a/chat-deploy-redis/build-core.sh
+++ b/chat-deploy-redis/build-core.sh
@@ -10,7 +10,7 @@ export APP_VERSION=0.0.1
 
 # makes no use of cloud configuration or config-maps
 # TODO: difference between '-D' and '--'
-export JAVA_TOOL_OPTIONS=" -Dspring.profiles.active=${SPRING_PROFILE} \
+export JAVA_TOOL_OPTIONS=" --enable-native-access=ALL-UNNAMED -Dspring.profiles.active=${SPRING_PROFILE} \
 -Dserver.port=$((CORE_PORT+1)) -Dspring.rsocket.server.port=${CORE_PORT} \
 -Dapp.service.core.pubsub=redis-pubsub \
 -Dapp.service.edge.topic \

--- a/chat-deploy/pom.xml
+++ b/chat-deploy/pom.xml
@@ -24,6 +24,11 @@
                     <plugin>
                         <groupId>org.graalvm.buildtools</groupId>
                         <artifactId>native-maven-plugin</artifactId>
+                        <configuration>
+                            <buildArgs>
+                                <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                            </buildArgs>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>

--- a/chat-vector-embedded/pom.xml
+++ b/chat-vector-embedded/pom.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.demo</groupId>
+        <artifactId>chat-parent</artifactId>
+        <version>0.0.1</version>
+    </parent>
+
+    <groupId>com.demo</groupId>
+    <artifactId>chat-vector-embedded</artifactId>
+    <version>0.0.1</version>
+    <name>chat-vector-embedded</name>
+    <description>Embedded Vector API provider ground for the Vectors adapter</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>--add-modules</arg>
+                        <arg>jdk.incubator.vector</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>--add-modules jdk.incubator.vector</argLine>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/VectorApiFlagTests.java
+++ b/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/VectorApiFlagTests.java
@@ -1,0 +1,17 @@
+package com.demo.chat.test.vector.embedded;
+
+import jdk.incubator.vector.FloatVector;
+import jdk.incubator.vector.VectorSpecies;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class VectorApiFlagTests {
+
+    @Test
+    void vectorApiModuleLoads() {
+        VectorSpecies<Float> species = FloatVector.SPECIES_PREFERRED;
+
+        assertThat(species.length()).isGreaterThan(0);
+    }
+}

--- a/forward-register.md
+++ b/forward-register.md
@@ -513,3 +513,32 @@ Proof:
 - `mvn -o -B -pl chat-client-rsocket -am -Dtest=MessageIndexRequesterTests,KeyValueIndexRequesterTests -Dsurefire.failIfNoSpecifiedTests=false test` passed.
 - `git diff --check` passed.
 - `drift check` returned ok.
+
+## JDK 25 vector runtime flags (2026-09-06)
+
+Issue `CHAT-eroapfub`.
+
+### What changed
+
+- Added `chat-vector-embedded` as the narrow compile and test ground for the
+  JDK Vector API.
+- Added `--add-modules jdk.incubator.vector` only to `chat-vector-embedded`.
+- Added `--enable-native-access=ALL-UNNAMED` to generated deploy runtime flags.
+- Added the native access flag to the static memory integration image flags.
+- Added the native access flag to legacy Redis deploy startup.
+- Added the native access flag to GraalVM native build arguments.
+
+### Flag reach
+
+Keep the incubator Vector API flag narrow. Only code that compiles or loads
+`jdk.incubator.vector` receives `--add-modules jdk.incubator.vector`.
+
+Keep native access broad for deploy runtimes. Netty uses native access on Java
+25. Future JDKs may block that path without `--enable-native-access=ALL-UNNAMED`.
+
+### Proof
+
+- `mvn -o -B -pl chat-vector-embedded test` passed.
+- `shell-scripts/test-flags.sh` passed all 15 golden cases.
+- The user reported the stacked `mvn -B clean verify -Ptest-build,integration -fae`
+  proof passed.

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>chat-index-lucene</module>
         <module>chat-vector-simple</module>
         <module>chat-vector-redis</module>
+        <module>chat-vector-embedded</module>
 
         <module>chat-messaging-kafka</module>
 

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -311,6 +311,7 @@ RSOCKET_SERVER_AUTOCONFIG_EXCLUDE = (
     "-Dspring.autoconfigure.exclude="
     "org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
 )
+NATIVE_ACCESS_FLAG = "--enable-native-access=ALL-UNNAMED"
 
 COMMON_FEATURES = ["local", "consul", "long", "uuid", "websocket", "debug"]
 
@@ -590,7 +591,10 @@ class BuildContext:
         return flags
 
     def main_flags(self) -> list[str]:
-        flags = [f"-Dspring.profiles.active={','.join(self.spring_profiles())}"]
+        flags = [
+            NATIVE_ACCESS_FLAG,
+            f"-Dspring.profiles.active={','.join(self.spring_profiles())}",
+        ]
         flags += self.endpoint_flags()
         flags += [
             f"-Dapp.key.type={self.key_type}",

--- a/shell-scripts/golden/authserv-client.flags
+++ b/shell-scripts/golden/authserv-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,jdbc
+--enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket
 -Dapp.client.rsocket.composite.user

--- a/shell-scripts/golden/core-build-image.flags
+++ b/shell-scripts/golden/core-build-image.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-cassandra.flags
+++ b/shell-scripts/golden/core-cassandra.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-debug.flags
+++ b/shell-scripts/golden/core-debug.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-e2ee.flags
+++ b/shell-scripts/golden/core-e2ee.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,e2ee,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-kafka.flags
+++ b/shell-scripts/golden/core-kafka.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-memory-consul.flags
+++ b/shell-scripts/golden/core-memory-consul.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket,register-consul
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-memory-init.flags
+++ b/shell-scripts/golden/core-memory-init.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-memory-tls.flags
+++ b/shell-scripts/golden/core-memory-tls.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-redis.flags
+++ b/shell-scripts/golden/core-redis.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-uuid.flags
+++ b/shell-scripts/golden/core-uuid.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/core-websocket.flags
+++ b/shell-scripts/golden/core-websocket.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key
 -Dapp.controller.message

--- a/shell-scripts/golden/gateway-client.flags
+++ b/shell-scripts/golden/gateway-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,expose-gateway
+--enable-native-access=ALL-UNNAMED
 -Dapp.key.type=long
 -Dapp.kv.store=none
 -Dapp.nodeid=0

--- a/shell-scripts/golden/rest-client.flags
+++ b/shell-scripts/golden/rest-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,expose-webflux
+--enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket
 -Dapp.client.rsocket.composite.message

--- a/shell-scripts/golden/shell-client.flags
+++ b/shell-scripts/golden/shell-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,shell
+--enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket
 -Dapp.client.rsocket.composite.message


### PR DESCRIPTION
## Summary
- Add `chat-vector-embedded` as the narrow Vector API flag target.
- Add `--add-modules jdk.incubator.vector` only to that module.
- Add `--enable-native-access=ALL-UNNAMED` to deploy runtime paths.

## Test Plan
- [x] `mvn -o -B -pl chat-vector-embedded test`
- [x] `CONDA_NO_PLUGINS=true bash -lc 'source "$(conda info --base)/etc/profile.d/conda.sh" && conda activate base && ./shell-scripts/test-flags.sh'`
- [x] `git diff --check`
- [x] `drift check`
- [x] User reported stacked `mvn -B clean verify -Ptest-build,integration -fae` passed.

## Notes
- Issue: `CHAT-eroapfub`
- This PR stacks on PR #67.
- PR #66 was closed because it mixed this work with the RSocket fix.
