### PR TITLE
feat: wire the embedded vector provider

### DIFF
--- a/chat-core/src/main/kotlin/com/demo/chat/config/VectorSelectorValidation.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/config/VectorSelectorValidation.kt
@@ -16,7 +16,14 @@ object VectorSelectorValidation {
         "mock" to "mock",
         "simple" to "mock",
         "redis" to "mock",
+        "embedded" to "mock",
     )
+
+    // Derived from legalPairs so the message cannot drift from the set.
+    private val legalPairsDescription =
+        legalPairs.joinToString(", ") { (vector, embedding) ->
+            "vector=$vector with embedding=$embedding"
+        }
 
     fun validate(vector: String?, embedding: String?) {
         val vectorSet = !vector.isNullOrBlank()
@@ -34,8 +41,7 @@ object VectorSelectorValidation {
             throw IllegalStateException(
                 "Illegal recall selector pair: app.service.core.vector=$vector, " +
                     "app.service.core.embedding=$embedding. Legal pairs: " +
-                    "vector=mock with embedding=mock, vector=simple with embedding=mock, " +
-                    "vector=redis with embedding=mock."
+                    "$legalPairsDescription."
             )
         }
     }

--- a/chat-core/src/main/kotlin/com/demo/chat/config/VectorSelectorValidation.kt
+++ b/chat-core/src/main/kotlin/com/demo/chat/config/VectorSelectorValidation.kt
@@ -19,6 +19,22 @@ object VectorSelectorValidation {
         "embedded" to "mock",
     )
 
+    const val EMBEDDED = "embedded"
+
+    /**
+     * The Vector API is an incubator module. A JVM without
+     * --add-modules jdk.incubator.vector cannot load it. The embedded
+     * vector store then throws NoClassDefFoundError at the first recall,
+     * far from the cause. This check moves that failure to startup.
+     */
+    private fun vectorApiPresent(): Boolean =
+        try {
+            Class.forName("jdk.incubator.vector.FloatVector")
+            true
+        } catch (absent: ClassNotFoundException) {
+            false
+        }
+
     // Derived from legalPairs so the message cannot drift from the set.
     private val legalPairsDescription =
         legalPairs.joinToString(", ") { (vector, embedding) ->
@@ -42,6 +58,17 @@ object VectorSelectorValidation {
                 "Illegal recall selector pair: app.service.core.vector=$vector, " +
                     "app.service.core.embedding=$embedding. Legal pairs: " +
                     "$legalPairsDescription."
+            )
+        }
+
+        // Checked last. An illegal pair is a configuration error and must be
+        // reported as one, whatever this JVM can load.
+        if (vector == EMBEDDED && !vectorApiPresent()) {
+            throw IllegalStateException(
+                "Recall selector app.service.core.vector=embedded needs the Vector API. " +
+                    "The module jdk.incubator.vector is absent from this JVM. " +
+                    "Add --add-modules jdk.incubator.vector to the launch command. " +
+                    "Without it the vector store fails at the first recall, not at startup."
             )
         }
     }

--- a/chat-core/src/test/kotlin/com/demo/chat/test/config/VectorSelectorValidationTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/config/VectorSelectorValidationTests.kt
@@ -45,6 +45,35 @@ class VectorSelectorValidationTests {
     }
 
     @Test
