### PR TITLE
build: give versions one central point and add a guard

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,67 @@
+# Reports known vulnerabilities in the dependency tree.
+#
+# This runs on a schedule, not on every push. OWASP dependency-check downloads
+# the National Vulnerability Database on its first run, which is large and
+# slow. A per-push run would add several minutes to every build for a report
+# that changes only when the NVD data changes.
+#
+# The job does not fail the build on a finding. Read the report, then decide.
+# A failing threshold can come later, once the current findings are known.
+#
+# Issue: CHAT-mgtbicsq
+name: dependency audit
+
+on:
+  schedule:
+    # 05:00 UTC each day, after the NVD publishes.
+    - cron: '0 5 * * *'
+  workflow_dispatch:
+
+jobs:
+  owasp:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          java-version: '25'
+          distribution: 'temurin'
+
+      - name: Cache Maven packages
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.m2/repository
+            ~/.m2/wrapper
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+
+      # The NVD data is the slow part. Keep it between runs.
+      - name: Cache the NVD data
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository/org/owasp/dependency-check-data
+          key: ${{ runner.os }}-nvd-${{ github.run_id }}
+          restore-keys: ${{ runner.os }}-nvd-
+
+      - name: Run OWASP dependency-check
+        # An NVD API key raises the download rate limit. Without it the first
+        # run is slow but still completes. Set NVD_API_KEY in repository
+        # secrets to speed it up.
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        run: >
+          mvn -B org.owasp:dependency-check-maven:aggregate
+          -DfailBuildOnCVSS=11
+          -DnvdApiKey="$NVD_API_KEY"
+          -DskipTests
+
+      - name: Upload the report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dependency-check-report
+          path: target/dependency-check-report.html
+          if-no-files-found: warn

--- a/chat-core/pom.xml
+++ b/chat-core/pom.xml
@@ -28,13 +28,11 @@
 			<dependency>
 				<groupId>org.mockito.kotlin</groupId>
 				<artifactId>mockito-kotlin</artifactId>
