### PR TITLE
build: move the Cassandra driver to the org.apache.cassandra groupId

### DIFF
--- a/chat-index-cassandra/pom.xml
+++ b/chat-index-cassandra/pom.xml
@@ -21,19 +21,16 @@
 			<version>0.0.1</version>
 		</dependency>
 		<dependency>
-			<groupId>com.datastax.oss</groupId>
+			<groupId>org.apache.cassandra</groupId>
 			<artifactId>java-driver-core</artifactId>
-            <version>${datastax-java-driver.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.datastax.oss</groupId>
+			<groupId>org.apache.cassandra</groupId>
 			<artifactId>java-driver-query-builder</artifactId>
-            <version>${datastax-java-driver.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>com.datastax.oss</groupId>
+			<groupId>org.apache.cassandra</groupId>
 			<artifactId>java-driver-mapper-runtime</artifactId>
-            <version>${datastax-java-driver.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.datastax.oss</groupId>

--- a/chat-persistence-cassandra/pom.xml
+++ b/chat-persistence-cassandra/pom.xml
@@ -21,19 +21,16 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.datastax.oss</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>java-driver-core</artifactId>
-            <version>${datastax-java-driver.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.datastax.oss</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>java-driver-query-builder</artifactId>
-            <version>${datastax-java-driver.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.datastax.oss</groupId>
+            <groupId>org.apache.cassandra</groupId>
             <artifactId>java-driver-mapper-runtime</artifactId>
-            <version>${datastax-java-driver.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,10 +23,6 @@
         <kotlin.version>2.4.10</kotlin.version>
         <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud-bom.version>2025.0.3</spring-cloud-bom.version>
-        <!-- Not managed by the Boot BOM. The driver moved to the
-             org.apache.cassandra groupId at 4.19, and these poms still
-             use com.datastax.oss. See CHAT issue for the migration. -->
-        <datastax-java-driver.version>4.17.0</datastax-java-driver.version>
         <vector.api.module.flag>--add-modules=jdk.incubator.vector</vector.api.module.flag>
         <!-- Overridden to empty by -Pintegration. See maven-surefire-plugin below. -->
         <excluded.test.groups>integration</excluded.test.groups>


### PR DESCRIPTION
Issue `CHAT-pjyvoeil`. One commit. Build configuration only. No source file changes.

This change moves the Cassandra driver to the groupId that Spring Boot manages.

## Why

The DataStax driver changed groupId at version 4.19. The old `com.datastax.oss` coordinates stop at 4.17.

Spring Boot 3.5.16 imports `org.apache.cassandra:java-driver-bom` and manages the driver at 4.19.3. While the poms used the old groupId, the BOM could not manage them, so the project carried a pin and could not reach a current version.

PR #73 removed inline pins across 19 poms. This pin was the one it could not remove. Taking it out failed the build:

```
dependencies.dependency.version for com.datastax.oss:java-driver-core:jar is missing
```

That failure is what identified the groupId as the real blocker.

## What moved

| Artifact | Before | After |
|----------|--------|-------|
| `java-driver-core` | `com.datastax.oss` 4.17.0 | `org.apache.cassandra` 4.19.3 |
| `java-driver-query-builder` | `com.datastax.oss` 4.17.0 | `org.apache.cassandra` 4.19.3 |
| `java-driver-mapper-runtime` | `com.datastax.oss` 4.17.0 | `org.apache.cassandra` 4.19.3 |

Affected poms: `chat-index-cassandra` and `chat-persistence-cassandra`.

The root pom loses the `datastax-java-driver.version` property. No pom pins the driver now.

## One artifact did not move

`native-protocol` keeps the `com.datastax.oss` groupId. Only the `java-driver` artifacts moved to Apache.

The `java-driver-bom` at 4.19.3 manages `native-protocol` at 1.5.2, and it does so under the old groupId. A blanket groupId change therefore breaks the build:

```
dependencies.dependency.version for org.apache.cassandra:native-protocol:jar is missing
```

The declaration in `chat-index-cassandra` keeps `com.datastax.oss` and carries no version. It resolves at 1.5.2 from the BOM.

## No source change

The driver kept its `com.datastax.oss.driver` package names when it moved to Apache. Only the Maven coordinates changed, so no import statement changes.

## Verification

Default mode: 35 modules pass, 552 tests, 0 failures, 0 errors, 30 skipped.

Integration mode: 35 modules pass, 28 containers start, 754 tests, 0 failures, 0 errors, 52 skipped.

The Cassandra container tests are the proof for this change, and they ran.

## Reading a red CI run

The CI integration job fails intermittently in `chat-persistence-cassandra`, on the same code, with a two second query timeout in test setup. Issue `CHAT-sgyaaivp` records three consecutive master runs that read failure, success, failure.

A red run on this branch is therefore ambiguous by default. Compare the failing test set against a master run before reading it as a driver problem. The local integration run above passed with all 28 containers.

## Follow-up

`CHAT-mgtbicsq` holds the remaining work. A verbose dependency tree still reports 106 conflicts across the reactor, and no rule yet stops a new pin from appearing.
