### PR TITLE
feat: add the Vectors Spring AI adapter

### DIFF
--- a/chat-vector-embedded/pom.xml
+++ b/chat-vector-embedded/pom.xml
@@ -14,7 +14,30 @@
     <name>chat-vector-embedded</name>
     <description>Embedded Vector API provider ground for the Vectors adapter</description>
 
+    <properties>
+        <vectors.version>0.1.20</vectors.version>
+    </properties>
+
     <dependencies>
+        <dependency>
+            <groupId>com.integrallis</groupId>
+            <artifactId>vectors-spring-ai</artifactId>
+            <version>${vectors.version}</version>
+        </dependency>
+        <!-- The adapter declares Spring AI as compileOnly, so it brings none
+             of it. This module supplies the Spring AI surface the adapter
+             binds to. The root BOM pins the version at 1.0.3. -->
+        <dependency>
+            <groupId>org.springframework.ai</groupId>
+            <artifactId>spring-ai-vector-store</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.demo</groupId>
+            <artifactId>chat-core</artifactId>
+            <type>test-jar</type>
+            <version>0.0.1</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/VectorsAdapterCompileTests.java
+++ b/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/VectorsAdapterCompileTests.java
@@ -1,0 +1,90 @@
+package com.demo.chat.test.vector.embedded;
+
+import com.demo.chat.service.dummy.DummyEmbeddingModel;
+import com.integrallis.vectors.core.SimilarityFunction;
+import com.integrallis.vectors.db.IndexType;
+import com.integrallis.vectors.db.VectorCollection;
+import com.integrallis.vectors.spring.ai.JavaVectorsVectorStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Compile and round trip proof for the Vectors Spring AI adapter.
+ *
+ * <p>Two earlier spikes read the published metadata only. Neither compiled the
+ * adapter. This test binds the adapter to the Spring AI surface that the root
+ * BOM pins at 1.0.3, and stores and reads one document.
+ */
+class VectorsAdapterCompileTests {
+
+    private static final int DIMENSIONS = 256;
+
+    private VectorCollection collection(Path storage) {
+        return VectorCollection.builder()
+                .dimension(DIMENSIONS)
+                .metric(SimilarityFunction.COSINE)
+                .indexType(IndexType.FLAT)
+                .storagePath(storage)
+                .build();
+    }
+
+    @Test
+    void adapterBuildsAVectorStore(@TempDir Path storage) throws Exception {
+        try (VectorCollection collection = collection(storage)) {
+            VectorStore store = JavaVectorsVectorStore
+                    .builder(new DummyEmbeddingModel(), collection)
+                    .collectionName("messages")
+                    .build();
+
+            assertThat(store).isInstanceOf(JavaVectorsVectorStore.class);
+        }
+    }
+
+    @Test
+    void storeAddsAndRecallsMessageDocuments(@TempDir Path storage) throws Exception {
+        try (VectorCollection collection = collection(storage)) {
+            VectorStore store = JavaVectorsVectorStore
+                    .builder(new DummyEmbeddingModel(), collection)
+                    .collectionName("messages")
+                    .commitAfterAdd(true)
+                    .build();
+
+            store.add(List.of(
+                    Document.builder().id("a").text("apple banana")
+                            .metadata(java.util.Map.of("kind", "message")).build(),
+                    Document.builder().id("b").text("zebra stripe")
+                            .metadata(java.util.Map.of("kind", "message")).build()));
+
+            List<Document> hits = store.similaritySearch(
+                    SearchRequest.builder().query("apple banana").topK(2).build());
+
+            assertThat(hits).isNotNull();
+            assertThat(hits).isNotEmpty();
+            assertThat(hits.get(0).getId()).isEqualTo("a");
+            assertThat(hits.get(0).getScore()).isNotNull();
+        }
+    }
+
+    @Test
+    void storagePathHoldsTheCollectionAfterCommit(@TempDir Path storage) throws Exception {
+        try (VectorCollection collection = collection(storage)) {
+            VectorStore store = JavaVectorsVectorStore
+                    .builder(new DummyEmbeddingModel(), collection)
+                    .collectionName("messages")
+                    .commitAfterAdd(true)
+                    .build();
+
+            store.add(List.of(Document.builder().id("a").text("apple banana").build()));
+
+            assertThat(storage.toFile().list()).isNotEmpty();
+        }
+    }
+}


