### PR TITLE
build: remove the inline dependency pins that sit below the Boot BOM

### DIFF
--- a/chat-authorization-server/pom.xml
+++ b/chat-authorization-server/pom.xml
@@ -23,8 +23,7 @@
             <dependencies>
                 <dependency>
                     <groupId>org.postgresql</groupId>
-                    <artifactId>postgresql</artifactId>
-                    <version>42.6.0</version> <!-- use the latest version -->
+                    <artifactId>postgresql</artifactId> <!-- use the latest version -->
                 </dependency>
                 <dependency>
                     <groupId>org.springframework.boot</groupId>

--- a/chat-client-consul/pom.xml
+++ b/chat-client-consul/pom.xml
@@ -65,13 +65,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>consul</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat-core/pom.xml
+++ b/chat-core/pom.xml
@@ -19,7 +19,6 @@
 		<dependency>
 			<groupId>org.jetbrains.kotlinx</groupId>
 			<artifactId>kotlinx-serialization-json</artifactId>
-			<version>${serialization.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -103,7 +102,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.5</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>

--- a/chat-deploy-cassandra/pom.xml
+++ b/chat-deploy-cassandra/pom.xml
@@ -66,14 +66,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>cassandra</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chat-deploy-redis/pom.xml
+++ b/chat-deploy-redis/pom.xml
@@ -130,13 +130,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <!-- The chat-core test jar carries the mock embedding model and the
@@ -156,7 +154,6 @@
         <dependency>
             <groupId>com.redis</groupId>
             <artifactId>testcontainers-redis</artifactId>
-            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat-deploy/pom.xml
+++ b/chat-deploy/pom.xml
@@ -144,7 +144,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.14.2</version>
         </dependency>
     </dependencies>
 

--- a/chat-index-cassandra/pom.xml
+++ b/chat-index-cassandra/pom.xml
@@ -23,22 +23,21 @@
 		<dependency>
 			<groupId>com.datastax.oss</groupId>
 			<artifactId>java-driver-core</artifactId>
-			<version>${datastax-java-driver.version}</version>
+            <version>${datastax-java-driver.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.datastax.oss</groupId>
 			<artifactId>java-driver-query-builder</artifactId>
-			<version>${datastax-java-driver.version}</version>
+            <version>${datastax-java-driver.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.datastax.oss</groupId>
 			<artifactId>java-driver-mapper-runtime</artifactId>
-			<version>${datastax-java-driver.version}</version>
+            <version>${datastax-java-driver.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.datastax.oss</groupId>
 			<artifactId>native-protocol</artifactId>
-			<version>1.5.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -97,7 +96,6 @@
 		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter</artifactId>
-			<version>2.2.0.RC1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/chat-index-elastic/pom.xml
+++ b/chat-index-elastic/pom.xml
@@ -31,14 +31,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>elasticsearch</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
 

--- a/chat-index-lucene/pom.xml
+++ b/chat-index-lucene/pom.xml
@@ -75,7 +75,6 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
 			<artifactId>jackson-module-kotlin</artifactId>
-			<version>2.9.7</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.module</groupId>
@@ -92,7 +91,6 @@
 		<dependency>
 			<groupId>io.projectreactor</groupId>
 			<artifactId>reactor-core</artifactId>
-			<version>3.3.0.RELEASE</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>
@@ -108,7 +106,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.5</version>
             <scope>compile</scope>
         </dependency>
 		<dependency>

--- a/chat-messaging-kafka/pom.xml
+++ b/chat-messaging-kafka/pom.xml
@@ -63,7 +63,6 @@
 		<dependency>
 			<groupId>org.jetbrains.kotlinx</groupId>
 			<artifactId>kotlinx-serialization-json</artifactId>
-			<version>${serialization.version}</version>
 		</dependency>
 
 		<!-- Reactor -->

--- a/chat-messaging-memory/pom.xml
+++ b/chat-messaging-memory/pom.xml
@@ -30,7 +30,6 @@
 		<dependency>
 			<groupId>org.jetbrains.kotlinx</groupId>
 			<artifactId>kotlinx-serialization-json</artifactId>
-			<version>${serialization.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -114,7 +113,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.5</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/chat-persistence-cassandra/pom.xml
+++ b/chat-persistence-cassandra/pom.xml
@@ -72,13 +72,11 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>cassandra</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chat-persistence-memory/pom.xml
+++ b/chat-persistence-memory/pom.xml
@@ -30,7 +30,6 @@
 		<dependency>
 			<groupId>org.jetbrains.kotlinx</groupId>
 			<artifactId>kotlinx-serialization-json</artifactId>
-			<version>${serialization.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
@@ -114,7 +113,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.5</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/chat-persistence-redis/pom.xml
+++ b/chat-persistence-redis/pom.xml
@@ -36,14 +36,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chat-persistence-xstream/pom.xml
+++ b/chat-persistence-xstream/pom.xml
@@ -36,14 +36,12 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.testcontainers/junit-jupiter -->
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chat-service-composite/pom.xml
+++ b/chat-service-composite/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>6.0.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chat-shell/pom.xml
+++ b/chat-shell/pom.xml
@@ -151,7 +151,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-cbor</artifactId>
-            <version>2.9.5</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/chat-vector-redis/pom.xml
+++ b/chat-vector-redis/pom.xml
@@ -59,7 +59,6 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.21.4</version>
             <scope>test</scope>
         </dependency>
         <!-- Redis's own testcontainers module, as Spring AI 1.0.3's
@@ -69,7 +68,6 @@
         <dependency>
             <groupId>com.redis</groupId>
             <artifactId>testcontainers-redis</artifactId>
-            <version>2.2.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat-webflux/pom.xml
+++ b/chat-webflux/pom.xml
@@ -79,7 +79,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>6.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -21,9 +21,11 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <java.version>25</java.version>
         <kotlin.version>2.4.10</kotlin.version>
-        <serialization.version>1.6.3</serialization.version>
         <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud-bom.version>2025.0.3</spring-cloud-bom.version>
+        <!-- Not managed by the Boot BOM. The driver moved to the
+             org.apache.cassandra groupId at 4.19, and these poms still
+             use com.datastax.oss. See CHAT issue for the migration. -->
         <datastax-java-driver.version>4.17.0</datastax-java-driver.version>
         <vector.api.module.flag>--add-modules=jdk.incubator.vector</vector.api.module.flag>
         <!-- Overridden to empty by -Pintegration. See maven-surefire-plugin below. -->


### PR DESCRIPTION
Issue `CHAT-hcgmcuxp`. One commit. Build configuration only. No source file changes.

This change removes inline dependency version pins where the Spring Boot BOM already manages the artifact.

## Why

Wave 1 removed five downward version overrides under `CHAT-onzqrqox`. That audit read the properties block only. These pins are version elements inside dependency declarations, so it never saw them.

Four of them sat below the managed version. One sat twelve minor versions below.

## What moved

Removed from 19 poms. Each version below is the resolved version, read from a dependency tree before and after.

| Artifact | Before | After |
|----------|--------|-------|
| `jackson-dataformat-cbor` | 2.9.5 | 2.21.4 |
| `jackson-module-kotlin` | 2.9.7 | 2.21.4 |
| `reactor-core` | 3.3.0.RELEASE | 3.7.19 |
| `spring-security-test` | 6.0.2 | 6.5.11 |
| `native-protocol` | 1.5.1 | 1.5.2, now transitive |
| `jackson-dataformat-yaml` | 2.14.2 | managed |
| `postgresql` | 42.6.0 | managed |
| `spring-cloud-starter` | 2.2.0.RC1 | managed |
| `testcontainers-redis` | 2.2.0 | managed |
| `testcontainers` and its modules | 1.21.4 | 1.21.4, so the pin was redundant |

The root pom loses `serialization.version`. It held 1.6.3 and the Boot BOM manages 1.6.3, so it was redundant. Nothing referenced it after the dependency change.

## The one that matters most

`jackson-dataformat-cbor` was pinned at 2.9.5 in five modules: `chat-core`, `chat-shell`, `chat-index-lucene`, `chat-messaging-memory` and `chat-persistence-memory`. Only `chat-messaging-kafka` declared it without a version.

`chat-core` was one of the five, so the old version reached every module that depends on `chat-core`.

Jackson sits on a serialization path. Treat the gap as security relevant, not only as currency.

## How these were found

Maven found them. A reading of the poms did not.

```
mvn -B dependency:tree -Dverbose -Dincludes=':::' | grep 'omitted for conflict'
```

That output names every place a local version beat a higher one. It is how `reactor-core` at 3.3.0.RELEASE was found beating the managed 3.7.19.

The verbose tree still reports 106 conflicts across the reactor. Most are transitive and belong to no pom here. Issue `CHAT-mgtbicsq` holds that work.

## One pin stays

The Cassandra driver keeps its pin, with a comment that names the reason.

The Boot BOM imports `org.apache.cassandra:java-driver-bom` and manages the driver at 4.19.3. These poms declare `com.datastax.oss:java-driver-*`, which the BOM does not manage. The driver changed groupId at 4.19, so the old coordinates stop at 4.17.

Removing the pin fails the build:

```
dependencies.dependency.version for com.datastax.oss:java-driver-core:jar is missing
```

Issue `CHAT-pjyvoeil` holds the groupId migration. That is the change which lets the pin go.

## Verification

Default mode: 35 modules pass, 552 tests, 0 failures, 0 errors, 30 skipped.

Integration mode: 35 modules pass, 28 containers start, 754 tests, 0 failures, 0 errors, 52 skipped.

`drift check` passes.

## Dependabot

Pull request #10 raises `jackson-dataformat-cbor` from 2.9.5 to 2.11.4 in one module. This change gives 2.21.4 in all five. Close #10 in favour of this.

Pull request #11 raises `postgresql` from 42.6.0. This change removes that pin, so the artifact now follows the BOM. Check #11 after this merges.

## A note for anyone running this locally

A scoped Maven run can cache a failed lookup of a `com.demo` artifact and then fail on later runs, with an error that names `repo.spring.io` rather than the real cause. Clear it and use the full reactor:

```
find ~/.m2/repository/com/demo -name '*.lastUpdated' -delete
mvn -B clean verify -Pintegration
```

## Follow-up recorded

- `CHAT-pjyvoeil`. Migrate the Cassandra driver to the `org.apache.cassandra` groupId.
- `CHAT-mgtbicsq`. Dependency version governance. One central point for versions, plus the tools that report which upgrades are safe and which are mandatory.
