### PR TITLE
build: enforce dependency upper bounds and convergence

### DIFF
--- a/docs/DEPENDENCY-AUDIT.md
+++ b/docs/DEPENDENCY-AUDIT.md
@@ -25,7 +25,15 @@ gh run download <run-id> -n dependency-check-report
 ```
 
 Related policy lives in `CHAT-mgtbicsq`. Versions have one central point, and
-`shell-scripts/check-dependency-versions.sh` keeps them there.
+three checks keep them there:
+
+- `shell-scripts/check-dependency-versions.sh` fails when a module pom declares a
+  third-party version.
+- `requireUpperBoundDeps` fails when a resolved version is lower than another path
+  in the tree requires.
+- `dependencyConvergence` fails when one artifact resolves to two versions.
+
+The two enforcer rules run in the `validate` phase, so every build checks them.
 
 ## The round of actions, today
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,20 @@
         <webjars-bootstrap.version>3.4.1</webjars-bootstrap.version>
         <webjars-jquery.version>3.4.1</webjars-jquery.version>
         <vectors.version>0.1.20</vectors.version>
+        <!-- kotlin-stdlib brings 13.0 and kotlinx-coroutines wants 23.0.0.
+             Maven picks the nearer one, so the higher request loses.
+             Pinned here to satisfy requireUpperBoundDeps. -->
+        <jetbrains-annotations.version>23.0.0</jetbrains-annotations.version>
+        <!-- The Cassandra driver brings 2.1.12 and micrometer-core wants
+             2.2.2. Pinned here to satisfy requireUpperBoundDeps. -->
+        <hdrhistogram.version>2.2.2</hdrhistogram.version>
+        <!-- Boot manages 2.4 and spring-cloud wants 2.5. -->
+        <snakeyaml.version>2.5</snakeyaml.version>
+        <!-- Three versions reach the tree: 9.37.3, 9.37.4 and 9.47. Pinned to
+             the highest so dependencyConvergence passes. -->
+        <nimbus-jose-jwt.version>9.47</nimbus-jose-jwt.version>
+        <!-- Three versions reach the tree: 4.5.5, 4.5.13 and 4.5.14. -->
+        <httpclient.version>4.5.14</httpclient.version>
         <vector.api.module.flag>--add-modules=jdk.incubator.vector</vector.api.module.flag>
         <!-- Overridden to empty by -Pintegration. See maven-surefire-plugin below. -->
         <excluded.test.groups>integration</excluded.test.groups>
@@ -179,6 +193,31 @@
                 <artifactId>vectors-spring-ai</artifactId>
                 <version>${vectors.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.jetbrains</groupId>
+                <artifactId>annotations</artifactId>
+                <version>${jetbrains-annotations.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.hdrhistogram</groupId>
+                <artifactId>HdrHistogram</artifactId>
+                <version>${hdrhistogram.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+                <version>${nimbus-jose-jwt.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient</artifactId>
+                <version>${httpclient.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -234,6 +273,33 @@
                         <goals>
                             <goal>build-info</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <!-- Two rules keep the dependency tree honest.
+                 requireUpperBoundDeps fails when a resolved version is lower
+                 than another path in the tree requires. That is the rule which
+                 would have caught jackson at 2.9.5 against a managed 2.21.4.
+                 dependencyConvergence fails when one artifact resolves to two
+                 versions. Both passed on all 35 modules when added. A new
+                 failure means a real change in the tree, so fix it in the
+                 parent dependencyManagement. See CHAT-mgtbicsq. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-dependency-versions</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireUpperBoundDeps/>
+                                <dependencyConvergence/>
+                            </rules>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
Issue `CHAT-mgtbicsq`. One commit. This completes that issue.

The rule now has a build-time check, not only a script and a document.

## What runs

Two enforcer rules, in the `validate` phase, in all 35 modules.

| Rule | Fails when |
|------|------------|
| `requireUpperBoundDeps` | A resolved version is lower than another path in the tree requires |
| `dependencyConvergence` | One artifact resolves to two versions |

The first is the rule that would have caught jackson at 2.9.5 against a managed 2.21.4.

## Five artifacts needed a parent entry first

| Artifact | Pinned | Why |
|----------|--------|-----|
| `org.jetbrains:annotations` | 23.0.0 | kotlin-stdlib brings 13.0, kotlinx-coroutines wants 23.0.0 |
| `org.hdrhistogram:HdrHistogram` | 2.2.2 | The Cassandra driver brings 2.1.12, micrometer-core wants 2.2.2 |
| `org.yaml:snakeyaml` | 2.5 | Boot manages 2.4, spring-cloud wants 2.5 |
| `com.nimbusds:nimbus-jose-jwt` | 9.47 | Three versions reached the tree |
| `org.apache.httpcomponents:httpclient` | 4.5.14 | Three versions reached the tree |

Each is a transitive artifact that no module declares. The version lives in the parent, which is where the rule from `CHAT-mgtbicsq` says it belongs.

## A correction to my own estimate

The `CHAT-mgtbicsq` description says 106 conflicts would stop every build if these rules were enabled. **That was wrong.**

That number came from counting every `omitted for conflict` line in a verbose dependency tree. Most of those are benign, because Maven already resolves the higher version and the omitted one is the lower.

Only five artifacts actually violated a rule. The work was five parent entries, not a long cleanup.

The sequencing advice in that issue, report then clean then enforce, still held. It just finished much sooner than the number suggested.

## Three checks now hold the rule

`docs/DEPENDENCY-AUDIT.md` lists them together:

- `shell-scripts/check-dependency-versions.sh` fails when a module pom declares a third-party version.
- `requireUpperBoundDeps` fails on a downgrade.
- `dependencyConvergence` fails on a split version.

The first catches a pin being written. The other two catch the tree drifting underneath it.

## Verification

Default mode: 35 modules pass, 552 tests, 0 failures, 0 errors, 30 skipped.

Integration mode: 35 modules pass, 28 containers start, 754 tests, 0 failures, 0 errors, 52 skipped.

The enforcer execution appears in all 35 module logs.

`drift check` passes.

## What a future failure means

A new failure is a real change in the dependency tree, not noise. The fix is a parent `dependencyManagement` entry, never a module pin. A module pin would re-create the defect that `CHAT-hcgmcuxp` removed.