### PR DESCRIPTION
Issue `CHAT-ciuqgqge`. One commit. This is the compile proof that two spikes never did.

## Why

Phase 2 of vector search adds [Vectors](https://integrallis.github.io/vectors/) as an in-process vector store. Two spikes read the published metadata and concluded the adapter works with the pinned Spring AI 1.0.3. Neither compiled it. This PR compiles and runs it.

## What landed

- `com.integrallis:vectors-spring-ai` pinned at **0.1.20** in `chat-vector-embedded`.
- `spring-ai-vector-store`, because the adapter declares Spring AI as `compileOnly` and brings none of it.
- `chat-core` test jar at test scope, for `DummyEmbeddingModel`.
- Three tests in `VectorsAdapterCompileTests`.

No production code. No configuration class. No selector change. Those are `CHAT-zsnzesqp` and `CHAT-sbpqlmki`.

## Version

The spike recorded 0.1.19 on 2026-09-03. Maven Central published **0.1.20** on 2026-09-05, one day later. The version is pinned rather than ranged, because a 0.1.x line can move its surface between releases.

The transitive set is unchanged from 0.1.19: `vectors-db` at compile scope, `vectors-hybrid` at runtime scope, `slf4j-api` at runtime scope.

## The spike conclusion now holds by compilation

The adapter binds to the Spring AI surface the root BOM pins at **1.0.3**. Spring Boot 4 and Spring AI 2.0 stay off this path.

## Tests

| Test | Proves |
|------|--------|
| `adapterBuildsAVectorStore` | The adapter constructs against `DummyEmbeddingModel` and a `VectorCollection` |
| `storeAddsAndRecallsMessageDocuments` | Two documents go in, the nearer one ranks first and carries a score |
| `storagePathHoldsTheCollectionAfterCommit` | The storage path holds files once `commitAfterAdd` runs |

Full reactor on GraalVM CE 25: **BUILD SUCCESS, 35 modules, 538 tests, 0 failures, 0 errors, 30 skipped.** The module count rose from 34 and the test count from 534.

The module already carried `--add-modules jdk.incubator.vector` in its compiler args and surefire `argLine` from PR #68. The Vector API loads under that flag.

## Construction path, recorded for the tasks that follow

```
VectorCollection.builder()
    .dimension(256).metric(COSINE).indexType(FLAT).storagePath(path).build()

JavaVectorsVectorStore.builder(embeddingModel, collection)
    .collectionName("messages").commitAfterAdd(true).build()
```

Three facts the scope did not have, now recorded on the downstream issues:

1. `IndexType` has **seven** values, not five. `CUVS_BRUTEFORCE` and `CUVS_CAGRA` are GPU indexes. Do not choose one. Noted on `CHAT-xiruozdh`.
2. Storage has a second form, `objectStore(StorageBackend, String)`, beside `storagePath(Path)`. It may remove the container volume problem. Noted on `CHAT-spohupjd`.
3. `VectorCollection` and `JavaVectorsVectorStore` are both `AutoCloseable`. A Spring bean needs a close path. The scope had no lifecycle note. Noted on `CHAT-spohupjd`.

## Build note for a single module run

`mvn -B test -pl chat-vector-embedded` fails on dependency resolution unless two things are installed first:

```
mvn -B install -pl chat-core -DskipTests   # the chat-core test jar
mvn -N -B install                          # the parent pom
```

This is the same shape as the register warning about running `-pl <module>` alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014JpbDMU3hCfR633tYpAopH