### PR TITLE
fix: send the Vector API flag to runtime paths

### DIFF
--- a/chat-authorization-server/pom.xml
+++ b/chat-authorization-server/pom.xml
@@ -42,6 +42,7 @@
                         <configuration>
                             <buildArgs>
                                 <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                                <buildArg>${vector.api.module.flag}</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/chat-deploy-memory-integration-test/pom.xml
+++ b/chat-deploy-memory-integration-test/pom.xml
@@ -51,6 +51,7 @@
                                 <cleanCache>true</cleanCache>
                                 <env>
                                     <BPE_APPEND_JAVA_TOOL_OPTIONS>--enable-native-access=ALL-UNNAMED
+${vector.api.module.flag}
 -Dspring.application.name=chat-integration-test
 -Dspring.profiles.active=prod -Dserver.port=6791
 -Dspring.rsocket.server.ssl.enabled=false

--- a/chat-deploy-redis/build-core.sh
+++ b/chat-deploy-redis/build-core.sh
@@ -10,7 +10,7 @@ export APP_VERSION=0.0.1
 
 # makes no use of cloud configuration or config-maps
 # TODO: difference between '-D' and '--'
-export JAVA_TOOL_OPTIONS=" --enable-native-access=ALL-UNNAMED -Dspring.profiles.active=${SPRING_PROFILE} \
+export JAVA_TOOL_OPTIONS=" --enable-native-access=ALL-UNNAMED --add-modules=jdk.incubator.vector -Dspring.profiles.active=${SPRING_PROFILE} \
 -Dserver.port=$((CORE_PORT+1)) -Dspring.rsocket.server.port=${CORE_PORT} \
 -Dapp.service.core.pubsub=redis-pubsub \
 -Dapp.service.edge.topic \

--- a/chat-deploy/pom.xml
+++ b/chat-deploy/pom.xml
@@ -27,6 +27,7 @@
                         <configuration>
                             <buildArgs>
                                 <buildArg>--enable-native-access=ALL-UNNAMED</buildArg>
+                                <buildArg>${vector.api.module.flag}</buildArg>
                             </buildArgs>
                         </configuration>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
         <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud-bom.version>2025.0.3</spring-cloud-bom.version>
         <datastax-java-driver.version>4.17.0</datastax-java-driver.version>
+        <vector.api.module.flag>--add-modules=jdk.incubator.vector</vector.api.module.flag>
         <!-- Overridden to empty by -Pintegration. See maven-surefire-plugin below. -->
         <excluded.test.groups>integration</excluded.test.groups>
     </properties>
@@ -213,6 +214,7 @@
                                 <cleanCache>false</cleanCache>
                                 <env>
                                     <BPE_APPEND_JAVA_TOOL_OPTIONS>${env.JAVA_TOOL_OPTIONS}
+                                        ${vector.api.module.flag}
                                     </BPE_APPEND_JAVA_TOOL_OPTIONS>
                                     <BP_JVM_VERSION>${java.version}</BP_JVM_VERSION>
                                 </env>

--- a/shell-scripts/chat-build
+++ b/shell-scripts/chat-build
@@ -312,6 +312,7 @@ RSOCKET_SERVER_AUTOCONFIG_EXCLUDE = (
     "org.springframework.boot.autoconfigure.rsocket.RSocketServerAutoConfiguration"
 )
 NATIVE_ACCESS_FLAG = "--enable-native-access=ALL-UNNAMED"
+VECTOR_API_MODULE_FLAG = "--add-modules=jdk.incubator.vector"
 
 COMMON_FEATURES = ["local", "consul", "long", "uuid", "websocket", "debug"]
 
@@ -593,6 +594,7 @@ class BuildContext:
     def main_flags(self) -> list[str]:
         flags = [
             NATIVE_ACCESS_FLAG,
+            VECTOR_API_MODULE_FLAG,
             f"-Dspring.profiles.active={','.join(self.spring_profiles())}",
         ]
         flags += self.endpoint_flags()

--- a/shell-scripts/golden/authserv-client.flags
+++ b/shell-scripts/golden/authserv-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,jdbc
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket

--- a/shell-scripts/golden/core-build-image.flags
+++ b/shell-scripts/golden/core-build-image.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-cassandra.flags
+++ b/shell-scripts/golden/core-cassandra.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-debug.flags
+++ b/shell-scripts/golden/core-debug.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-e2ee.flags
+++ b/shell-scripts/golden/core-e2ee.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,e2ee,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-kafka.flags
+++ b/shell-scripts/golden/core-kafka.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-memory-consul.flags
+++ b/shell-scripts/golden/core-memory-consul.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket,register-consul
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-memory-init.flags
+++ b/shell-scripts/golden/core-memory-init.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-memory-tls.flags
+++ b/shell-scripts/golden/core-memory-tls.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-redis.flags
+++ b/shell-scripts/golden/core-redis.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-uuid.flags
+++ b/shell-scripts/golden/core-uuid.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/core-websocket.flags
+++ b/shell-scripts/golden/core-websocket.flags
@@ -1,4 +1,5 @@
 # profiles: deploy,expose-rsocket
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.controller.index
 -Dapp.controller.key

--- a/shell-scripts/golden/gateway-client.flags
+++ b/shell-scripts/golden/gateway-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,expose-gateway
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.key.type=long
 -Dapp.kv.store=none

--- a/shell-scripts/golden/rest-client.flags
+++ b/shell-scripts/golden/rest-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,expose-webflux
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket

--- a/shell-scripts/golden/shell-client.flags
+++ b/shell-scripts/golden/shell-client.flags
@@ -1,4 +1,5 @@
 # profiles: client-backend,deploy,shell
+--add-modules=jdk.incubator.vector
 --enable-native-access=ALL-UNNAMED
 -Dapp.client.discovery=properties
 -Dapp.client.protocol=rsocket


### PR DESCRIPTION
Issue CHAT-zmrthqio.

This change sends the Vector API module flag to runtime paths.

The launcher now adds --add-modules=jdk.incubator.vector to JAVA_TOOL_OPTIONS.

All launcher golden files now include that flag.

Buildpack images now receive the same flag from the parent POM.

The memory integration image receives the flag from the shared property.

Native build profiles receive the same flag.

The legacy Redis build script receives the same flag.

Verification:

- shell-scripts/test-flags.sh passed with all 15 cases.
- mvn -q -pl chat-deploy-memory-integration-test validate -DskipTests passed.
- git diff --check passed.
- drift check passed.

I did not run full build-health or integration mode.