### PR TITLE
build: remove the jvmTarget 1.8 pin in chat-index-elastic

### DIFF
--- a/chat-index-elastic/pom.xml
+++ b/chat-index-elastic/pom.xml
@@ -125,7 +125,6 @@
                     <compilerPlugins>
                         <plugin>spring</plugin>
                     </compilerPlugins>
-                    <jvmTarget>1.8</jvmTarget>
                 </configuration>
                 <dependencies>
                     <dependency>


### PR DESCRIPTION
Issue `CHAT-ixazwico`. One commit.

This change removes the `jvmTarget` pin in `chat-index-elastic`.

## The defect

The module set `<jvmTarget>1.8</jvmTarget>`. It was the only pom in the repo that set `jvmTarget`. Every other module takes the value from `java.version` through the Spring Boot parent.

The pin was not only an inconsistency. It changed the output.

The module emitted class files with major version 52. That is Java 8. The build targets Java 25, and every other module emits major version 69.

So one module has been producing Java 8 bytecode inside a Java 25 build.

## Proof

Before the change, on `chat-index-elastic/target/classes`:

```
major version: 52
```

After the change, same class:

```
major version: 69
```

No pom in the repo now sets `jvmTarget`.

## How it survived

`java.version` moved 17 to 25 in PR #65. The Kotlin compiler accepted the mismatch and reported nothing. Only reading the class file shows it.

The pin predates the JDK move. It was found while raising `java.version`, and recorded then rather than fixed, because the build passed either way.

## Verification

Integration mode passes. 35 modules, 28 containers, 754 tests, 0 failures, 0 errors, 52 skipped.

`drift check` passes.