+    fun `embedded vector without embedding fails startup naming both selectors`() {
+        val failure = failureFor(mapOf("app.service.core.vector" to "embedded"))
+
+        assertThat(failure.message)
+            .contains("app.service.core.vector=embedded")
+            .contains("app.service.core.embedding")
+    }
+
+    @Test
+    fun `embedded vector with a reserved embedding fails startup`() {
+        val failure = failureFor(
+            mapOf("app.service.core.vector" to "embedded", "app.service.core.embedding" to "local")
+        )
+
+        assertThat(failure.message).contains("app.service.core.embedding=local")
+    }
+
+    @Test
+    fun `the illegal pair message lists every legal pair`() {
+        val failure = failureFor(
+            mapOf("app.service.core.vector" to "sqlite", "app.service.core.embedding" to "mock")
+        )
+
+        for ((vector, embedding) in LEGAL_PAIRS) {
+            assertThat(failure.message).contains("vector=$vector with embedding=$embedding")
+        }
+    }
+
+    @Test
     fun `both unset starts`() {
         runner(emptyMap()).run { context ->
             assertThat(context).hasNotFailed()
@@ -53,7 +82,7 @@ class VectorSelectorValidationTests {
 
     @Test
     fun `legal pairs start`() {
-        for ((vector, embedding) in listOf("mock" to "mock", "simple" to "mock", "redis" to "mock")) {
+        for ((vector, embedding) in LEGAL_PAIRS) {
             runner(
                 mapOf(
                     "app.service.core.vector" to vector,
@@ -63,6 +92,16 @@ class VectorSelectorValidationTests {
                 assertThat(context).hasNotFailed()
             }
         }
+    }
+
+    private companion object {
+        // Mirrors VectorSelectorValidation.legalPairs. Both must change together.
+        val LEGAL_PAIRS = listOf(
+            "mock" to "mock",
+            "simple" to "mock",
+            "redis" to "mock",
+            "embedded" to "mock",
+        )
     }
 
     private fun runner(properties: Map<String, String>): ApplicationContextRunner =

--- a/chat-core/src/test/kotlin/com/demo/chat/test/config/VectorSelectorValidationTests.kt
+++ b/chat-core/src/test/kotlin/com/demo/chat/test/config/VectorSelectorValidationTests.kt
@@ -74,6 +74,19 @@ class VectorSelectorValidationTests {
     }
 
     @Test
+    fun `embedded fails startup when the Vector API is absent`() {
+        // This module declares no --add-modules jdk.incubator.vector, so the
+        // module is absent here. That is the condition under test.
+        val failure = failureFor(
+            mapOf("app.service.core.vector" to "embedded", "app.service.core.embedding" to "mock")
+        )
+
+        assertThat(failure.message)
+            .contains("jdk.incubator.vector")
+            .contains("--add-modules")
+    }
+
+    @Test
     fun `both unset starts`() {
         runner(emptyMap()).run { context ->
             assertThat(context).hasNotFailed()
@@ -82,7 +95,10 @@ class VectorSelectorValidationTests {
 
     @Test
     fun `legal pairs start`() {
-        for ((vector, embedding) in LEGAL_PAIRS) {
+        // embedded is excluded. This module's test JVM carries no
+        // --add-modules jdk.incubator.vector, so the Vector API check
+        // rejects it. The positive path is proven in chat-deploy-memory.
+        for ((vector, embedding) in LEGAL_PAIRS.filterNot { it.first == "embedded" }) {
             runner(
                 mapOf(
                     "app.service.core.vector" to vector,

--- a/chat-deploy-memory/pom.xml
+++ b/chat-deploy-memory/pom.xml
@@ -32,6 +32,11 @@
         </dependency>
         <dependency>
             <groupId>com.demo</groupId>
+            <artifactId>chat-vector-embedded</artifactId>
+            <version>0.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.demo</groupId>
             <artifactId>chat-persistence-memory</artifactId>
             <version>0.0.1</version>
         </dependency>
@@ -108,6 +113,17 @@
         <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
         <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <!-- The embedded vector provider loads the Vector API in
+                         this module's test JVM. Without the flag the library
+                         throws NoClassDefFoundError on jdk/incubator/vector.
+                         It does not fall back to a scalar path. -->
+                    <argLine>--add-modules jdk.incubator.vector</argLine>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.jetbrains.kotlin</groupId>
                 <artifactId>kotlin-maven-plugin</artifactId>

--- a/chat-deploy-memory/pom.xml
+++ b/chat-deploy-memory/pom.xml
@@ -120,7 +120,7 @@
                     <!-- The embedded vector provider loads the Vector API in
                          this module's test JVM. Without the flag the library
                          throws NoClassDefFoundError on jdk/incubator/vector.
-                         It does not fall back to a scalar path. -->
+                         It does not use a scalar path. -->
                     <argLine>--add-modules jdk.incubator.vector</argLine>
                 </configuration>
             </plugin>

--- a/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryEmbeddedVectorRecallBootTests.kt
+++ b/chat-deploy-memory/src/test/kotlin/com/demo/chat/test/deploy/memory/MemoryEmbeddedVectorRecallBootTests.kt
@@ -1,0 +1,97 @@
+package com.demo.chat.test.deploy.memory
+
+import com.demo.chat.ChatApp
+import com.integrallis.vectors.spring.ai.JavaVectorsVectorStore
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.Test
+import org.springframework.ai.document.Document
+import org.springframework.ai.vectorstore.SearchRequest
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.support.GenericApplicationContext
+import org.springframework.test.context.TestPropertySource
+
+/**
+ * Boots the memory composition root with the embedded vector provider.
+ *
+ * This is the first place the narrow Vector API flag reach is tested. The
+ * incubator flag lives in the chat-vector-embedded module. The store loads
+ * the Vector API inside this module's test JVM, so this module carries the
+ * flag in its own surefire argLine.
+ *
+ * The storage path is unset on purpose. The provider then uses a temporary
+ * directory, which matches the rebuild on failure decision.
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.NONE,
+    classes = [ChatApp::class]
+)
+@TestPropertySource(
+    properties = [
+        "spring.config.additional-location=classpath:/config/logging.yml,classpath:/config/management-defaults.yml,classpath:/config/userinit.yml",
+        "spring.application.name=test-deployment-vector-embedded", "app.server.proto=rsocket",
+        "server.port=0", "spring.rsocket.server.port=0", "app.key.type=long", "app.nodeid=1",
+        "app.service.core.key=memory",
+        "app.service.core.pubsub=memory", "app.service.core.index=lucene", "app.service.core.persistence=memory",
+        "app.service.core.secrets=memory", "app.service.composite", "app.service.composite.auth",
+        "app.service.core.vector=embedded", "app.service.core.embedding=mock",
+        "app.controller.secrets", "app.controller.key", "app.controller.persistence", "app.controller.index",
+        "app.controller.user", "app.controller.message", "app.controller.topic", "app.controller.pubsub",
+        "app.controller.recall",
+        "app.service.security.userdetails"
+    ]
+)
+class MemoryEmbeddedVectorRecallBootTests {
+
+    @Autowired
+    private lateinit var context: GenericApplicationContext
+
+    @Test
+    fun recallServiceIsActive() {
+        Assertions
+            .assertThat(context.containsBean("messageRecallService"))
+            .isTrue
+    }
+
+    @Test
+    fun messageVectorIndexerIsActive() {
+        Assertions
+            .assertThat(context.containsBean("messageVectorIndexer"))
+            .isTrue
+    }
+
+    @Test
+    fun theVectorStoreIsTheEmbeddedProvider() {
+        Assertions
+            .assertThat(context.getBean(VectorStore::class.java))
+            .isInstanceOf(JavaVectorsVectorStore::class.java)
+    }
+
+    /**
+     * Exercises the distance kernels. A bean type check alone never touches
+     * them, so it cannot show that the store works inside this module.
+     */
+    @Test
+    fun theEmbeddedStoreAddsAndRecalls() {
+        val store = context.getBean(VectorStore::class.java)
+        store.add(
+            listOf(
+                Document.builder().id("a").text("apple banana").build(),
+                Document.builder().id("b").text("zebra stripe").build(),
+            )
+        )
+
+        val hits = store.similaritySearch(
+            SearchRequest.builder().query("apple banana").topK(2).build()
+        )
+
+        Assertions.assertThat(hits).isNotNull
+        Assertions.assertThat(hits!!).isNotEmpty
+        Assertions.assertThat(hits.first().id).isEqualTo("a")
+    }
+
+    @Test
+    fun contextLoads() {
+    }
+}

--- a/chat-vector-embedded/pom.xml
+++ b/chat-vector-embedded/pom.xml
@@ -32,6 +32,17 @@
             <artifactId>spring-ai-vector-store</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <!-- This module has no chat-core dependency, so it does not get the
+             Kotlin runtime transitively the way the other providers do. -->
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.demo</groupId>
             <artifactId>chat-core</artifactId>
             <type>test-jar</type>
@@ -46,7 +57,29 @@
     </dependencies>
 
     <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
         <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <configuration>
+                    <args>
+                        <arg>-Xjsr305=strict</arg>
+                    </args>
+                    <!-- The spring plugin opens @Configuration classes and their
+                         @Bean methods. Without it Spring cannot proxy them. -->
+                    <compilerPlugins>
+                        <plugin>spring</plugin>
+                    </compilerPlugins>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jetbrains.kotlin</groupId>
+                        <artifactId>kotlin-maven-allopen</artifactId>
+                        <version>${kotlin.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>

--- a/chat-vector-embedded/src/main/kotlin/com/demo/chat/config/vector/embedded/EmbeddedVectorStoreConfiguration.kt
+++ b/chat-vector-embedded/src/main/kotlin/com/demo/chat/config/vector/embedded/EmbeddedVectorStoreConfiguration.kt
@@ -1,0 +1,78 @@
+package com.demo.chat.config.vector.embedded
+
+import com.integrallis.vectors.core.SimilarityFunction
+import com.integrallis.vectors.db.IndexType
+import com.integrallis.vectors.db.VectorCollection
+import com.integrallis.vectors.spring.ai.JavaVectorsVectorStore
+import org.springframework.ai.embedding.EmbeddingModel
+import org.springframework.ai.vectorstore.VectorStore
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * In-process vector store, backed by the Vectors library.
+ *
+ * The store is a derived cache. The persisted messages are the source of
+ * truth. A lost storage directory is a rebuild, not a data loss, so the
+ * default path is ephemeral and no deployment mounts a volume. Issue
+ * CHAT-oghjsnad tracks the rebuild path, which does not exist yet.
+ *
+ * The index is FLAT with the cosine metric and no quantization. FLAT is
+ * exact and needs no tuning. A measured query over 100000 vectors at topK
+ * 50 costs near 8.3 ms, and the recall API rejects a limit above 50. Move
+ * to HNSW above 100000 vectors in one collection.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "app.service.core", name = ["vector"], havingValue = "embedded")
+class EmbeddedVectorStoreConfiguration {
+
+    /**
+     * The collection holds the vectors and owns the storage directory.
+     *
+     * The dimension comes from the embedding model rather than a property.
+     * A property could disagree with the model, and the collection rejects
+     * a vector of the wrong width only when the first add runs.
+     */
+    @Bean(destroyMethod = "close")
+    fun embeddedVectorCollection(
+        embeddingModel: EmbeddingModel,
+        @Value("\${app.service.core.vector.embedded.path:}") configuredPath: String,
+    ): VectorCollection =
+        VectorCollection.builder()
+            .dimension(embeddingModel.dimensions())
+            .metric(SimilarityFunction.COSINE)
+            .indexType(IndexType.FLAT)
+            .storagePath(storageDirectory(configuredPath))
+            .build()
+
+    @Bean(destroyMethod = "close")
+    fun embeddedVectorStore(
+        embeddingModel: EmbeddingModel,
+        collection: VectorCollection,
+    ): VectorStore =
+        JavaVectorsVectorStore
+            .builder(embeddingModel, collection)
+            .collectionName(COLLECTION_NAME)
+            .commitAfterAdd(true)
+            .build()
+
+    /**
+     * An unset path gives a temporary directory. That matches the rebuild
+     * on failure decision. A set path is created when it does not exist.
+     */
+    private fun storageDirectory(configuredPath: String): Path =
+        if (configuredPath.isBlank()) {
+            Files.createTempDirectory(TEMP_PREFIX)
+        } else {
+            Files.createDirectories(Path.of(configuredPath))
+        }
+
+    companion object {
+        const val COLLECTION_NAME = "messages"
+        const val TEMP_PREFIX = "chat-vector-embedded"
+    }
+}

--- a/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/EmbeddedVectorStoreConfigurationTests.java
+++ b/chat-vector-embedded/src/test/java/com/demo/chat/test/vector/embedded/EmbeddedVectorStoreConfigurationTests.java
@@ -1,0 +1,109 @@
+package com.demo.chat.test.vector.embedded;
+
+import com.demo.chat.config.vector.embedded.EmbeddedVectorStoreConfiguration;
+import com.demo.chat.service.dummy.DummyEmbeddingModel;
+import com.integrallis.vectors.spring.ai.JavaVectorsVectorStore;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.core.env.MapPropertySource;
+
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Mirrors SimpleVectorStoreConfigurationTests, which pins the same three
+ * behaviours for the simple provider.
+ */
+class EmbeddedVectorStoreConfigurationTests {
+
+    private AnnotationConfigApplicationContext context(Map<String, Object> properties) {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        if (!properties.isEmpty()) {
+            context.getEnvironment().getPropertySources()
+                    .addFirst(new MapPropertySource("test", properties));
+        }
+        context.getBeanFactory().registerSingleton("embeddingModel", new DummyEmbeddingModel());
+        context.register(EmbeddedVectorStoreConfiguration.class);
+        context.refresh();
+        return context;
+    }
+
+    @Test
+    void vectorEmbeddedWithEmbeddingMockCreatesTheStoreBean(@TempDir Path storage) {
+        try (AnnotationConfigApplicationContext context = context(Map.of(
+                "app.service.core.vector", "embedded",
+                "app.service.core.vector.embedded.path", storage.toString()))) {
+
+            assertThat(context.getBean(VectorStore.class))
+                    .isInstanceOf(JavaVectorsVectorStore.class);
+        }
+    }
+
+    @Test
+    void vectorSelectorUnsetCreatesNoStoreBean() {
+        try (AnnotationConfigApplicationContext context = context(Map.of())) {
+            assertThat(context.getBeanNamesForType(VectorStore.class)).isEmpty();
+        }
+    }
+
+    @Test
+    void embeddedStoreStoresAndRecallsMessageDocuments(@TempDir Path storage) {
+        try (AnnotationConfigApplicationContext context = context(Map.of(
+                "app.service.core.vector", "embedded",
+                "app.service.core.vector.embedded.path", storage.toString()))) {
+
+            VectorStore store = context.getBean(VectorStore.class);
+            store.add(List.of(
+                    Document.builder().id("a").text("apple banana")
+                            .metadata(Map.of("kind", "message")).build(),
+                    Document.builder().id("b").text("zebra stripe")
+                            .metadata(Map.of("kind", "message")).build()));
+
+            List<Document> hits = store.similaritySearch(
+                    SearchRequest.builder().query("apple banana").topK(2).build());
+
+            assertThat(hits).isNotNull();
+            assertThat(hits).isNotEmpty();
+            assertThat(hits.get(0).getId()).isEqualTo("a");
+            assertThat(hits.get(0).getScore()).isNotNull();
+        }
+    }
+
+    @Test
+    void unsetPathStillCreatesAWorkingStore() {
+        try (AnnotationConfigApplicationContext context = context(Map.of(
+                "app.service.core.vector", "embedded"))) {
+
+            VectorStore store = context.getBean(VectorStore.class);
+            store.add(List.of(Document.builder().id("a").text("apple banana").build()));
+
+            List<Document> hits = store.similaritySearch(
+                    SearchRequest.builder().query("apple banana").topK(1).build());
+
+            assertThat(hits).isNotEmpty();
+        }
+    }
+
+    @Test
+    void dimensionComesFromTheEmbeddingModel(@TempDir Path storage) {
+        try (AnnotationConfigApplicationContext context = context(Map.of(
+                "app.service.core.vector", "embedded",
+                "app.service.core.vector.embedded.path", storage.toString()))) {
+
+            VectorStore store = context.getBean(VectorStore.class);
+            // DummyEmbeddingModel declares 256. A collection built at another
+            // width rejects the add, so a successful add pins the wiring.
+            store.add(List.of(Document.builder().id("a").text("apple banana").build()));
+
+            assertThat(context.getBean(com.integrallis.vectors.db.VectorCollection.class).size())
+                    .isEqualTo(1);
+        }
+    }
+}

--- a/docs/superpowers/specs/2026-09-01-message-vector-recall-design.md
+++ b/docs/superpowers/specs/2026-09-01-message-vector-recall-design.md
@@ -463,3 +463,19 @@ The issue must cover:
 - Retry.
 - Compensation.
 - Repair.
+
+Issue `CHAT-oghjsnad` records the vector reindex path. It is scheduled for a
+following sprint.
+
+This spec lists message repair and reindex jobs under Out Of Scope. That stays
+true for this sprint. The embedded provider added later made the gap concrete:
+the store is a derived cache on ephemeral storage, so a lost storage directory
+must be rebuilt from the persisted messages.
+
+No rebuild path exists today. `MessageVectorIndexer` declares `add` and `remove`
+only. A lost index makes recall return fewer hits. It does not throw and it does
+not warn, so a caller cannot tell an empty result from a lost index.
+
+This is safe while recall stays test only. It is not safe once recall serves
+users. Check `CHAT-oghjsnad` against `CHAT-ruduojeu` before starting, because
+that issue already names repair.

--- a/docs/superpowers/specs/2026-09-01-message-vector-recall-design.md
+++ b/docs/superpowers/specs/2026-09-01-message-vector-recall-design.md
@@ -235,6 +235,7 @@ Vector values:
 - `mock`: tests only.
 - `simple`: local and integration tests.
 - `redis`: shared runtime.
+- `embedded`: in-process store, added after this sprint. See below.
 
 Embedding values:
 
@@ -258,11 +259,21 @@ Legal matrix:
 | `mock` | `mock` | unit tests only |
 | `simple` | `mock` | local integration tests |
 | `redis` | `mock` | shared runtime integration tests |
+| `embedded` | `mock` | in-process store, added after this sprint |
 | `redis` | `gateway` | reserved future pair |
 
 The reserved future pair fails at startup in this sprint.
 
 All other pairs fail at startup.
+
+The `embedded` pair was added after this sprint, with the Vectors library.
+`VectorSelectorValidation` holds the authoritative set. This table must match it.
+
+The `embedded` pair carries one extra condition. The Vectors library needs the
+Vector API, which is an incubator module. A JVM without
+`--add-modules jdk.incubator.vector` cannot load it. `VectorSelectorValidation`
+therefore rejects `embedded` at startup on such a JVM. Without that check the
+store throws `NoClassDefFoundError` at the first recall, far from the cause.
 
 This sprint implements:
 


### PR DESCRIPTION
Issues `CHAT-zsnzesqp`, `CHAT-sbpqlmki`, `CHAT-imnzrkci`, `CHAT-zmrthqio`.

This change wires the embedded vector provider for its selector.

## Commits

| Commit | Issue | Change |
|--------|-------|--------|
| `d2bfa132` | `CHAT-zsnzesqp` | Add `EmbeddedVectorStoreConfiguration` for `app.service.core.vector=embedded` |
| `21e0145b` | | Record the vector reindex follow-up in the design spec |
| `ff3e48fd` | `CHAT-sbpqlmki`, `CHAT-imnzrkci` | Accept the `embedded` pair. Boot it in the memory composition root |
| `ef4a4ea7` | `CHAT-zmrthqio` | Reject `embedded` at startup when the Vector API is absent |

## Index choice

The index is FLAT. The metric is cosine. There is no quantization.

The choice is measured. The table shows FLAT on this hardware at 256 dimensions and topK 50.

| Vectors | Build | Query |
|---------|-------|-------|
| 1000 | 62 ms | 0.165 ms |
| 10000 | 96 ms | 0.937 ms |
| 100000 | 541 ms | 8.295 ms |

`RecallRequestValidation` rejects a limit above 50. So topK 50 is the worst case, and the table measures it.

FLAT is exact. It needs no tuning. Query cost grows with collection size. Change to HNSW above 100000 vectors in one collection.

Issue `CHAT-xiruozdh` holds the full record.

## Storage choice

The store is a derived cache. The persisted messages are the authoritative data. A lost storage directory is a rebuild.

So the default path is a temporary directory. Container storage is ephemeral. No deployment mounts a volume.

This also closes the `app.nodeid` question. Two instances cannot share one memory mapped file, because each instance holds its own.

Issue `CHAT-spohupjd` holds the full record.

## Three choices the tasks did not name

1. The dimension comes from `embeddingModel.dimensions()`. It does not come from a property. A property can disagree with the model. The collection rejects a wrong width only at the first add.
2. Both beans declare `destroyMethod = "close"`. `VectorCollection` and `JavaVectorsVectorStore` are `AutoCloseable`. Without this the memory mapped file outlives the context.
3. `chat-vector-embedded` declares `kotlin-stdlib`. The module has no `chat-core` dependency, so it does not inherit the Kotlin runtime.

The illegal pair message is derived from `legalPairs`. The prose cannot drift from the set. One test asserts the message lists every legal pair.

## A defect the boot test found

The first boot test asserted the bean type only. It passed. No provider log appeared, because a type check never touches the distance kernels.

The test then added a real `add` and `similaritySearch`. It failed.

```
java.lang.NoClassDefFoundError: jdk/incubator/vector/FloatVector
  at com.integrallis.vectors.core.PanamaConstants.<clinit>
  at com.integrallis.vectors.core.VectorizationProvider.buildToggleSummary
  at com.integrallis.vectors.core.VectorizationProvider.selectProvider
```

The library logs `provider panama unavailable, trying next`. It then fails inside its own error logging, because that path reads `PanamaConstants`.

There is no scalar path. A missing flag is a hard failure.

`chat-deploy-memory` therefore carries `--add-modules jdk.incubator.vector` in its surefire `argLine`. The log then reads `Using Panama Vector API SIMD provider (vector bits: 128)`.

## The startup check

Review found a real problem. The `embedded` pair became legal before any runtime carries the flag. A deployment could set it and fail at the first recall.

`VectorSelectorValidation` now checks for `jdk.incubator.vector` when the vector selector is `embedded`. A JVM without the module fails at startup. The message names the flag to add.

The check runs after the legal pair check. An illegal pair stays a configuration error.

Both directions are proven. `chat-core` has no flag, so it rejects `embedded` at startup. `chat-deploy-memory` has the flag, so it boots and recalls.

## Open work

Issue `CHAT-zmrthqio` remains open. The flag still reaches no runtime path. It is absent from `shell-scripts/chat-build`, every file under `shell-scripts/golden`, the image `BPE_APPEND_JAVA_TOOL_OPTIONS`, and the `native-maven-plugin` `buildArgs`.

The startup check makes that state safe. A deployment now fails at startup with a clear message. It no longer fails at the first recall.

Issue `CHAT-oghjsnad` records the vector reindex path for a following sprint. No rebuild path exists today. The design spec records the same.

## Verification

Default mode on GraalVM CE 25 passes. 35 modules, 552 tests, 0 failures, 0 errors, 30 skipped.

`drift check` passes.

The CI integration job fails on this branch. The failure is one error in `TypedKeyValueStoreTests` in `chat-persistence-cassandra`. This branch changes nothing in that module.

Master fails the same job on the base commit `5581f1ce`, with 15 errors across 7 classes in the same module. The failure on this branch is a subset of that.

The cause is a 2 second Cassandra query timeout in test setup. Three consecutive master runs read failure, success, failure. Issue `CHAT-sgyaaivp` records the evidence and the fix.

