### PR TITLE
ci: fail the dependency audit on a critical finding

### DIFF
--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -5,8 +5,9 @@
 # slow. A per-push run would add several minutes to every build for a report
 # that changes only when the NVD data changes.
 #
-# The job does not fail the build on a finding. Read the report, then decide.
-# A failing threshold can come later, once the current findings are known.
+# The job fails on a CVSS score of 9.0 or above, which is the critical band.
+# That is deliberately high. Lower it to 7 once the deployment surface is
+# wider and the first reports are known.
 #
 # Issue: CHAT-mgtbicsq
 name: dependency audit
@@ -47,14 +48,18 @@ jobs:
           restore-keys: ${{ runner.os }}-nvd-
 
       - name: Run OWASP dependency-check
+        # The plugin version is pinned so a run is reproducible. An unpinned
+        # coordinate takes the latest release, and a plugin update could then
+        # change the result overnight.
+        #
         # An NVD API key raises the download rate limit. Without it the first
-        # run is slow but still completes. Set NVD_API_KEY in repository
-        # secrets to speed it up.
+        # run is slow but still completes. The key must be a repository secret.
+        # A local .envrc does not reach this job.
         env:
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
         run: >
-          mvn -B org.owasp:dependency-check-maven:aggregate
-          -DfailBuildOnCVSS=11
+          mvn -B org.owasp:dependency-check-maven:13.0.0:aggregate
+          -DfailBuildOnCVSS=9
           -DnvdApiKey="$NVD_API_KEY"
           -DskipTests
 


### PR DESCRIPTION
Issue `CHAT-mgtbicsq`. One commit. CI configuration only.

## What changed

| Setting | Before | After |
|---------|--------|-------|
| `failBuildOnCVSS` | 11 | **9** |
| plugin version | unpinned | **13.0.0** |

`failBuildOnCVSS=11` could never fire, because a CVSS score stops at 10. The job reported and nothing more. It now fails on the critical band.

9 is deliberately high. The deployment surface is small today. Lower it to 7 when that changes and the first reports are known.

The plugin coordinate had no version, so each run took the latest release. A plugin update could change the result overnight, and no two runs were guaranteed to match. It is pinned at 13.0.0.

## The API key needs a repository secret

The workflow reads `${{ secrets.NVD_API_KEY }}`.

A key in a local `.envrc` covers a local run only. It does not reach a GitHub Actions job. Add the key at Settings, then Secrets and variables, then Actions.

Without the key the job still works. The NVD download is rate limited, so the first run is slow enough to look stalled.

`.envrc` is listed in `.gitignore` at line 53 and is not tracked, so a key there is not at risk of being committed.

## First run

Nothing has run yet. The schedule is daily at 05:00 UTC, and the job also accepts a manual trigger:

```
gh workflow run dependency-audit.yml
```

The first run now carries a real gate. If the tree holds a critical finding, that run fails. That is the intended signal, not a defect in the job.