-				<version>4.1.0</version>
 				<scope>test</scope>
 			</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-			<version>${spring-boot.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/chat-crypto/pom.xml
+++ b/chat-crypto/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/chat-deploy-e2ee/pom.xml
+++ b/chat-deploy-e2ee/pom.xml
@@ -40,7 +40,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/chat-index-cassandra/pom.xml
+++ b/chat-index-cassandra/pom.xml
@@ -39,7 +39,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-cassandra-reactive</artifactId>
-			<version>${spring-boot.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.jetbrains.kotlin</groupId>
@@ -76,7 +75,6 @@
 		<dependency>
 			<groupId>com.playtika.testcontainers</groupId>
 			<artifactId>embedded-cassandra</artifactId>
-			<version>2.2.14</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/chat-index-elastic/pom.xml
+++ b/chat-index-elastic/pom.xml
@@ -75,12 +75,10 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib-jdk8</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-test</artifactId>
-            <version>${kotlin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat-index-lucene/pom.xml
+++ b/chat-index-lucene/pom.xml
@@ -30,35 +30,25 @@
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-memory</artifactId>
-			<version>8.7.0</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/org.apache.lucene/lucene-analyzers -->
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-analyzers-common</artifactId>
-			<version>8.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-queryparser</artifactId>
-			<version>8.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.lucene</groupId>
 			<artifactId>lucene-core</artifactId>
-			<version>8.7.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-			<dependency>
-				<groupId>com.nhaarman.mockitokotlin2</groupId>
-				<artifactId>mockito-kotlin</artifactId>
-				<version>2.2.0</version>
-				<scope>test</scope>
-			</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>

--- a/chat-messaging-kafka/pom.xml
+++ b/chat-messaging-kafka/pom.xml
@@ -115,12 +115,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.nhaarman.mockitokotlin2</groupId>
-			<artifactId>mockito-kotlin</artifactId>
-			<version>2.2.0</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.awaitility</groupId>
 			<artifactId>awaitility</artifactId>
 			<scope>test</scope>

--- a/chat-messaging-memory/pom.xml
+++ b/chat-messaging-memory/pom.xml
@@ -36,16 +36,9 @@
 			<artifactId>junit-jupiter-engine</artifactId>
 			<scope>test</scope>
 		</dependency>
-			<dependency>
-				<groupId>com.nhaarman.mockitokotlin2</groupId>
-				<artifactId>mockito-kotlin</artifactId>
-				<version>2.2.0</version>
-				<scope>test</scope>
-			</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-			<version>${spring-boot.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/chat-persistence-memory/pom.xml
+++ b/chat-persistence-memory/pom.xml
@@ -39,13 +39,11 @@
 		<dependency>
 			<groupId>org.mockito.kotlin</groupId>
 			<artifactId>mockito-kotlin</artifactId>
-			<version>4.1.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
-			<version>${spring-boot.version}</version>
 			<scope>compile</scope>
 		</dependency>
 		<dependency>

--- a/chat-persistence-redis/pom.xml
+++ b/chat-persistence-redis/pom.xml
@@ -80,7 +80,6 @@
         <dependency>
             <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
-            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/chat-presence/pom.xml
+++ b/chat-presence/pom.xml
@@ -34,7 +34,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/chat-security/pom.xml
+++ b/chat-security/pom.xml
@@ -69,13 +69,11 @@
         <dependency>
             <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
-            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.12.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat-service-composite/pom.xml
+++ b/chat-service-composite/pom.xml
@@ -88,7 +88,6 @@
         <dependency>
             <groupId>org.mockito.kotlin</groupId>
             <artifactId>mockito-kotlin</artifactId>
-            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/chat-shell/pom.xml
+++ b/chat-shell/pom.xml
@@ -45,7 +45,6 @@
         <dependency>
             <groupId>org.springframework.shell</groupId>
             <artifactId>spring-shell-starter</artifactId>
-            <version>${spring-shell.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -82,12 +81,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.nhaarman.mockitokotlin2</groupId>
-            <artifactId>mockito-kotlin</artifactId>
-            <version>2.2.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
         </dependency>
@@ -98,7 +91,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
-            <version>${spring-boot.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/chat-vector-embedded/pom.xml
+++ b/chat-vector-embedded/pom.xml
@@ -14,15 +14,10 @@
     <name>chat-vector-embedded</name>
     <description>Embedded Vector API provider ground for the Vectors adapter</description>
 
-    <properties>
-        <vectors.version>0.1.20</vectors.version>
-    </properties>
-
     <dependencies>
         <dependency>
             <groupId>com.integrallis</groupId>
             <artifactId>vectors-spring-ai</artifactId>
-            <version>${vectors.version}</version>
         </dependency>
         <!-- The adapter declares Spring AI as compileOnly, so it brings none
              of it. This module supplies the Spring AI surface the adapter
@@ -40,7 +35,6 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
-            <version>${kotlin.version}</version>
         </dependency>
         <dependency>
             <groupId>com.demo</groupId>

--- a/chat-web/pom.xml
+++ b/chat-web/pom.xml
@@ -40,12 +40,10 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>bootstrap</artifactId>
-            <version>3.4.1</version>
         </dependency>
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>3.4.1</version>
         </dependency>
 
         <dependency>

--- a/justfile
+++ b/justfile
@@ -20,6 +20,10 @@ check-integration:
 check-flags:
 	./shell-scripts/test-flags.sh
 
+# Fail when a module pom declares a third-party dependency version.
+check-deps:
+	./shell-scripts/check-dependency-versions.sh
+
 # Run the same Maven command as the CI build job.
 ci-local:
 	mvn -B clean test

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,17 @@
         <kotlin.version>2.4.10</kotlin.version>
         <spring-boot.version>3.5.16</spring-boot.version>
         <spring-cloud-bom.version>2025.0.3</spring-cloud-bom.version>
+
+        <!-- No BOM manages these. They are declared once in
+             dependencyManagement below. A module must not repeat a version.
+             See CHAT-mgtbicsq. -->
+        <lucene.version>8.7.0</lucene.version>
+        <mockito-kotlin.version>4.1.0</mockito-kotlin.version>
+        <testng.version>7.12.0</testng.version>
+        <playtika-testcontainers.version>2.2.14</playtika-testcontainers.version>
+        <webjars-bootstrap.version>3.4.1</webjars-bootstrap.version>
+        <webjars-jquery.version>3.4.1</webjars-jquery.version>
+        <vectors.version>0.1.20</vectors.version>
         <vector.api.module.flag>--add-modules=jdk.incubator.vector</vector.api.module.flag>
         <!-- Overridden to empty by -Pintegration. See maven-surefire-plugin below. -->
         <excluded.test.groups>integration</excluded.test.groups>
@@ -111,6 +122,62 @@
                 <version>1.0.3</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <!-- Artifacts that no imported BOM manages. Every version for
+                 these lives here. A module declares the dependency without a
+                 version. See CHAT-mgtbicsq. -->
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>${lucene.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-memory</artifactId>
+                <version>${lucene.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>${lucene.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>${lucene.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito.kotlin</groupId>
+                <artifactId>mockito-kotlin</artifactId>
+                <version>${mockito-kotlin.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.playtika.testcontainers</groupId>
+                <artifactId>embedded-cassandra</artifactId>
+                <version>${playtika-testcontainers.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars</groupId>
+                <artifactId>bootstrap</artifactId>
+                <version>${webjars-bootstrap.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.webjars</groupId>
+                <artifactId>jquery</artifactId>
+                <version>${webjars-jquery.version}</version>
+            </dependency>
+            <!-- The Vectors library is at 0.1.x, so its surface can move
+                 between releases. Pin the exact version. -->
+            <dependency>
+                <groupId>com.integrallis</groupId>
+                <artifactId>vectors-spring-ai</artifactId>
+                <version>${vectors.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/shell-scripts/check-dependency-versions.sh
+++ b/shell-scripts/check-dependency-versions.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Fails when a module pom declares a version for a third-party dependency.
+#
+# The rule: no module declares a third-party version. If a BOM manages the
+# artifact, declare it with no version. If no BOM manages it, put the version
+# in the parent dependencyManagement and still declare it without a version in
+# the module.
+#
+# The rule exists because three separate cleanups found the same defect: a
+# stale local override that the build accepts in silence. CHAT-onzqrqox removed
+# five downward properties. CHAT-ixazwico removed a jvmTarget pin that made one
+# module emit Java 8 bytecode in a Java 25 build. CHAT-hcgmcuxp removed inline
+# versions that beat the managed ones, including jackson at 2.9.5 against a
+# managed 2.21.4.
+#
+#   ./shell-scripts/check-dependency-versions.sh
+#
+# Exit status: 0 when no module declares a third-party version, 1 when one does.
+
+set -uo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT="$( cd "$DIR/.." && pwd )"
+cd "$ROOT" || exit 1
+
+python3 - <<'PY'
+import re, glob, sys
+
+# A BOM import needs its own version. So does the parent pom, which is where
+# every unmanaged version belongs.
+ALLOWED_IMPORT_SCOPE = True
+
+violations = []
+for path in sorted(glob.glob('**/pom.xml', recursive=True)):
+    if '/target/' in path:
+        continue
+    if path == 'pom.xml':
+        continue
+    text = re.sub(r'<!--.*?-->', '', open(path).read(), flags=re.S)
+    # A plugin dependency lives inside <build> and must carry its own version.
+    # pluginManagement does not cover it. Drop those sections before scanning.
+    text = re.sub(r'<build>.*?</build>', '', text, flags=re.S)
+    for block in re.finditer(r'<dependency>(.*?)</dependency>', text, re.S):
+        body = block.group(1)
+        version = re.search(r'<version>([^<]*)</version>', body)
+        if not version:
+            continue
+        group = re.search(r'<groupId>([^<]*)</groupId>', body)
+        artifact = re.search(r'<artifactId>([^<]*)</artifactId>', body)
+        group = group.group(1) if group else '?'
+        artifact = artifact.group(1) if artifact else '?'
+        # Reactor modules carry their own version.
+        if group.startswith('com.demo'):
+            continue
+        # A BOM import must name a version.
+        if ALLOWED_IMPORT_SCOPE and '<scope>import</scope>' in body:
+            continue
+        violations.append((path, group, artifact, version.group(1)))
+
+if violations:
+    print('Third-party versions declared in a module pom:')
+    print()
+    for path, group, artifact, version in violations:
+        print(f'  {path}')
+        print(f'    {group}:{artifact} at {version}')
+    print()
+    print('Move the version to the parent dependencyManagement, or remove it if')
+    print('an imported BOM already manages the artifact.')
+    sys.exit(1)
+
+print('dependency versions: no module declares a third-party version')
+sys.exit(0)
+PY


### PR DESCRIPTION
Issue `CHAT-mgtbicsq`. One commit.

This change gives dependency versions one central point, adds a check that keeps them there, and adds a vulnerability report.

## Why

Three cleanups have now found the same defect class. A stale local override that the build accepts in silence.

- `CHAT-onzqrqox` removed five downward version properties.
- `CHAT-ixazwico` removed a `jvmTarget` pin. That module was emitting Java 8 bytecode inside a Java 25 build.
- `CHAT-hcgmcuxp` removed inline versions that beat the managed ones, including jackson at 2.9.5 against a managed 2.21.4.

Each was invisible until somebody looked. None failed a build. Nothing stopped a fourth.

## The rule

No module declares a third-party version.

- A BOM manages the artifact: declare it with no version.
- No BOM manages it: the version lives in the parent `dependencyManagement`, and the module still declares it without one.

A version element in a module pom is then always a defect, which makes the rule checkable.

## What the parent now owns

New properties, beside the existing ones: `lucene.version`, `mockito-kotlin.version`, `testng.version`, `playtika-testcontainers.version`, `webjars-bootstrap.version`, `webjars-jquery.version`, `vectors.version`.

Each has a matching `dependencyManagement` entry. These are the artifacts that no imported BOM manages.

25 version elements were removed from module poms. Most were redundant. The Boot parent already manages `spring-boot-starter` and the Kotlin artifacts through its own BOMs, so those pins did nothing.

## A dead dependency, in four modules

`com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0` was declared in `chat-shell`, `chat-messaging-kafka`, `chat-index-lucene` and `chat-messaging-memory`.

No Kotlin source imports it. All eight files that use mockito-kotlin import `org.mockito.kotlin` instead. The nhaarman artifact is the deprecated predecessor of that library.

So the repo carried both the old library and its replacement, and used only the replacement. The four declarations are deleted. No source change was needed.

## The guard

`shell-scripts/check-dependency-versions.sh`, and the just recipe `check-deps`.

It fails when a module pom declares a third-party version. It skips three cases:

- reactor modules, which carry their own version
- BOM imports, which must name a version
- plugin dependencies, which must carry their own version because `pluginManagement` does not cover them

The third case is not theoretical. While writing this change I stripped the version from `spring-restdocs-asciidoctor`, which is a plugin dependency, and the build failed on a missing version. The exclusion is what the build itself requires.

## The vulnerability report

`.github/workflows/dependency-audit.yml` runs OWASP dependency-check.

It runs on a daily schedule and on demand, not on every push. The first run downloads the National Vulnerability Database, which is large. A per-push run would add minutes to every build for a report that changes only when the NVD data changes.

The job reports and uploads the HTML report. **It does not fail on a finding.** The current findings are unknown, so a threshold would either be arbitrary or would block the first run. Read the first report, then set one.

An `NVD_API_KEY` repository secret raises the download rate limit. The job works without it, more slowly.

## What this change deliberately does not do

The enforcer rules are absent.

A verbose dependency tree still reports **106 conflicts** across the reactor. Most are transitive and belong to no pom here. Enabling `requireUpperBoundDeps` or `dependencyConvergence` now would stop every build.

The order is report, then clean, then enforce. This change delivers the report and the rule. The conflict cleanup and the enforcer are follow-up work.

## Verification

Default mode: 35 modules pass, 552 tests, 0 failures, 0 errors, 30 skipped.

Integration mode: 35 modules pass, 28 containers start, 754 tests, 0 failures, 0 errors, 52 skipped.

`./shell-scripts/check-dependency-versions.sh` passes.

`drift check` passes.
